### PR TITLE
nrf_radio_802154: Use chosen zephyr,entropy to get entropy device

### DIFF
--- a/drivers/nrf_radio_802154/platform/random/nrf_802154_random_zephyr.c
+++ b/drivers/nrf_radio_802154/platform/random/nrf_802154_random_zephyr.c
@@ -75,7 +75,7 @@ void nrf_802154_random_init(void)
     struct device *dev;
     int err;
 
-    dev = device_get_binding(DT_LABEL(DT_INST(0, nordic_nrf_rng)));
+    dev = device_get_binding(DT_CHOSEN_ZEPHYR_ENTROPY_LABEL);
     __ASSERT_NO_MSG(dev != NULL);
 
     err = entropy_get_entropy(dev, (uint8_t *)&s, sizeof(s));


### PR DESCRIPTION
Use the label property of the node pointed by "zephyr,entropy" chosen
entry as the name of the entropy device to bind to. The pointed node
does not necessarily need to be a "nordic,nrf-rng" compatible one, what
was incorrectly assumed when CONFIG_ENTROPY_NAME was replaced in commit
5505d0baa66a89848f643120fafad232876df695.

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>