### PR TITLE
drivers: 802154: Device instance are all constant now

### DIFF
--- a/drivers/nrf_radio_802154/platform/random/nrf_802154_random_zephyr.c
+++ b/drivers/nrf_radio_802154/platform/random/nrf_802154_random_zephyr.c
@@ -72,7 +72,7 @@ static uint64_t next(void)
 
 void nrf_802154_random_init(void)
 {
-    struct device *dev;
+    const struct device *dev;
     int err;
 
     dev = device_get_binding(DT_CHOSEN_ZEPHYR_ENTROPY_LABEL);

--- a/nrfx_glue.c
+++ b/nrfx_glue.c
@@ -7,7 +7,7 @@
 #include <nrfx.h>
 #include <kernel.h>
 
-void nrfx_isr(void *irq_handler)
+void nrfx_isr(const void *irq_handler)
 {
 	((nrfx_irq_handler_t)irq_handler)();
 }
@@ -18,7 +18,7 @@ void nrfx_busy_wait(uint32_t usec_to_wait)
 }
 
 char const *nrfx_error_string_get(nrfx_err_t code)
-{ 
+{
 	#define NRFX_ERROR_STRING_CASE(code)  case code: return #code
 	switch (code) {
 		NRFX_ERROR_STRING_CASE(NRFX_SUCCESS);

--- a/nrfx_glue.h
+++ b/nrfx_glue.h
@@ -281,7 +281,7 @@ extern const uint32_t z_bt_ctlr_used_nrf_ppi_groups;
  *
  * @param[in] irq_handler  Pointer to the nrfx IRQ handler to be called.
  */
-void nrfx_isr(void *irq_handler);
+void nrfx_isr(const void *irq_handler);
 
 /** @} */
 


### PR DESCRIPTION
Switching device parameter to constant.

Signed-off-by: Tomasz Bursztyka <tomasz.bursztyka@linux.intel.com>