### PR TITLE
nrfx_config_nrf52840: Disable extended SPIM features

### DIFF
--- a/nrfx_config_nrf52840.h
+++ b/nrfx_config_nrf52840.h
@@ -1840,7 +1840,7 @@
 
 
 #ifndef NRFX_SPIM_EXTENDED_ENABLED
-#define NRFX_SPIM_EXTENDED_ENABLED 1
+#define NRFX_SPIM_EXTENDED_ENABLED 0
 #endif
 
 // <o> NRFX_SPIM_MISO_PULL_CFG  - MISO pin pull configuration.


### PR DESCRIPTION
These features are available only for SPIM3 and when they are enabled
but this instance is not, the compilation fails.
Currently these features are not at all used in Zephyr, so there is no
point in enabling them by default in nrfx (this can be overriden by
setting `NRFX_SPIM_EXTENDED_ENABLED` to 1 in an application that would
need it).

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>