### PR TITLE
CMakelists: missing "src" in one path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ if(CONFIG_HAS_NRFX)
 
   zephyr_library_sources(nrfx_glue.c)
 
-  zephyr_library_sources_ifdef(CONFIG_NRFX_PRS     nrfx/drivers/prs/nrfx_prs.c)
+  zephyr_library_sources_ifdef(CONFIG_NRFX_PRS     nrfx/drivers/src/prs/nrfx_prs.c)
 
   zephyr_library_sources_ifdef(CONFIG_NRFX_ADC     nrfx/drivers/src/nrfx_adc.c)
   zephyr_library_sources_ifdef(CONFIG_NRFX_CLOCK   nrfx/drivers/src/nrfx_clock.c)


### PR DESCRIPTION
Missing "src" in path [nrfx/drivers/"src"/prs/nrfx_prs.c]

Signed-off-by: Martin Lesund <martin.lesund@nordicsemi.no>