### PR TITLE
nrfx_nvmc: Fix compilation issue NRF_UICR not defined

### DIFF
--- a/nrfx/drivers/src/nrfx_nvmc.c
+++ b/nrfx/drivers/src/nrfx_nvmc.c
@@ -222,8 +222,11 @@ static void nvmc_words_write(uint32_t addr, void const * src, uint32_t num_words
 
 nrfx_err_t nrfx_nvmc_page_erase(uint32_t addr)
 {
-    NRFX_ASSERT(((addr - NVMC_FLASH_BASE_ADDRESS) < flash_total_size_get()) ||
-                ((addr - (uint32_t)NRF_UICR) < sizeof(NRF_UICR_Type)));
+    NRFX_ASSERT(((addr - NVMC_FLASH_BASE_ADDRESS) < flash_total_size_get())
+#if !defined(NRF_TRUSTZONE_NONSECURE)
+     || ((addr - (uint32_t)NRF_UICR) < sizeof(NRF_UICR_Type))
+#endif
+    );
 
     if (!is_page_aligned_check(addr))
     {
@@ -265,8 +268,11 @@ void nrfx_nvmc_all_erase(void)
 #if defined(NRF_NVMC_PARTIAL_ERASE_PRESENT)
 nrfx_err_t nrfx_nvmc_page_partial_erase_init(uint32_t addr, uint32_t duration_ms)
 {
-    NRFX_ASSERT(((addr - NVMC_FLASH_BASE_ADDRESS) < flash_total_size_get()) ||
-                ((addr - (uint32_t)NRF_UICR) < sizeof(NRF_UICR_Type)));
+    NRFX_ASSERT(((addr - NVMC_FLASH_BASE_ADDRESS) < flash_total_size_get())
+#if !defined(NRF_TRUSTZONE_NONSECURE)
+     || ((addr - (uint32_t)NRF_UICR) < sizeof(NRF_UICR_Type))
+#endif
+    );
 
     if (!is_page_aligned_check(addr))
     {
@@ -312,8 +318,11 @@ bool nrfx_nvmc_page_partial_erase_continue(void)
 
 bool nrfx_nvmc_byte_writable_check(uint32_t addr, uint8_t val_to_check)
 {
-    NRFX_ASSERT(((addr - NVMC_FLASH_BASE_ADDRESS) < flash_total_size_get()) ||
-                ((addr - (uint32_t)NRF_UICR) < sizeof(NRF_UICR_Type)));
+    NRFX_ASSERT(((addr - NVMC_FLASH_BASE_ADDRESS) < flash_total_size_get())
+#if !defined(NRF_TRUSTZONE_NONSECURE)
+     || ((addr - (uint32_t)NRF_UICR) < sizeof(NRF_UICR_Type))
+#endif
+    );
 
     uint8_t val_on_addr = *(uint8_t const *)addr;
     return (val_to_check & val_on_addr) == val_to_check;
@@ -321,8 +330,11 @@ bool nrfx_nvmc_byte_writable_check(uint32_t addr, uint8_t val_to_check)
 
 bool nrfx_nvmc_halfword_writable_check(uint32_t addr, uint16_t val_to_check)
 {
-    NRFX_ASSERT(((addr - NVMC_FLASH_BASE_ADDRESS) < flash_total_size_get()) ||
-                ((addr - (uint32_t)NRF_UICR) < sizeof(NRF_UICR_Type)));
+    NRFX_ASSERT(((addr - NVMC_FLASH_BASE_ADDRESS) < flash_total_size_get())
+#if !defined(NRF_TRUSTZONE_NONSECURE)
+     || ((addr - (uint32_t)NRF_UICR) < sizeof(NRF_UICR_Type))
+#endif
+    );
     NRFX_ASSERT(is_halfword_aligned(addr));
 
     uint16_t val_on_addr;
@@ -340,8 +352,11 @@ bool nrfx_nvmc_halfword_writable_check(uint32_t addr, uint16_t val_to_check)
 
 bool nrfx_nvmc_word_writable_check(uint32_t addr, uint32_t val_to_check)
 {
-    NRFX_ASSERT(((addr - NVMC_FLASH_BASE_ADDRESS) < flash_total_size_get()) ||
-                ((addr - (uint32_t)NRF_UICR) < sizeof(NRF_UICR_Type)));
+    NRFX_ASSERT(((addr - NVMC_FLASH_BASE_ADDRESS) < flash_total_size_get())
+#if !defined(NRF_TRUSTZONE_NONSECURE)
+     || ((addr - (uint32_t)NRF_UICR) < sizeof(NRF_UICR_Type))
+#endif
+    );
     NRFX_ASSERT(nrfx_is_word_aligned((void const *)addr));
 
     uint32_t val_on_addr = *(uint32_t const *)addr;
@@ -350,8 +365,11 @@ bool nrfx_nvmc_word_writable_check(uint32_t addr, uint32_t val_to_check)
 
 void nrfx_nvmc_byte_write(uint32_t addr, uint8_t value)
 {
-    NRFX_ASSERT(((addr - NVMC_FLASH_BASE_ADDRESS) < flash_total_size_get()) ||
-                ((addr - (uint32_t)NRF_UICR) < sizeof(NRF_UICR_Type)));
+    NRFX_ASSERT(((addr - NVMC_FLASH_BASE_ADDRESS) < flash_total_size_get())
+#if !defined(NRF_TRUSTZONE_NONSECURE)
+     || ((addr - (uint32_t)NRF_UICR) < sizeof(NRF_UICR_Type))
+#endif
+    );
 
     uint32_t aligned_addr = addr & ~(0x03UL);
 
@@ -360,8 +378,11 @@ void nrfx_nvmc_byte_write(uint32_t addr, uint8_t value)
 
 void nrfx_nvmc_halfword_write(uint32_t addr, uint16_t value)
 {
-    NRFX_ASSERT(((addr - NVMC_FLASH_BASE_ADDRESS) < flash_total_size_get()) ||
-                ((addr - (uint32_t)NRF_UICR) < sizeof(NRF_UICR_Type)));
+    NRFX_ASSERT(((addr - NVMC_FLASH_BASE_ADDRESS) < flash_total_size_get())
+#if !defined(NRF_TRUSTZONE_NONSECURE)
+     || ((addr - (uint32_t)NRF_UICR) < sizeof(NRF_UICR_Type))
+#endif
+    );
     NRFX_ASSERT(is_halfword_aligned(addr));
 
     uint32_t aligned_addr = addr & ~(0x03UL);
@@ -371,8 +392,11 @@ void nrfx_nvmc_halfword_write(uint32_t addr, uint16_t value)
 
 void nrfx_nvmc_word_write(uint32_t addr, uint32_t value)
 {
-    NRFX_ASSERT(((addr - NVMC_FLASH_BASE_ADDRESS) < flash_total_size_get()) ||
-                ((addr - (uint32_t)NRF_UICR) < sizeof(NRF_UICR_Type)));
+    NRFX_ASSERT(((addr - NVMC_FLASH_BASE_ADDRESS) < flash_total_size_get())
+#if !defined(NRF_TRUSTZONE_NONSECURE)
+     || ((addr - (uint32_t)NRF_UICR) < sizeof(NRF_UICR_Type))
+#endif
+    );
     NRFX_ASSERT(nrfx_is_word_aligned((void const *)addr));
 
     nvmc_write_mode_set();
@@ -384,8 +408,11 @@ void nrfx_nvmc_word_write(uint32_t addr, uint32_t value)
 
 void nrfx_nvmc_bytes_write(uint32_t addr, void const * src, uint32_t num_bytes)
 {
-    NRFX_ASSERT(((addr - NVMC_FLASH_BASE_ADDRESS) < flash_total_size_get()) ||
-                ((addr - (uint32_t)NRF_UICR) < sizeof(NRF_UICR_Type)));
+    NRFX_ASSERT(((addr - NVMC_FLASH_BASE_ADDRESS) < flash_total_size_get())
+#if !defined(NRF_TRUSTZONE_NONSECURE)
+     || ((addr - (uint32_t)NRF_UICR) < sizeof(NRF_UICR_Type))
+#endif
+    );
 
     nvmc_write_mode_set();
 
@@ -447,8 +474,11 @@ void nrfx_nvmc_bytes_write(uint32_t addr, void const * src, uint32_t num_bytes)
 
 void nrfx_nvmc_words_write(uint32_t addr, void const * src, uint32_t num_words)
 {
-    NRFX_ASSERT(((addr - NVMC_FLASH_BASE_ADDRESS) < flash_total_size_get()) ||
-                ((addr - (uint32_t)NRF_UICR) < sizeof(NRF_UICR_Type)));
+    NRFX_ASSERT(((addr - NVMC_FLASH_BASE_ADDRESS) < flash_total_size_get())
+#if !defined(NRF_TRUSTZONE_NONSECURE)
+     || ((addr - (uint32_t)NRF_UICR) < sizeof(NRF_UICR_Type))
+#endif
+    );
     NRFX_ASSERT(nrfx_is_word_aligned((void const *)addr));
     NRFX_ASSERT(nrfx_is_word_aligned(src));
 


### PR DESCRIPTION
Fix compilation issue when NRF_TRUSTZONE_NONSECURE is defined.
In this case NRF_UICR is not defined and should not be accessible
from non-secure.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>