### PR TITLE
drivers: nrf_radio_802154: Fix typo in the clock driver

### DIFF
--- a/drivers/nrf_radio_802154/platform/clock/nrf_802154_clock_zephyr.c
+++ b/drivers/nrf_radio_802154/platform/clock/nrf_802154_clock_zephyr.c
@@ -127,7 +127,7 @@ void nrf_802154_clock_lfclk_stop(void)
             z_nrf_clock_control_get_onoff(CLOCK_CONTROL_NRF_SUBSYS_LF);
     __ASSERT_NO_MSG(mgr != NULL);
 
-    hfclk_is_running = false;
+    lfclk_is_running = false;
 
     ret = onoff_release(mgr);
     __ASSERT_NO_MSG(ret >= 0);


### PR DESCRIPTION
hfclk_is_running was used instead of lfclk_is_running in
nrf_802154_clock_lfclk_stop() function.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>