### PR TITLE
nrfx_usbd: fix data type for atomic variable

### DIFF
--- a/nrfx/drivers/src/nrfx_usbd.c
+++ b/nrfx/drivers/src/nrfx_usbd.c
@@ -269,7 +269,7 @@ static uint32_t m_ep_ready;
  * Mask prepared USBD data for transmission.
  * It is cleared when no more data to transmit left.
  */
-static uint32_t m_ep_dma_waiting;
+static nrfx_atomic_t m_ep_dma_waiting;
 
 /**
  * @brief Current EasyDMA state.


### PR DESCRIPTION
m_ep_dma_waiting is passed to various NRFX_ATOMIC functions,
but is defined as uint32_t. Depending on the implementation,
this may cause warnings if this is not the same data type as
nrfx_atomic_t. Change this to match.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>