### PR TITLE
drivers: nrf_radio_802154: ACK timeout, RX timestamps, delayed TX

### DIFF
--- a/drivers/nrf_radio_802154/CMakeLists.txt
+++ b/drivers/nrf_radio_802154/CMakeLists.txt
@@ -17,6 +17,7 @@ zephyr_library_sources(
   mac_features/nrf_802154_csma_ca.c
   mac_features/nrf_802154_filter.c
   mac_features/nrf_802154_frame_parser.c
+  mac_features/nrf_802154_precise_ack_timeout.c
   mac_features/ack_generator/nrf_802154_ack_data.c
   mac_features/ack_generator/nrf_802154_ack_generator.c
   mac_features/ack_generator/nrf_802154_enh_ack_generator.c
@@ -84,6 +85,6 @@ zephyr_compile_definitions(
   NRF_802154_FRAME_TIMESTAMP_ENABLED=1
   NRF_802154_DELAYED_TRX_ENABLED=1
 
-  # Disable unused radio driver features
-  NRF_802154_ACK_TIMEOUT_ENABLED=0
+  # ACK timeout
+  NRF_802154_ACK_TIMEOUT_ENABLED=1
 )

--- a/drivers/nrf_radio_802154/CMakeLists.txt
+++ b/drivers/nrf_radio_802154/CMakeLists.txt
@@ -21,8 +21,10 @@ zephyr_library_sources(
   mac_features/ack_generator/nrf_802154_ack_generator.c
   mac_features/ack_generator/nrf_802154_enh_ack_generator.c
   mac_features/ack_generator/nrf_802154_imm_ack_generator.c
+  mac_features/nrf_802154_delayed_trx.c
   platform/clock/nrf_802154_clock_zephyr.c
   platform/coex/nrf_802154_wifi_coex_none.c
+  platform/hp_timer/nrf_802154_hp_timer.c
   platform/lp_timer/nrf_802154_lp_timer_zephyr.c
   platform/random/nrf_802154_random_zephyr.c
   platform/temperature/nrf_802154_temperature_none.c
@@ -78,8 +80,10 @@ zephyr_compile_definitions(
   NRF_802154_CSMA_CA_ENABLED=1
   NRF_802154_TX_STARTED_NOTIFY_ENABLED=1
 
+  # Timestamps
+  NRF_802154_FRAME_TIMESTAMP_ENABLED=1
+  NRF_802154_DELAYED_TRX_ENABLED=1
+
   # Disable unused radio driver features
   NRF_802154_ACK_TIMEOUT_ENABLED=0
-  NRF_802154_FRAME_TIMESTAMP_ENABLED=0
-  NRF_802154_DELAYED_TRX_ENABLED=0
 )

--- a/drivers/nrf_radio_802154/nrf_802154_timer_coord.c
+++ b/drivers/nrf_radio_802154/nrf_802154_timer_coord.c
@@ -101,7 +101,7 @@ void nrf_802154_timer_coord_uninit(void)
     nrf_ppi_channel_disable(NRF_PPI, PPI_SYNC);
     nrf_ppi_channel_endpoint_setup(NRF_PPI, PPI_SYNC, 0, 0);
 
-    nrf_ppi_group_disable(PPI_TIMESTAMP_GROUP);
+    nrf_ppi_group_disable(NRF_PPI, PPI_TIMESTAMP_GROUP);
     nrf_ppi_channel_and_fork_endpoint_setup(NRF_PPI, PPI_TIMESTAMP, 0, 0, 0);
 }
 
@@ -136,9 +136,9 @@ void nrf_802154_timer_coord_timestamp_prepare(uint32_t event_addr)
                                             event_addr,
                                             nrf_802154_hp_timer_timestamp_task_get(),
                                             (uint32_t)nrf_ppi_task_group_disable_address_get(
-                                                PPI_TIMESTAMP_GROUP));
+                                                NRF_PPI, PPI_TIMESTAMP_GROUP));
 
