### PR TITLE
nrfx_glue: Move #include directives outside of extern "C" blocks

### DIFF
--- a/nrfx_glue.h
+++ b/nrfx_glue.h
@@ -32,6 +32,10 @@
 #ifndef NRFX_GLUE_H__
 #define NRFX_GLUE_H__
 
+#include <sys/__assert.h>
+#include <sys/atomic.h>
+#include <irq.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -46,8 +50,6 @@ extern "C" {
  */
 
 //------------------------------------------------------------------------------
-
-#include <sys/__assert.h>
 
 /**
  * @brief Macro for placing a runtime assertion.
@@ -65,8 +67,6 @@ extern "C" {
         BUILD_ASSERT(expression, "assertion failed")
 
 //------------------------------------------------------------------------------
-
-#include <irq.h>
 
 /**
  * @brief Macro for setting the priority of a specific IRQ.
@@ -150,8 +150,6 @@ extern "C" {
 void nrfx_busy_wait(u32_t usec_to_wait);
 
 //------------------------------------------------------------------------------
-
-#include <sys/atomic.h>
 
 /** @brief Atomic 32-bit unsigned type. */
 #define nrfx_atomic_t  atomic_t

--- a/nrfx_log.h
+++ b/nrfx_log.h
@@ -32,6 +32,8 @@
 #ifndef NRFX_LOG_H__
 #define NRFX_LOG_H__
 
+#include <logging/log.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -62,7 +64,6 @@ extern "C" {
 #elif	NRFX_MODULE_CONFIG_LOG_LEVEL == 4
 #define NRFX_MODULE_LOG_LEVEL		LOG_LEVEL_DBG
 #endif
-#include <logging/log.h>
 LOG_MODULE_REGISTER(NRFX_MODULE_PREFIX, NRFX_MODULE_LOG_LEVEL);
 
 /**


### PR DESCRIPTION
To prevent compilation errors when some C++ elements, like a template
definition, happen to appear in those included files or files included
by them.

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>