### PR TITLE
nrf_gpio: Prevent warnings about switch cases falling through

### DIFF
--- a/nrfx/hal/nrf_gpio.h
+++ b/nrfx/hal/nrf_gpio.h
@@ -542,9 +542,11 @@ NRF_STATIC_INLINE NRF_GPIO_Type * nrf_gpio_pin_port_decode(uint32_t * p_pin)
         default:
             NRFX_ASSERT(0);
 #if defined(P0_FEATURE_PINS_PRESENT)
+        /* FALLTHROUGH */
         case 0: return NRF_P0;
 #endif
 #if defined(P1_FEATURE_PINS_PRESENT)
+        /* FALLTHROUGH */
         case 1: return NRF_P1;
 #endif
     }


### PR DESCRIPTION
Add special comments that will prevent warnings that would otherwise
appear when compilation is done with the -Wimplicit-fallthrough
options, as the falls through are intentional.

This is a temporary change in a file imported from the nrfx repository
and it is supposed to be overwritten by the next update of nrfx.

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>