### PR TITLE
nrfx_i2s: Introduce NRFX_I2S_STATUS_TRANSFER_STOPPED flag

### DIFF
--- a/nrfx/drivers/include/nrfx_i2s.h
+++ b/nrfx/drivers/include/nrfx_i2s.h
@@ -120,12 +120,16 @@ typedef struct
     .ratio        = NRF_I2S_RATIO_32X,                                                  \
 }
 
-#define NRFX_I2S_STATUS_NEXT_BUFFERS_NEEDED  (1UL << 0)
+#define NRFX_I2S_STATUS_NEXT_BUFFERS_NEEDED (1UL << 0)
     /**< The application must provide buffers that are to be used in the next
      *   part of the transfer. A call to @ref nrfx_i2s_next_buffers_set must
      *   be done before the currently used buffers are completely processed
      *   (that is, the time remaining for supplying the next buffers depends on
      *   the used size of the buffers). */
+
+#define NRFX_I2S_STATUS_TRANSFER_STOPPED    (1UL << 1)
+    /**< The I2S peripheral has been stopped and all buffers that were passed
+     *   to the driver have been released. */
 
 /**
  * @brief I2S driver data handler type.
@@ -155,14 +159,22 @@ typedef struct
  *                        Both pointers in this structure are NULL when the
  *                        handler is called for the first time after a transfer
  *                        is started, because no data has been transferred yet
- *                        at this point. In all successive calls the pointers
+ *                        at this point. In all successive calls, the pointers
  *                        specify what has been sent (TX) and what has been
- *                        received (RX) in the part of transfer that has just
- *                        been completed (provided that a given direction is
- *                        enabled, see @ref nrfx_i2s_start).
+ *                        received (RX) in the part of the transfer that has
+ *                        just been completed (provided that a given direction
+ *                        is enabled, see @ref nrfx_i2s_start).
+ *                        @note Since the peripheral is stopped asynchronously,
+ *                              buffers that are released after the call to
+ *                              @ref nrfx_i2s_stop are not used entirely.
+ *                              In this case, only a part (if any) of the TX
+ *                              buffer has been actually transmitted and only
+ *                              a part (if any) of the RX buffer is filled with
+ *                              received data.
  * @param[in] status  Bit field describing the current status of the transfer.
  *                    It can be 0 or a combination of the following flags:
  *                    - @ref NRFX_I2S_STATUS_NEXT_BUFFERS_NEEDED
+ *                    - @ref NRFX_I2S_STATUS_TRANSFER_STOPPED
  */
 typedef void (* nrfx_i2s_data_handler_t)(nrfx_i2s_buffers_t const * p_released,
                                          uint32_t                   status);

--- a/nrfx/drivers/src/nrfx_i2s.c
+++ b/nrfx/drivers/src/nrfx_i2s.c
@@ -377,12 +377,18 @@ void nrfx_i2s_irq_handler(void)
         nrf_i2s_disable(NRF_I2S);
 
         // When stopped, release all buffers, including these scheduled for
-        // the next transfer.
-        m_cb.handler(&m_cb.current_buffers, 0);
-        m_cb.handler(&m_cb.next_buffers, 0);
+        // the next part of the transfer, and signal that the transfer has
+        // finished.
 
+        m_cb.handler(&m_cb.current_buffers, 0);
+
+        // Change the state of the driver before calling the handler with
+        // the flag signaling that the transfer has finished, so that it is
+        // possible to start a new transfer directly from the handler function.
         m_cb.state = NRFX_DRV_STATE_INITIALIZED;
         NRFX_LOG_INFO("Stopped.");
+
+        m_cb.handler(&m_cb.next_buffers, NRFX_I2S_STATUS_TRANSFER_STOPPED);
     }
     else
     {


### PR DESCRIPTION
Add the NRFX_I2S_STATUS_TRANSFER_STOPPED flag to the nrfx_i2s driver's
API, to provide the application with a notification when the driver
actually stops the transfer after the nrfx_i2s_stop function is called.

Move also the corresponding update of the driver's state to the point
before the handler function is called, so that it is possible to start
a next transfer directly from the handler function.

This is a temporary patch, needed to proceed with a PR in the main
Zephyr repository that requires such extension of the nrfx_i2s driver.
Same changes will be contained in the next release of nrfx.

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>