### PR TITLE
nrf_radio_802154: Replace CONFIG_ENTROPY_NAME with DT_LABEL(<rng_node>)

### DIFF
--- a/drivers/nrf_radio_802154/platform/random/nrf_802154_random_zephyr.c
+++ b/drivers/nrf_radio_802154/platform/random/nrf_802154_random_zephyr.c
@@ -75,7 +75,7 @@ void nrf_802154_random_init(void)
     struct device *dev;
     int err;
 
-    dev = device_get_binding(CONFIG_ENTROPY_NAME);
+    dev = device_get_binding(DT_LABEL(DT_INST(0, nordic_nrf_rng)));
     __ASSERT_NO_MSG(dev != NULL);
 
     err = entropy_get_entropy(dev, (uint8_t *)&s, sizeof(s));


### PR DESCRIPTION
Align with the replacement done in the main Zephyr repository.

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>