### PR TITLE
nrfx_config: Add missing _S/_NS symbol translations for nRF5340/nRF9160

### DIFF
--- a/nrfx/hal/nrf_i2s.h
+++ b/nrfx/hal/nrf_i2s.h
@@ -38,6 +38,10 @@
 extern "C" {
 #endif
 
+#ifndef NRF_I2S0
+#define NRF_I2S0 NRF_I2S
+#endif
+
 /**
  * @defgroup nrf_i2s_hal I2S HAL
  * @{

--- a/nrfx_config_nrf5340_application.h
+++ b/nrfx_config_nrf5340_application.h
@@ -38,6 +38,7 @@
 
 #define NRF_COMP         NRF_PERIPH(NRF_COMP)
 #define NRF_CLOCK        NRF_PERIPH(NRF_CLOCK)
+#define NRF_CTRLAP       NRF_PERIPH(NRF_CTRLAP)
 #define NRF_DCNF         NRF_PERIPH(NRF_DCNF)
 #define NRF_DPPIC        NRF_PERIPH(NRF_DPPIC)
 #define NRF_EGU0         NRF_PERIPH(NRF_EGU0)
@@ -47,7 +48,7 @@
 #define NRF_EGU4         NRF_PERIPH(NRF_EGU4)
 #define NRF_EGU5         NRF_PERIPH(NRF_EGU5)
 #define NRF_FPU          NRF_PERIPH(NRF_FPU)
-#define NRF_I2S          NRF_PERIPH(NRF_I2S0)
+#define NRF_I2S0         NRF_PERIPH(NRF_I2S0)
 #define NRF_IPC          NRF_PERIPH(NRF_IPC)
 #define NRF_KMU          NRF_PERIPH(NRF_KMU)
 #define NRF_LPCOMP       NRF_PERIPH(NRF_LPCOMP)
@@ -113,9 +114,11 @@
 #define NRF_CACHEINFO    NRF_CACHEINFO_S
 #define NRF_CACHEDATA    NRF_CACHEDATA_S
 #define NRF_CRYPTOCELL   NRF_CRYPTOCELL_S
+#define NRF_CTI          NRF_CTI_S
 #define NRF_FICR         NRF_FICR_S
 #define NRF_GPIOTE0      NRF_GPIOTE0_S
 #define NRF_SPU          NRF_SPU_S
+#define NRF_TAD          NRF_TAD_S
 #define NRF_UICR         NRF_UICR_S
 #endif
 

--- a/nrfx_config_nrf5340_network.h
+++ b/nrfx_config_nrf5340_network.h
@@ -43,10 +43,12 @@
  * use the macros without any suffixes, you must translate the names.
  * The following section provides configuration for the name translation.
  */
-#define NRF_ACL        NRF_ACL_NS
 #define NRF_AAR        NRF_AAR_NS
+#define NRF_ACL        NRF_ACL_NS
 #define NRF_CCM        NRF_CCM_NS
 #define NRF_CLOCK      NRF_CLOCK_NS
+#define NRF_CTI        NRF_CTI_NS
+#define NRF_CTRLAP     NRF_CTRLAP_NS
 #define NRF_DCNF       NRF_DCNF_NS
 #define NRF_DPPIC      NRF_DPPIC_NS
 #define NRF_ECB        NRF_ECB_NS
@@ -80,7 +82,6 @@
 #define NRF_VMC        NRF_VMC_NS
 #define NRF_VREQCTRL   NRF_VREQCTRL_NS
 #define NRF_WDT        NRF_WDT_NS
-
 
 // <<< Use Configuration Wizard in Context Menu >>>\n
 

--- a/nrfx_config_nrf9160.h
+++ b/nrfx_config_nrf9160.h
@@ -36,55 +36,55 @@
 #error "Do not include this file directly, only through nrfx_config.h."
 #endif
 
-#define NRF_CLOCK       NRF_PERIPH(NRF_CLOCK)
-#define NRF_DPPIC       NRF_PERIPH(NRF_DPPIC)
-#define NRF_EGU0        NRF_PERIPH(NRF_EGU0)
-#define NRF_EGU1        NRF_PERIPH(NRF_EGU1)
-#define NRF_EGU2        NRF_PERIPH(NRF_EGU2)
-#define NRF_EGU3        NRF_PERIPH(NRF_EGU3)
-#define NRF_EGU4        NRF_PERIPH(NRF_EGU4)
-#define NRF_EGU5        NRF_PERIPH(NRF_EGU5)
-#define NRF_FPU         NRF_PERIPH(NRF_FPU)
-#define NRF_IPC         NRF_PERIPH(NRF_IPC)
-#define NRF_I2S         NRF_PERIPH(NRF_I2S)
-#define NRF_KMU         NRF_PERIPH(NRF_KMU)
-#define NRF_NVMC        NRF_PERIPH(NRF_NVMC)
-#define NRF_P0          NRF_PERIPH(NRF_P0)
-#define NRF_PDM         NRF_PERIPH(NRF_PDM)
-#define NRF_POWER       NRF_PERIPH(NRF_POWER)
-#define NRF_PWM0        NRF_PERIPH(NRF_PWM0)
-#define NRF_PWM1        NRF_PERIPH(NRF_PWM1)
-#define NRF_PWM2        NRF_PERIPH(NRF_PWM2)
-#define NRF_PWM3        NRF_PERIPH(NRF_PWM3)
-#define NRF_REGULATORS  NRF_PERIPH(NRF_REGULATORS)
-#define NRF_RTC0        NRF_PERIPH(NRF_RTC0)
-#define NRF_RTC1        NRF_PERIPH(NRF_RTC1)
-#define NRF_SAADC       NRF_PERIPH(NRF_SAADC)
-#define NRF_SPIM0       NRF_PERIPH(NRF_SPIM0)
-#define NRF_SPIM1       NRF_PERIPH(NRF_SPIM1)
-#define NRF_SPIM2       NRF_PERIPH(NRF_SPIM2)
-#define NRF_SPIM3       NRF_PERIPH(NRF_SPIM3)
-#define NRF_SPIS0       NRF_PERIPH(NRF_SPIS0)
-#define NRF_SPIS1       NRF_PERIPH(NRF_SPIS1)
-#define NRF_SPIS2       NRF_PERIPH(NRF_SPIS2)
-#define NRF_SPIS3       NRF_PERIPH(NRF_SPIS3)
-#define NRF_TIMER0      NRF_PERIPH(NRF_TIMER0)
-#define NRF_TIMER1      NRF_PERIPH(NRF_TIMER1)
-#define NRF_TIMER2      NRF_PERIPH(NRF_TIMER2)
-#define NRF_TWIM0       NRF_PERIPH(NRF_TWIM0)
-#define NRF_TWIM1       NRF_PERIPH(NRF_TWIM1)
-#define NRF_TWIM2       NRF_PERIPH(NRF_TWIM2)
-#define NRF_TWIM3       NRF_PERIPH(NRF_TWIM3)
-#define NRF_TWIS0       NRF_PERIPH(NRF_TWIS0)
-#define NRF_TWIS1       NRF_PERIPH(NRF_TWIS1)
-#define NRF_TWIS2       NRF_PERIPH(NRF_TWIS2)
-#define NRF_TWIS3       NRF_PERIPH(NRF_TWIS3)
-#define NRF_UARTE0      NRF_PERIPH(NRF_UARTE0)
-#define NRF_UARTE1      NRF_PERIPH(NRF_UARTE1)
-#define NRF_UARTE2      NRF_PERIPH(NRF_UARTE2)
-#define NRF_UARTE3      NRF_PERIPH(NRF_UARTE3)
-#define NRF_VMC         NRF_PERIPH(NRF_VMC)
-#define NRF_WDT         NRF_PERIPH(NRF_WDT)
+#define NRF_CLOCK        NRF_PERIPH(NRF_CLOCK)
+#define NRF_DPPIC        NRF_PERIPH(NRF_DPPIC)
+#define NRF_EGU0         NRF_PERIPH(NRF_EGU0)
+#define NRF_EGU1         NRF_PERIPH(NRF_EGU1)
+#define NRF_EGU2         NRF_PERIPH(NRF_EGU2)
+#define NRF_EGU3         NRF_PERIPH(NRF_EGU3)
+#define NRF_EGU4         NRF_PERIPH(NRF_EGU4)
+#define NRF_EGU5         NRF_PERIPH(NRF_EGU5)
+#define NRF_FPU          NRF_PERIPH(NRF_FPU)
+#define NRF_IPC          NRF_PERIPH(NRF_IPC)
+#define NRF_I2S          NRF_PERIPH(NRF_I2S)
+#define NRF_KMU          NRF_PERIPH(NRF_KMU)
+#define NRF_NVMC         NRF_PERIPH(NRF_NVMC)
+#define NRF_P0           NRF_PERIPH(NRF_P0)
+#define NRF_PDM          NRF_PERIPH(NRF_PDM)
+#define NRF_POWER        NRF_PERIPH(NRF_POWER)
+#define NRF_PWM0         NRF_PERIPH(NRF_PWM0)
+#define NRF_PWM1         NRF_PERIPH(NRF_PWM1)
+#define NRF_PWM2         NRF_PERIPH(NRF_PWM2)
+#define NRF_PWM3         NRF_PERIPH(NRF_PWM3)
+#define NRF_REGULATORS   NRF_PERIPH(NRF_REGULATORS)
+#define NRF_RTC0         NRF_PERIPH(NRF_RTC0)
+#define NRF_RTC1         NRF_PERIPH(NRF_RTC1)
+#define NRF_SAADC        NRF_PERIPH(NRF_SAADC)
+#define NRF_SPIM0        NRF_PERIPH(NRF_SPIM0)
+#define NRF_SPIM1        NRF_PERIPH(NRF_SPIM1)
+#define NRF_SPIM2        NRF_PERIPH(NRF_SPIM2)
+#define NRF_SPIM3        NRF_PERIPH(NRF_SPIM3)
+#define NRF_SPIS0        NRF_PERIPH(NRF_SPIS0)
+#define NRF_SPIS1        NRF_PERIPH(NRF_SPIS1)
+#define NRF_SPIS2        NRF_PERIPH(NRF_SPIS2)
+#define NRF_SPIS3        NRF_PERIPH(NRF_SPIS3)
+#define NRF_TIMER0       NRF_PERIPH(NRF_TIMER0)
+#define NRF_TIMER1       NRF_PERIPH(NRF_TIMER1)
+#define NRF_TIMER2       NRF_PERIPH(NRF_TIMER2)
+#define NRF_TWIM0        NRF_PERIPH(NRF_TWIM0)
+#define NRF_TWIM1        NRF_PERIPH(NRF_TWIM1)
+#define NRF_TWIM2        NRF_PERIPH(NRF_TWIM2)
+#define NRF_TWIM3        NRF_PERIPH(NRF_TWIM3)
+#define NRF_TWIS0        NRF_PERIPH(NRF_TWIS0)
+#define NRF_TWIS1        NRF_PERIPH(NRF_TWIS1)
+#define NRF_TWIS2        NRF_PERIPH(NRF_TWIS2)
+#define NRF_TWIS3        NRF_PERIPH(NRF_TWIS3)
+#define NRF_UARTE0       NRF_PERIPH(NRF_UARTE0)
+#define NRF_UARTE1       NRF_PERIPH(NRF_UARTE1)
+#define NRF_UARTE2       NRF_PERIPH(NRF_UARTE2)
+#define NRF_UARTE3       NRF_PERIPH(NRF_UARTE3)
+#define NRF_VMC          NRF_PERIPH(NRF_VMC)
+#define NRF_WDT          NRF_PERIPH(NRF_WDT)
 
 /*
  * The following section provides the name translation for peripherals with
@@ -92,20 +92,23 @@
  * between secure and non-secure mapping.
  */
 #if defined(NRF_TRUSTZONE_NONSECURE)
-#define NRF_GPIOTE1     NRF_GPIOTE1_NS
+#define NRF_GPIOTE1      NRF_GPIOTE1_NS
 #else
-#define NRF_CRYPTOCELL  NRF_CRYPTOCELL_S
-#define NRF_FICR        NRF_FICR_S
-#define NRF_GPIOTE0     NRF_GPIOTE0_S
-#define NRF_SPU         NRF_SPU_S
-#define NRF_UICR        NRF_UICR_S
+#define NRF_CC_HOST_RGF  NRF_CC_HOST_RGF_S
+#define NRF_CRYPTOCELL   NRF_CRYPTOCELL_S
+#define NRF_CTRL_AP_PERI NRF_CTRL_AP_PERI_S
+#define NRF_FICR         NRF_FICR_S
+#define NRF_GPIOTE0      NRF_GPIOTE0_S
+#define NRF_SPU          NRF_SPU_S
+#define NRF_TAD          NRF_TAD_S
+#define NRF_UICR         NRF_UICR_S
 #endif
 
 /* Fixup for the GPIOTE driver. */
 #if defined(NRF_TRUSTZONE_NONSECURE)
-#define NRF_GPIOTE      NRF_GPIOTE1
+#define NRF_GPIOTE       NRF_GPIOTE1
 #else
-#define NRF_GPIOTE      NRF_GPIOTE0
+#define NRF_GPIOTE       NRF_GPIOTE0
 #endif
 
 


### PR DESCRIPTION
This is a follow-up to #26.

Add translations of names with _S and _NS suffixes for peripheral
access symbols that are available for a given chip but were not used
so far in any nrfx HAL or driver, to make the lists of translations
complete and consistent.

This commit corrects also the translation of NRF_I2S symbol for nRF5340
whose name for this SoC contains also the index 0 (so it needs to be
handled similarly like NRF_PDM0 is).