### PR TITLE
drivers: nrf_radio_802154: Port active_vector_priority_is_high to platform IRQ

### DIFF
--- a/drivers/nrf_radio_802154/nrf_802154_request_swi.c
+++ b/drivers/nrf_radio_802154/nrf_802154_request_swi.c
@@ -96,8 +96,8 @@ static inline void assert_interrupt_status(void)
  */
 static bool active_vector_priority_is_high(void)
 {
-
-    return nrf_802154_critical_section_active_vector_priority_get() <= NRF_802154_SWI_PRIORITY;
+    return nrf_802154_critical_section_active_vector_priority_get() <=
+            nrf_802154_irq_priority_get(NRF_802154_SWI_IRQN);
 }
 
 void nrf_802154_request_init(void)


### PR DESCRIPTION
Bug description: A `nrf_802154_request_buffer_free` call would return `false` due to not having high enough priority. The required priority comparison would be based on invalid value. Using platform IRQ solves the issue.

Fixes #28360

Signed-off-by: Kwiek, Pawel <pawel.kwiek@nordicsemi.no>