### PR TITLE
nrf_power: Fix implementation of workaround for nRF52 anomaly 197

### DIFF
--- a/nrfx/hal/nrf_power.h
+++ b/nrfx/hal/nrf_power.h
@@ -1147,7 +1147,7 @@ NRF_STATIC_INLINE uint32_t nrf_power_rampower_mask_get(NRF_POWER_Type const * p_
 #if NRF_POWER_HAS_DCDCEN_VDDH
 NRF_STATIC_INLINE void nrf_power_dcdcen_vddh_set(NRF_POWER_Type * p_reg, bool enable)
 {
-    if (nrf52_errata_197())
+    if (enable && nrf52_errata_197())
     {
         // Workaround for anomaly 197 "POWER: DCDC of REG0 not functional".
         *(volatile uint32_t *)0x40000638ul = 1ul;


### PR DESCRIPTION
Since the workaround increases power consumption in System ON IDLE,
it should be applied only when the DC/DC converter for REG0 stage is
to be enabled, not regardless of the applied setting as it was done
so far.

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>