### PR TITLE
NVMC improvements for UICR/OTP

### DIFF
--- a/nrfx/drivers/include/nrfx_nvmc.h
+++ b/nrfx/drivers/include/nrfx_nvmc.h
@@ -155,6 +155,37 @@ bool nrfx_nvmc_byte_writable_check(uint32_t address, uint8_t value);
 void nrfx_nvmc_byte_write(uint32_t address, uint8_t value);
 
 /**
+ * @brief Function for checking whether a halfword is writable at the specified address.
+ *
+ * The NVMC is only able to write '0' to bits in the Flash that are erased (set to '1').
+ * It cannot rewrite a bit back to '1'. This function checks if the value currently
+ * residing at the specified address can be transformed to the desired value
+ * without any '0' to '1' transitions.
+ *
+ * @param address Address to be checked. Must be halfword-aligned.
+ * @param value   Value to be checked.
+ *
+ * @retval true  Word can be written at the specified address.
+ * @retval false Word cannot be written at the specified address.
+ *               Erase page or change address.
+ */
+bool nrfx_nvmc_halfword_writable_check(uint32_t address, uint16_t value);
+
+/**
+ * @brief Function for writing a 16-bit halfword to flash.
+ *
+ * To determine if the flash write has been completed, use @ref nrfx_nvmc_write_done_check().
+ *
+ * @note Depending on the source of the code being executed,
+ *       the CPU may be halted during the operation.
+ *       Refer to the Product Specification for more information.
+ *
+ * @param address Address to write to. Must be halfword-aligned.
+ * @param value   Value to write.
+ */
+void nrfx_nvmc_halfword_write(uint32_t address, uint16_t value);
+
+/**
  * @brief Function for checking whether a word is writable at the specified address.
  *
  * The NVMC is only able to write '0' to bits in the Flash that are erased (set to '1').
@@ -214,6 +245,18 @@ void nrfx_nvmc_bytes_write(uint32_t address, void const * src, uint32_t num_byte
  * @param num_words Number of words to write.
  */
 void nrfx_nvmc_words_write(uint32_t address, void const * src, uint32_t num_words);
