### PR TITLE
drivers: nrf_radio_802154: Enable CSMA/CA

### DIFF
--- a/drivers/nrf_radio_802154/CMakeLists.txt
+++ b/drivers/nrf_radio_802154/CMakeLists.txt
@@ -14,6 +14,7 @@ zephyr_library_sources(
   nrf_802154_timer_coord.c
   nrf_802154.c
   fal/nrf_802154_fal.c
+  mac_features/nrf_802154_csma_ca.c
   mac_features/nrf_802154_filter.c
   mac_features/nrf_802154_frame_parser.c
   mac_features/ack_generator/nrf_802154_ack_data.c
@@ -73,10 +74,12 @@ zephyr_compile_definitions(
   NRF_802154_CCA_CORR_THRESHOLD_DEFAULT=${CONFIG_NRF_802154_CCA_CORR_THRESHOLD}
   NRF_802154_CCA_ED_THRESHOLD_DEFAULT=${CONFIG_NRF_802154_CCA_ED_THRESHOLD}
 
+  # Enable CSMA/CA
+  NRF_802154_CSMA_CA_ENABLED=1
+  NRF_802154_TX_STARTED_NOTIFY_ENABLED=1
+
   # Disable unused radio driver features
-  NRF_802154_CSMA_CA_ENABLED=0
   NRF_802154_ACK_TIMEOUT_ENABLED=0
   NRF_802154_FRAME_TIMESTAMP_ENABLED=0
   NRF_802154_DELAYED_TRX_ENABLED=0
-  NRF_802154_TX_STARTED_NOTIFY_ENABLED=0
 )

--- a/drivers/nrf_radio_802154/platform/lp_timer/nrf_802154_lp_timer_zephyr.c
+++ b/drivers/nrf_radio_802154/platform/lp_timer/nrf_802154_lp_timer_zephyr.c
@@ -28,50 +28,16 @@
  *
  */
 
-/**
- * @file
- *   This file contains standalone implementation of the nRF 802.15.4 timer abstraction.
- *
- * This implementation is built on top of the RTC peripheral.
- *
- */
-
-#include <stdint.h>
-
 #include <kernel.h>
 
-#include "nrf_802154_lp_timer.h"
-#include "nrf_802154_utils.h"
+#define nrf_802154_lp_timer_init nrf_802154_lp_timer_init_nodrv
+#include "nrf_802154_lp_timer_nodrv.c"
+#undef nrf_802154_lp_timer_init
 
 void nrf_802154_lp_timer_init(void)
 {
-    /* Intentionally empty. */
-}
+    IRQ_CONNECT(NRF_802154_RTC_IRQN, NRF_802154_RTC_IRQ_PRIORITY,
+                NRF_802154_RTC_IRQ_HANDLER, NULL, 0);
 
-void nrf_802154_lp_timer_deinit(void)
-{
-    /* Intentionally empty. */
-}
-
-void nrf_802154_lp_timer_critical_section_enter(void)
-{
-
-    /* Intentionally empty. */
-}
-
-void nrf_802154_lp_timer_critical_section_exit(void)
-{
-    /* Intentionally empty. */
-}
-
-uint32_t nrf_802154_lp_timer_time_get(void)
-{
-    u64_t ticks = k_cycle_get_32();
-
-    return (u32_t)(NRF_802154_RTC_TICKS_TO_US(ticks));
-}
-
-uint32_t nrf_802154_lp_timer_granularity_get(void)
-{
-    return NRF_802154_US_PER_TICK;
+    nrf_802154_lp_timer_init_nodrv();
 }

--- a/drivers/nrf_radio_802154/platform/random/nrf_802154_random_zephyr.c
+++ b/drivers/nrf_radio_802154/platform/random/nrf_802154_random_zephyr.c
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019, Nordic Semiconductor ASA
+/* Copyright (c) 2019 - 2020, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -28,23 +28,58 @@
  *
  */
 
+/*
+ * Based on code written in 2016-2018 by David Blackman and Sebastiano Vigna
+ * (vigna@acm.org)
+ *
+ * To the extent possible under law, the author has dedicated all copyright
+ * and related and neighboring rights to this software to the public domain
+ * worldwide. This software is distributed without any warranty.
+ *
+ * See <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+
 /**
  * @file
  *   This file implements the pseudo-random number generator abstraction layer.
  *
- * This pseudo-random number abstraction layer uses standard library rand() function.
+ * This pseudo-random number abstraction layer implements xoroshiro128+ algorithm.
  *
  */
 
 #include "nrf_802154_random.h"
 
-#include <zephyr.h>
+#include <drivers/entropy.h>
 
-#include "nrf.h"
+static uint64_t s[2];
+
+static inline uint64_t rotl(const uint64_t x, int k) {
+    return (x << k) | (x >> (64 - k));
+}
+
+static uint64_t next(void)
+{
+    const uint64_t s0 = s[0];
+    uint64_t s1 = s[1];
+    const uint64_t result = s0 + s1;
+
+    s1 ^= s0;
+    s[0] = rotl(s0, 24) ^ s1 ^ (s1 << 16); // a, b
+    s[1] = rotl(s1, 37); // c
+
+    return result;
+}
 
 void nrf_802154_random_init(void)
 {
-    // Intentionally empty
+    struct device *dev;
+    int err;
+
+    dev = device_get_binding(CONFIG_ENTROPY_NAME);
+    __ASSERT_NO_MSG(dev != NULL);
+
+    err = entropy_get_entropy(dev, (uint8_t *)&s, sizeof(s));
+    __ASSERT_NO_MSG(err == 0);
 }
 
 void nrf_802154_random_deinit(void)
@@ -54,5 +89,5 @@ void nrf_802154_random_deinit(void)
 
 uint32_t nrf_802154_random_get(void)
 {
-    return sys_rand32_get();
+    return (uint32_t)next();
 }


### PR DESCRIPTION
Enable CSMA/CA support in the radio driver. Implement/rework features in the platform layer needed to make it work.