### PR TITLE
nrfx_glue: Define NRFX_ASSERT as __ASSERT_NO_MSG

### DIFF
--- a/nrfx_glue.h
+++ b/nrfx_glue.h
@@ -47,14 +47,14 @@ extern "C" {
 
 //------------------------------------------------------------------------------
 
-#include <assert.h>
+#include <sys/__assert.h>
 
 /**
  * @brief Macro for placing a runtime assertion.
  *
  * @param expression Expression to be evaluated.
  */
-#define NRFX_ASSERT(expression)  assert(expression)
+#define NRFX_ASSERT(expression)  __ASSERT_NO_MSG(expression)
 
 /**
  * @brief Macro for placing a compile time assertion.


### PR DESCRIPTION
Use __ASSERT_NO_MSG directly, not through the assert macro that comes
from libc, as the definition of the latter might be different when
some specific libc version is used, and this could generate troubles.

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>