+
+/**
+ * @brief Function for reading a 16-bit aligned halfword from flash.
+ *
+ * This can be used if unaligned accesses are not supported on the flash area.
+ * This applies e.g. to UICR.
+ *
+ * @param address   Address to read from. Must be halfword-aligned.
+ *
+ * @retval The contents at @p address.
+ */
+uint16_t nrfx_nvmc_halfword_read(uint32_t address);
 
 /**
  * @brief Function for getting the total flash size in bytes.

--- a/nrfx/drivers/nrfx_common.h
+++ b/nrfx/drivers/nrfx_common.h
@@ -282,6 +282,16 @@ NRF_STATIC_INLINE bool nrfx_is_in_uicr(void const * p_object);
 NRF_STATIC_INLINE bool nrfx_is_word_aligned(void const * p_object);
 
 /**
+ * @brief Function for checking if an object is aligned to a 16-bit halfword
+ *
+ * @param[in] p_object  Pointer to an object whose location is to be checked.
+ *
+ * @retval true  The pointed object is aligned to a 16-bit word.
+ * @retval false The pointed object is not aligned to a 16-bit word.
+ */
+NRF_STATIC_INLINE bool nrfx_is_halfword_aligned(void const * p_object);
+
+/**
  * @brief Function for getting the interrupt number for the specified peripheral.
  *
  * @param[in] p_reg Peripheral base pointer.
@@ -341,6 +351,11 @@ NRF_STATIC_INLINE bool nrfx_is_in_uicr(void const * p_object)
 #endif
     return ((uint32_t)p_object >= (uint32_t)UICR_NAME)
            && ((uint32_t)p_object < ((uint32_t)UICR_NAME + sizeof(*UICR_NAME)));
+}
+
+NRF_STATIC_INLINE bool nrfx_is_halfword_aligned(void const * p_object)
+{
+    return ((((uint32_t)p_object) & 0x1u) == 0u);
 }
 
 NRF_STATIC_INLINE bool nrfx_is_word_aligned(void const * p_object)

--- a/nrfx/drivers/nrfx_common.h
+++ b/nrfx/drivers/nrfx_common.h
@@ -254,6 +254,20 @@ typedef enum
 NRF_STATIC_INLINE bool nrfx_is_in_ram(void const * p_object);
 
 /**
+ * @brief Function for checking if an object is placed in the UICR region.
+ *
+ * UICR is a flash area, but certain unique restrictions apply e.g. for
+ * unaligned reads. The UICR resides in a separate address region from regular
+ * FLASH.
+ *
+ * @param[in] p_object Pointer to an object whose location is to be checked.
+ *
+ * @retval true  The pointed object is located in the UICR region.
+ * @retval false The pointed object is not located in the UICR region.
+ */
+NRF_STATIC_INLINE bool nrfx_is_in_uicr(void const * p_object);
+
+/**
  * @brief Function for checking if an object is aligned to a 32-bit word
  *
  * Several peripherals (the ones using EasyDMA) require the transfer buffers
@@ -314,6 +328,19 @@ NRF_STATIC_INLINE uint32_t nrfx_event_to_bitpos(uint32_t event);
 NRF_STATIC_INLINE bool nrfx_is_in_ram(void const * p_object)
 {
     return ((((uint32_t)p_object) & 0xE0000000u) == 0x20000000u);
+}
+
+NRF_STATIC_INLINE bool nrfx_is_in_uicr(void const * p_object)
+{
+#ifdef NRF_UICR
+    #define UICR_NAME NRF_UICR
+#elif defined(NRF_UICR_S)
+    #define UICR_NAME NRF_UICR_S
+#elif defined(NRF_UICR_NS)
+    #define UICR_NAME NRF_UICR_NS
+#endif
+    return ((uint32_t)p_object >= (uint32_t)UICR_NAME)
+           && ((uint32_t)p_object < ((uint32_t)UICR_NAME + sizeof(*UICR_NAME)));
 }
 
 NRF_STATIC_INLINE bool nrfx_is_word_aligned(void const * p_object)

--- a/nrfx/drivers/src/nrfx_nvmc.c
+++ b/nrfx/drivers/src/nrfx_nvmc.c
@@ -141,6 +141,10 @@ static uint32_t flash_total_size_get(void)
     return flash_page_size_get() * flash_page_count_get();
 }
 
+static bool is_in_code_flash(void const * p_object)
+{
+    return ((uint32_t)p_object - NVMC_FLASH_BASE_ADDRESS) < flash_total_size_get();
+}
 
 static bool is_page_aligned_check(uint32_t addr)
 {
@@ -218,7 +222,7 @@ static void nvmc_words_write(uint32_t addr, void const * src, uint32_t num_words
 
 nrfx_err_t nrfx_nvmc_page_erase(uint32_t addr)
 {
-    NRFX_ASSERT((addr - NVMC_FLASH_BASE_ADDRESS) < flash_total_size_get());
+    NRFX_ASSERT(is_in_code_flash((void *)addr) || nrfx_is_in_uicr((void *)addr));
 
     if (!is_page_aligned_check(addr))
     {
@@ -260,7 +264,7 @@ void nrfx_nvmc_all_erase(void)
 #if defined(NRF_NVMC_PARTIAL_ERASE_PRESENT)
 nrfx_err_t nrfx_nvmc_page_partial_erase_init(uint32_t addr, uint32_t duration_ms)
 {
-    NRFX_ASSERT((addr - NVMC_FLASH_BASE_ADDRESS) < flash_total_size_get());
+    NRFX_ASSERT(is_in_code_flash((void *)addr) || nrfx_is_in_uicr((void *)addr));
 
     if (!is_page_aligned_check(addr))
     {
@@ -306,7 +310,7 @@ bool nrfx_nvmc_page_partial_erase_continue(void)
 
 bool nrfx_nvmc_byte_writable_check(uint32_t addr, uint8_t val_to_check)
 {
-    NRFX_ASSERT((addr - NVMC_FLASH_BASE_ADDRESS) < flash_total_size_get());
+    NRFX_ASSERT(is_in_code_flash((void *)addr) || nrfx_is_in_uicr((void *)addr));
 
     uint8_t val_on_addr = *(uint8_t const *)addr;
     return (val_to_check & val_on_addr) == val_to_check;
@@ -314,7 +318,7 @@ bool nrfx_nvmc_byte_writable_check(uint32_t addr, uint8_t val_to_check)
 
 bool nrfx_nvmc_word_writable_check(uint32_t addr, uint32_t val_to_check)
 {
-    NRFX_ASSERT((addr - NVMC_FLASH_BASE_ADDRESS) < flash_total_size_get());
+    NRFX_ASSERT(is_in_code_flash((void *)addr) || nrfx_is_in_uicr((void *)addr));
     NRFX_ASSERT(nrfx_is_word_aligned((void const *)addr));
 
     uint32_t val_on_addr = *(uint32_t const *)addr;
@@ -323,6 +327,8 @@ bool nrfx_nvmc_word_writable_check(uint32_t addr, uint32_t val_to_check)
 
 void nrfx_nvmc_byte_write(uint32_t addr, uint8_t value)
 {
+    NRFX_ASSERT(is_in_code_flash((void *)addr) || nrfx_is_in_uicr((void *)addr));
+
     uint32_t aligned_addr = addr & ~(0x03UL);
 
     nrfx_nvmc_word_write(aligned_addr, partial_word_create(addr, &value, 1));
@@ -330,7 +336,7 @@ void nrfx_nvmc_byte_write(uint32_t addr, uint8_t value)
 
 void nrfx_nvmc_word_write(uint32_t addr, uint32_t value)
 {
-    NRFX_ASSERT((addr - NVMC_FLASH_BASE_ADDRESS) < flash_total_size_get());
+    NRFX_ASSERT(is_in_code_flash((void *)addr) || nrfx_is_in_uicr((void *)addr));
     NRFX_ASSERT(nrfx_is_word_aligned((void const *)addr));
 
     nvmc_write_mode_set();
@@ -342,7 +348,7 @@ void nrfx_nvmc_word_write(uint32_t addr, uint32_t value)
 
 void nrfx_nvmc_bytes_write(uint32_t addr, void const * src, uint32_t num_bytes)
 {
-    NRFX_ASSERT((addr - NVMC_FLASH_BASE_ADDRESS) < flash_total_size_get());
+    NRFX_ASSERT(is_in_code_flash((void *)addr) || nrfx_is_in_uicr((void *)addr));
 
     nvmc_write_mode_set();
 
@@ -404,7 +410,7 @@ void nrfx_nvmc_bytes_write(uint32_t addr, void const * src, uint32_t num_bytes)
 
 void nrfx_nvmc_words_write(uint32_t addr, void const * src, uint32_t num_words)
 {
-    NRFX_ASSERT((addr - NVMC_FLASH_BASE_ADDRESS) < flash_total_size_get());
+    NRFX_ASSERT(is_in_code_flash((void *)addr) || nrfx_is_in_uicr((void *)addr));
     NRFX_ASSERT(nrfx_is_word_aligned((void const *)addr));
     NRFX_ASSERT(nrfx_is_word_aligned(src));
 


### PR DESCRIPTION
Fix some limitations in the driver relating to the HW:

 - The assert triggers for writes to UICR, since it is outside regular flash.
 - The OTP region is centered around halfwords.

Found while working on https://github.com/NordicPlayground/fw-nrfconnect-nrf/pull/1917.

I haven't tested this extensively, hence the Draft.

Mirrored in https://github.com/NordicSemiconductor/nrfx/pull/72