-    nrf_ppi_group_enable(PPI_TIMESTAMP_GROUP);
+    nrf_ppi_group_enable(NRF_PPI, PPI_TIMESTAMP_GROUP);
 
     nrf_802154_log(EVENT_TRACE_EXIT, FUNCTION_TCOOR_TIMESTAMP_PREPARE);
 }

--- a/drivers/nrf_radio_802154/platform/clock/nrf_802154_clock_zephyr.c
+++ b/drivers/nrf_radio_802154/platform/clock/nrf_802154_clock_zephyr.c
@@ -56,25 +56,31 @@ void nrf_802154_clock_deinit(void)
     /* Intentionally empty. */
 }
 
+static void hfclk_on_callback(struct device *dev, clock_control_subsys_t subsys,
+                              void *user_data)
+{
+    hfclk_is_running = true;
+    nrf_802154_clock_hfclk_ready();
+}
+
 void nrf_802154_clock_hfclk_start(void)
 {
+    static struct clock_control_async_data clk_data = {
+        .cb = hfclk_on_callback
+    };
     struct device *clk;
 
-    clk = device_get_binding(DT_INST_0_NORDIC_NRF_CLOCK_LABEL);
+    clk = device_get_binding(DT_LABEL(DT_INST(0, nordic_nrf_clock)));
     __ASSERT_NO_MSG(clk != NULL);
 
-    clock_control_on(clk, CLOCK_CONTROL_NRF_SUBSYS_HF); /* Blocking call. */
-
-    hfclk_is_running = true;
-
-    nrf_802154_clock_hfclk_ready();
+    clock_control_async_on(clk, CLOCK_CONTROL_NRF_SUBSYS_HF, &clk_data);
 }
 
 void nrf_802154_clock_hfclk_stop(void)
 {
     struct device *clk;
 
-    clk = device_get_binding(DT_INST_0_NORDIC_NRF_CLOCK_LABEL);
+    clk = device_get_binding(DT_LABEL(DT_INST(0, nordic_nrf_clock)));
     __ASSERT_NO_MSG(clk != NULL);
 
     hfclk_is_running = false;
@@ -87,25 +93,31 @@ bool nrf_802154_clock_hfclk_is_running(void)
     return hfclk_is_running;
 }
 
+static void lfclk_on_callback(struct device *dev, clock_control_subsys_t subsys,
+                              void *user_data)
+{
+    lfclk_is_running = true;
+    nrf_802154_clock_lfclk_ready();
+}
+
 void nrf_802154_clock_lfclk_start(void)
 {
+    static struct clock_control_async_data clk_data = {
+        .cb = lfclk_on_callback
+    };
     struct device *clk;
 
-    clk = device_get_binding(DT_INST_0_NORDIC_NRF_CLOCK_LABEL);
+    clk = device_get_binding(DT_LABEL(DT_INST(0, nordic_nrf_clock)));
     __ASSERT_NO_MSG(clk != NULL);
 
-    clock_control_on(clk, CLOCK_CONTROL_NRF_SUBSYS_LF);
-
-    lfclk_is_running = true;
-
-    nrf_802154_clock_lfclk_ready();
+    clock_control_async_on(clk, CLOCK_CONTROL_NRF_SUBSYS_LF, &clk_data);
 }
 
 void nrf_802154_clock_lfclk_stop(void)
 {
     struct device *clk;
 
-    clk = device_get_binding(DT_INST_0_NORDIC_NRF_CLOCK_LABEL);
+    clk = device_get_binding(DT_LABEL(DT_INST(0, nordic_nrf_clock)));
     __ASSERT_NO_MSG(clk != NULL);
 
     lfclk_is_running = false;


### PR DESCRIPTION
Several improvements for the radio driver:
* Switch clock implementation to Zephyr asychronous clock API,
* Enable ACK timeout feature,
* Enable RX timestamps,
* Enable delayed TX.