### PR TITLE
nrfx_glue: Reserve PPI/DPPI channels and groups used by 802.15.4 driver

### DIFF
--- a/drivers/nrf_radio_802154/CMakeLists.txt
+++ b/drivers/nrf_radio_802154/CMakeLists.txt
@@ -103,3 +103,9 @@ else()
     NRF_802154_IFS_ENABLED=1
   )
 endif()
+
+if (CONFIG_MPSL)
+  zephyr_compile_definitions(
+    NRF_802154_VERIFY_PERIPHS_ALLOC_AGAINST_MPSL=1
+  )
+endif()

--- a/drivers/nrf_radio_802154/nrf_802154_driver_sources.cmake
+++ b/drivers/nrf_radio_802154/nrf_802154_driver_sources.cmake
@@ -8,6 +8,7 @@ set(NRF_802154_DRIVER_SOURCES_COMMON
   ${NRF_802154_DRIVER_ROOT}/src/nrf_802154_debug.c
   ${NRF_802154_DRIVER_ROOT}/src/nrf_802154_debug_assert.c
   ${NRF_802154_DRIVER_ROOT}/src/nrf_802154_pib.c
+  ${NRF_802154_DRIVER_ROOT}/src/nrf_802154_peripherals_alloc.c
   ${NRF_802154_DRIVER_ROOT}/src/nrf_802154_queue.c
   ${NRF_802154_DRIVER_ROOT}/src/nrf_802154_rssi.c
   ${NRF_802154_DRIVER_ROOT}/src/nrf_802154_rx_buffer.c

--- a/drivers/nrf_radio_802154/src/nrf_802154_peripherals_alloc.c
+++ b/drivers/nrf_radio_802154/src/nrf_802154_peripherals_alloc.c
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2017 - 2021, Nordic Semiconductor ASA
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY, AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file supplies bitmasks specifying which of the peripherals are used
+ *   by the 802.15.4 driver.
+ *
+ * Bitmasks currently provided applies to:
+ *   - PPI or DPPI channels (g_nrf_802154_used_nrf_ppi_channels)
+ *   - PPI or DPPI channel groups (g_nrf_802154_used_nrf_ppi_groups)
+ */
+
+#include "nrf_802154_peripherals.h"
+
+#include <stdint.h>
+
+#if NRF_802154_VERIFY_PERIPHS_ALLOC_AGAINST_MPSL
+/* Obtaining the MPSL_RESERVED_.. macros */
+#include "mpsl.h"
+#endif
+
+#if defined(NRF52_SERIES)
+#define NRF_802154_PPI_CH_USED_MSK NRF_802154_PPI_CHANNELS_USED_MASK
+#define NRF_802154_PPI_GR_USED_MSK NRF_802154_PPI_GROUPS_USED_MASK
+#elif defined(NRF53_SERIES)
+#define NRF_802154_PPI_CH_USED_MSK NRF_802154_DPPI_CHANNELS_USED_MASK
+#define NRF_802154_PPI_GR_USED_MSK NRF_802154_DPPI_GROUPS_USED_MASK
+#else
+#error Unsupported chip family
+#endif
+
+const uint32_t g_nrf_802154_used_nrf_ppi_channels = NRF_802154_PPI_CH_USED_MSK;
+const uint32_t g_nrf_802154_used_nrf_ppi_groups   = NRF_802154_PPI_GR_USED_MSK;
+
+#if NRF_802154_VERIFY_PERIPHS_ALLOC_AGAINST_MPSL
+
+#if ((NRF_802154_PPI_CH_USED_MSK & MPSL_RESERVED_PPI_CHANNELS) != 0UL)
+#error PPI channels for 802.15.4 driver overlap with MPSL channels
+#endif
+
+#if ((NRF_802154_PPI_GR_USED_MSK & MPSL_RESERVED_PPI_GROUPS) != 0UL)
+#error PPI groups for 802.15.4 driver overlap with MPSL groups
+#endif
+
+#endif // NRF_802154_VERIFY_PERIPHS_ALLOC_AGAINST_MPSL

--- a/drivers/nrf_radio_802154/src/nrf_802154_peripherals_nrf53.h
+++ b/drivers/nrf_radio_802154/src/nrf_802154_peripherals_nrf53.h
@@ -158,6 +158,28 @@ extern "C" {
 #define NRF_802154_DPPI_RADIO_SYNC_TO_EGU_SYNC 8U
 #endif
 
+/**
+ * @def NRF_802154_DPPI_CHANNELS_USED_MASK
+ *
+ * Bit mask of DPPI channels used by the 802.15.4 driver.
+ */
+#ifndef NRF_802154_DPPI_CHANNELS_USED_MASK
+#define NRF_802154_DPPI_CHANNELS_USED_MASK (                   \
+        (1UL << NRF_802154_DPPI_RADIO_DISABLED_TO_EGU) |       \
+        (1UL << NRF_802154_DPPI_EGU_TO_RADIO_RAMP_UP) |        \
+        (1UL << NRF_802154_DPPI_TIMER_COMPARE_TO_RADIO_TXEN) | \
+        (1UL << NRF_802154_DPPI_RADIO_SYNC_TO_EGU_SYNC))
+#endif // NRF_802154_DPPI_CHANNELS_USED_MASK
+
+/**
+ * @def NRF_802154_DPPI_GROUPS_USED_MASK
+ *
+ * Bit mask of DPPI groups identifiers used by the 802.15.4 driver.
+ */
+#ifndef NRF_802154_DPPI_GROUPS_USED_MASK
+#define NRF_802154_DPPI_GROUPS_USED_MASK 0UL
+#endif // NRF_802154_DPPI_GROUPS_USED_MASK
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Provides bit masks which are intended for use in the nrfx_glue.h
to mark the (D)PPI channels used by the 802.15.4 driver as occupied
and thus unavailable for allocation through nrfx_ppi.

Verification if resources used by the 802.15.4 driver do not overlap
with those used by the mpsl (if mpsl enabled).

Signed-off-by: Adam Zelik <adam.zelik@nordicsemi.no>