### PR TITLE
boards: nrf52_bsim: nrfx porting for bsim using nrfx directly

### DIFF
--- a/nrfx_config.h
+++ b/nrfx_config.h
@@ -379,6 +379,9 @@
 #define NRFX_WDT1_ENABLED 1
 #endif
 
+#if defined(CONFIG_SOC_SERIES_BSIM_NRFXX)
+#include "nrfx_config_bsim.h"
+#endif
 
 /*
  * For chips with TrustZone support, MDK provides CMSIS-Core peripheral

--- a/nrfx_glue.h
+++ b/nrfx_glue.h
@@ -283,6 +283,10 @@ extern const uint32_t z_bt_ctlr_used_nrf_ppi_groups;
  */
 void nrfx_isr(const void *irq_handler);
 
+#if defined(CONFIG_SOC_SERIES_BSIM_NRFXX)
+#include "nrfx_glue_bsim.h"
+#endif
+
 /** @} */
 
 #ifdef __cplusplus


### PR DESCRIPTION
We need to ensure two things:
 1. None of the HAL APIs are inlined.
    This is ensured by defining NRF_DECLARE_ONLY and
    defining NRF_STATIC_INLINE to nothing
 2. Redefining the peripheral and peripheral base defines
    after they have been defined by the MDK. As nrfx_glue.h
    is included after the MDK, we can do it here.

Signed-off-by: Rubin Gerritsen <rubin.gerritsen@nordicsemi.no>