### PR TITLE
drivers: nrfx_spi.c: Set SCK pin in high drive at high SPI frequency

### DIFF
--- a/nrfx/drivers/src/nrfx_spi.c
+++ b/nrfx/drivers/src/nrfx_spi.c
@@ -124,11 +124,21 @@ nrfx_err_t nrfx_spi_init(nrfx_spi_t const *        p_instance,
     {
         nrf_gpio_pin_set(p_config->sck_pin);
     }
+    nrf_gpio_pin_drive_t sck_pin_drive;
+    if (p_config->frequency > SPI_FREQUENCY_FREQUENCY_M4) {
+        // With standard drive : Simulation on a large capacitor load (100nF @ 3V)
+        // show that the rise and fall time [of a GPIO] on the nRF52 is 150ns.
+        // using high drive should not increase current consumption
+        // as it only affects the rise and fall times
+        sck_pin_drive = NRF_GPIO_PIN_H0H1;
+    } else {
+        sck_pin_drive = NRF_GPIO_PIN_S0S1;
+    }
     nrf_gpio_cfg(p_config->sck_pin,
                  NRF_GPIO_PIN_DIR_OUTPUT,
                  NRF_GPIO_PIN_INPUT_CONNECT,
                  NRF_GPIO_PIN_NOPULL,
-                 NRF_GPIO_PIN_S0S1,
+                 sck_pin_drive,
                  NRF_GPIO_PIN_NOSENSE);
     // - MOSI (optional) - output with initial value 0,
     if (p_config->mosi_pin != NRFX_SPI_PIN_NOT_USED)


### PR DESCRIPTION
This PR fixes communication issues with some SPI devices when the SPI frequency is too high for the load capacitor.

Using ADXL372 with Zephyr, I had the error "failed to read ID" at init. I found some answers in this link, the comment I added in the code refers to the answer of a nordic application engineer.
https://devzone.nordicsemi.com/f/nordic-q-a/16691/nrf52832--why-when-using-nrf_drv_spi-with-an-adxl362-i-need-to-set-the-clock-in-high-drive-h0h1#post-id-111090

I suggest this easy fix but maybe the best would be to be able to configure the drive strength from Zephyr, so we can adapt it to each SPI device (according to the load capacitor).
