### PR TITLE
drivers: Fix warning and linker errors in debug build

### DIFF
--- a/drivers/nrf_802154_sl_opensource/src/nrf_802154_sl_log.c
+++ b/drivers/nrf_802154_sl_opensource/src/nrf_802154_sl_log.c
@@ -38,6 +38,16 @@
 
 #include "nrf_802154_sl_log.h"
 
+/**
+ * @brief Buffer used to store debug log messages.
+ */
+volatile uint32_t g_nrf_802154_sl_log_buffer[NRF_802154_SL_DEBUG_LOG_BUFFER_LEN];
+
+/**
+ * @brief Index of the log buffer pointing to the element that should be filled with next log message.
+ */
+volatile uint32_t gp_nrf_802154_sl_log_ptr = 0;
+
 void nrf_802154_sl_log_init(void)
 {
     /* intentionally empty */

--- a/drivers/nrf_radio_802154/src/nrf_802154_trx_ppi.c
+++ b/drivers/nrf_radio_802154/src/nrf_802154_trx_ppi.c
@@ -43,6 +43,8 @@
 #include "hal/nrf_radio.h"
 #include "hal/nrf_timer.h"
 
+#include "fem/nrf_fem_protocol_api.h"
+
 #define EGU_EVENT                  NRF_EGU_EVENT_TRIGGERED15
 #define EGU_TASK                   NRF_EGU_TASK_TRIGGER15
 


### PR DESCRIPTION
This commit fixes warning in IEEE 802.15.4 nRF Radio Driver
and linker error in debug build of IEEE 802.15.4 nRF Service
Layer.

Signed-off-by: Czeslaw Makarski <Czeslaw.Makarski@nordicsemi.no>