### PR TITLE
drivers: nrf_radio_802154: Add callout for custom initialization part

### DIFF
--- a/drivers/nrf_radio_802154/src/nrf_802154.c
+++ b/drivers/nrf_radio_802154/src/nrf_802154.c
@@ -842,6 +842,11 @@ uint32_t nrf_802154_time_get(void)
     return nrf_802154_timer_sched_time_get();
 }
 
+__WEAK void nrf_802154_custom_part_of_radio_init(void)
+{
+    // Intentionally empty
+}
+
 __WEAK void nrf_802154_tx_ack_started(const uint8_t * p_data)
 {
     (void)p_data;

--- a/drivers/nrf_radio_802154/src/nrf_802154.h
+++ b/drivers/nrf_radio_802154/src/nrf_802154.h
@@ -72,6 +72,15 @@ void nrf_802154_init(void);
  */
 void nrf_802154_deinit(void);
 
+/**
+ * @brief Perform some additional operations during initialization of the RADIO peripheral.
+ *
+ * By implementing this function the higher layer can provide some additional operations
+ * to be performed at the beginning of each new timeslot. These can in particular be
+ * modifications of RADIO peripheral register values.
+ */
+extern void nrf_802154_custom_part_of_radio_init(void);
+
 #if !NRF_802154_INTERNAL_RADIO_IRQ_HANDLING
 /**
  * @brief Handles the interrupt request from the RADIO peripheral.

--- a/drivers/nrf_radio_802154/src/nrf_802154_trx.c
+++ b/drivers/nrf_radio_802154/src/nrf_802154_trx.c
@@ -444,6 +444,9 @@ void nrf_802154_trx_enable(void)
     // Set channel
     channel_set(nrf_802154_pib_channel_get());
 
+    // Custom initialization operations
+    nrf_802154_custom_part_of_radio_init();
+
     irq_init();
 
     assert(nrf_radio_shorts_get(NRF_RADIO) == SHORTS_IDLE);


### PR DESCRIPTION
This commit introduces nrf_802154_custom_part_of_radio_init callout.
Application can override weak empty implementation to provide some additional
operations to be performed at the beginning of each new timeslot.
In particular, the intention is to enable the injection of special radio
register values during such initialization.
