### PR TITLE
nordic: Clean up nrfx inclusions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,6 @@ endif()
 if(CONFIG_HAS_NRFX)
   zephyr_include_directories(nrfx)
   zephyr_include_directories(nrfx/drivers/include)
-  zephyr_include_directories(nrfx/hal)
   zephyr_include_directories(nrfx/mdk)
   zephyr_include_directories(.)
 

--- a/nrfx_glue.h
+++ b/nrfx_glue.h
@@ -132,8 +132,6 @@ extern "C" {
 
 //------------------------------------------------------------------------------
 
-#include <kernel.h>
-
 /**
  * @brief When set to a non-zero value, this macro specifies that
  *        @ref nrfx_coredep_delay_us uses a precise DWT-based solution.


### PR DESCRIPTION
Two minor corrections related to the clean up of nrfx inclusions in the main Zephry repo.

**CMakeLists.txt: Remove nrfx/hal from list of include directories**

HAL headers are not supposed to be included directly, but only with
their names prepended with the hal/ directory (so that the inclusion
of a HAL header clearly differs from the inclusion of a driver one).

**nrfx_glue.h: Remove inclusion of <kernel.h>**

Remove this inclusion to avoid creating a cycle when nrfx.h is included
from kernel.h via soc.h, what can result in half processed header files
in between and consequently missing definitions.

cc @SebastianBoe