### PR TITLE
drivers: nrf_802154_sl_opensource: Restore hp_timer 32-bit width

### DIFF
--- a/drivers/nrf_802154_sl_opensource/src/platform/hp_timer/nrf_802154_hp_timer.c
+++ b/drivers/nrf_802154_sl_opensource/src/platform/hp_timer/nrf_802154_hp_timer.c
@@ -88,7 +88,9 @@ void nrf_802154_hp_timer_deinit(void)
 
 void nrf_802154_hp_timer_start(void)
 {
-    // Intentionally empty
+    // This resource is shared, so its configuration must be restored before every use
+    // instead of setting in initialization only.
+    nrf_timer_bit_width_set(TIMER, NRF_TIMER_BIT_WIDTH_32);
 }
 
 void nrf_802154_hp_timer_stop(void)


### PR DESCRIPTION
NRF_TIMER0 used in nRF 802.15.4 hp_timer platform example implementation
must be configured to 32-bit width before every use in order for
hp_timer to work correctly.

Signed-off-by: Jedrzej Ciupis <jedrzej.ciupis@nordicsemi.no>