### PR TITLE
nrfx: Fix build issue with clang-llvm

### DIFF
--- a/nrfx/mdk/compiler_abstraction.h
+++ b/nrfx/mdk/compiler_abstraction.h
@@ -150,7 +150,8 @@ POSSIBILITY OF SUCH DAMAGE.
 
     static inline unsigned int gcc_current_sp(void)
     {
-        register unsigned sp __ASM("sp");
+        register unsigned sp;
+        __ASM volatile("mov  %0, sp" : "=r" (sp));
         return sp;
     }
 


### PR DESCRIPTION
When trying to build Zephyr with clang-llvm we run into this error
message:

nrfx/mdk/compiler_abstraction.h:154:16: error: variable 'sp' is
uninitialized when used here [-Werror,-Wuninitialized]
        return sp;
               ^~

Rework the inline asm to address the issue.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>