### PR TITLE
drivers: Add CMake file list variables for IEEE 802.15.4

### DIFF
--- a/drivers/nrf_802154_sl_opensource/CMakeLists.txt
+++ b/drivers/nrf_802154_sl_opensource/CMakeLists.txt
@@ -1,26 +1,17 @@
+set(NRF_802154_SL_ROOT ${CMAKE_CURRENT_SOURCE_DIR})
+
+include(nrf_802154_sl_files.cmake)
+
 if (CONFIG_NRF_802154_SL_OPENSOURCE)
-  zephyr_include_directories(include)
+  zephyr_include_directories(${NRF_802154_SL_OPENSOURCE_INCLUDE_DIRS})
   zephyr_library_sources(
-    src/nrf_802154_sl_ant_div.c
-    src/nrf_802154_sl_coex.c
-    src/nrf_802154_sl_fem.c
-    src/nrf_802154_sl_log.c
-    src/nrf_802154_sl_rsch.c
-    src/nrf_802154_sl_timer.c
-    )
+    ${NRF_802154_SL_OPENSOURCE_SOURCES}
+  )
 
 else()
+  zephyr_include_directories(${NRF_802154_SL_INCLUDE_DIRS})
   zephyr_library_sources(
-    src/platform/gpiote/nrf_802154_gpiote_zephyr.c
-    src/platform/gpiote/nrf_802154_gpiote_crit_sect.c
-    src/platform/hp_timer/nrf_802154_hp_timer.c
-    src/platform/lp_timer/nrf_802154_lp_timer.c
+    ${NRF_802154_SL_SOURCES}
   )
 
 endif()
-
-zephyr_include_directories(src)
-zephyr_library_sources(
-  src/platform/clock/nrf_802154_clock_zephyr.c
-  src/platform/irq/nrf_802154_irq_zephyr.c
-)

--- a/drivers/nrf_802154_sl_opensource/nrf_802154_sl_files.cmake
+++ b/drivers/nrf_802154_sl_opensource/nrf_802154_sl_files.cmake
@@ -1,0 +1,28 @@
+set(NRF_802154_SL_OPENSOURCE_SOURCES
+  ${NRF_802154_SL_ROOT}/src/nrf_802154_sl_ant_div.c
+  ${NRF_802154_SL_ROOT}/src/nrf_802154_sl_coex.c
+  ${NRF_802154_SL_ROOT}/src/nrf_802154_sl_fem.c
+  ${NRF_802154_SL_ROOT}/src/nrf_802154_sl_log.c
+  ${NRF_802154_SL_ROOT}/src/nrf_802154_sl_rsch.c
+  ${NRF_802154_SL_ROOT}/src/nrf_802154_sl_timer.c
+  ${NRF_802154_SL_ROOT}/src/platform/clock/nrf_802154_clock_zephyr.c
+  ${NRF_802154_SL_ROOT}/src/platform/irq/nrf_802154_irq_zephyr.c
+)
+
+set(NRF_802154_SL_OPENSOURCE_INCLUDE_DIRS
+  ${NRF_802154_SL_ROOT}/include
+  ${NRF_802154_SL_ROOT}/src
+)
+
+set(NRF_802154_SL_SOURCES
+  ${NRF_802154_SL_ROOT}/src/platform/gpiote/nrf_802154_gpiote_zephyr.c
+  ${NRF_802154_SL_ROOT}/src/platform/gpiote/nrf_802154_gpiote_crit_sect.c
+  ${NRF_802154_SL_ROOT}/src/platform/hp_timer/nrf_802154_hp_timer.c
+  ${NRF_802154_SL_ROOT}/src/platform/lp_timer/nrf_802154_lp_timer.c
+  ${NRF_802154_SL_ROOT}/src/platform/clock/nrf_802154_clock_zephyr.c
+  ${NRF_802154_SL_ROOT}/src/platform/irq/nrf_802154_irq_zephyr.c
+)
+
+set(NRF_802154_SL_INCLUDE_DIRS
+  ${NRF_802154_SL_ROOT}/src
+)

--- a/drivers/nrf_radio_802154/CMakeLists.txt
+++ b/drivers/nrf_radio_802154/CMakeLists.txt
@@ -1,40 +1,16 @@
-zephyr_include_directories(src)
+set(NRF_802154_DRIVER_ROOT ${CMAKE_CURRENT_SOURCE_DIR})
 
-zephyr_library_sources(
-  src/nrf_802154.c
-  src/nrf_802154_core.c
-  src/nrf_802154_core_hooks.c
-  src/nrf_802154_critical_section.c
-  src/nrf_802154_debug.c
-  src/nrf_802154_debug_assert.c
-  src/nrf_802154_pib.c
-  src/nrf_802154_queue.c
-  src/nrf_802154_rssi.c
-  src/nrf_802154_rx_buffer.c
-  src/nrf_802154_stats.c
-  src/nrf_802154_swi.c
-  src/nrf_802154_trx.c
-  src/mac_features/nrf_802154_csma_ca.c
-  src/mac_features/nrf_802154_delayed_trx.c
-  src/mac_features/nrf_802154_filter.c
-  src/mac_features/nrf_802154_frame_parser.c
-  src/mac_features/nrf_802154_ifs.c
-  src/mac_features/nrf_802154_precise_ack_timeout.c
-  src/mac_features/ack_generator/nrf_802154_ack_data.c
-  src/mac_features/ack_generator/nrf_802154_ack_generator.c
-  src/mac_features/ack_generator/nrf_802154_enh_ack_generator.c
-  src/mac_features/ack_generator/nrf_802154_imm_ack_generator.c
-  src/platform/random/nrf_802154_random_zephyr.c
-  src/platform/temperature/nrf_802154_temperature_none.c
-  )
+include(nrf_802154_driver_sources.cmake)
+
+zephyr_include_directories(${NRF_802154_DRIVER_INCLUDE_DIRS})
 
 if (CONFIG_SOC_SERIES_NRF52X)
 zephyr_library_sources(
-  src/nrf_802154_trx_ppi.c
+  ${NRF_802154_DRIVER_SOURCES_NRF52}
   )
 elseif (CONFIG_SOC_SERIES_NRF53X)
 zephyr_library_sources(
-  src/nrf_802154_trx_dppi.c
+  ${NRF_802154_DRIVER_SOURCES_NRF53}
   )
 else()
     message(FATAL_ERROR "SoC unsupported by this module")
@@ -42,15 +18,12 @@ endif()
 
 if (CONFIG_NRF_802154_SL_OPENSOURCE)
 zephyr_library_sources(
-  src/nrf_802154_notification_direct.c
-  src/nrf_802154_request_direct.c
+  ${NRF_802154_DRIVER_SOURCES_DIRECT}
   )
 
 else()
 zephyr_library_sources(
-  src/nrf_802154_notification_swi.c
-  src/nrf_802154_priority_drop_swi.c
-  src/nrf_802154_request_swi.c
+  ${NRF_802154_DRIVER_SOURCES_SWI}
   )
 
 endif()

--- a/drivers/nrf_radio_802154/nrf_802154_driver_sources.cmake
+++ b/drivers/nrf_radio_802154/nrf_802154_driver_sources.cmake
@@ -1,0 +1,50 @@
+set(NRF_802154_DRIVER_INCLUDE_DIRS ${NRF_802154_DRIVER_ROOT}/src)
+
+set(NRF_802154_DRIVER_SOURCES_COMMON
+  ${NRF_802154_DRIVER_ROOT}/src/nrf_802154.c
+  ${NRF_802154_DRIVER_ROOT}/src/nrf_802154_core.c
+  ${NRF_802154_DRIVER_ROOT}/src/nrf_802154_core_hooks.c
+  ${NRF_802154_DRIVER_ROOT}/src/nrf_802154_critical_section.c
+  ${NRF_802154_DRIVER_ROOT}/src/nrf_802154_debug.c
+  ${NRF_802154_DRIVER_ROOT}/src/nrf_802154_debug_assert.c
+  ${NRF_802154_DRIVER_ROOT}/src/nrf_802154_pib.c
+  ${NRF_802154_DRIVER_ROOT}/src/nrf_802154_queue.c
+  ${NRF_802154_DRIVER_ROOT}/src/nrf_802154_rssi.c
+  ${NRF_802154_DRIVER_ROOT}/src/nrf_802154_rx_buffer.c
+  ${NRF_802154_DRIVER_ROOT}/src/nrf_802154_stats.c
+  ${NRF_802154_DRIVER_ROOT}/src/nrf_802154_swi.c
+  ${NRF_802154_DRIVER_ROOT}/src/nrf_802154_trx.c
+  ${NRF_802154_DRIVER_ROOT}/src/mac_features/nrf_802154_csma_ca.c
+  ${NRF_802154_DRIVER_ROOT}/src/mac_features/nrf_802154_delayed_trx.c
+  ${NRF_802154_DRIVER_ROOT}/src/mac_features/nrf_802154_filter.c
+  ${NRF_802154_DRIVER_ROOT}/src/mac_features/nrf_802154_frame_parser.c
+  ${NRF_802154_DRIVER_ROOT}/src/mac_features/nrf_802154_ifs.c
+  ${NRF_802154_DRIVER_ROOT}/src/mac_features/nrf_802154_precise_ack_timeout.c
+  ${NRF_802154_DRIVER_ROOT}/src/mac_features/ack_generator/nrf_802154_ack_data.c
+  ${NRF_802154_DRIVER_ROOT}/src/mac_features/ack_generator/nrf_802154_ack_generator.c
+  ${NRF_802154_DRIVER_ROOT}/src/mac_features/ack_generator/nrf_802154_enh_ack_generator.c
+  ${NRF_802154_DRIVER_ROOT}/src/mac_features/ack_generator/nrf_802154_imm_ack_generator.c
+  ${NRF_802154_DRIVER_ROOT}/src/platform/random/nrf_802154_random_zephyr.c
+  ${NRF_802154_DRIVER_ROOT}/src/platform/temperature/nrf_802154_temperature_none.c
+  )
+
+set(NRF_802154_DRIVER_SOURCES_NRF52
+  ${NRF_802154_DRIVER_SOURCES_COMMON}
+  ${NRF_802154_DRIVER_ROOT}/src/nrf_802154_trx_ppi.c
+  )
+
+set(NRF_802154_DRIVER_SOURCES_NRF53
+  ${NRF_802154_DRIVER_SOURCES_COMMON}
+  ${NRF_802154_DRIVER_ROOT}/src/nrf_802154_trx_dppi.c
+  )
+
+set(NRF_802154_DRIVER_SOURCES_DIRECT
+  ${NRF_802154_DRIVER_ROOT}/src/nrf_802154_notification_direct.c
+  ${NRF_802154_DRIVER_ROOT}/src/nrf_802154_request_direct.c
+  )
+
+set(NRF_802154_DRIVER_SOURCES_SWI
+  ${NRF_802154_DRIVER_ROOT}/src/nrf_802154_notification_swi.c
+  ${NRF_802154_DRIVER_ROOT}/src/nrf_802154_priority_drop_swi.c
+  ${NRF_802154_DRIVER_ROOT}/src/nrf_802154_request_swi.c
+  )


### PR DESCRIPTION
This commit introduces file list variables providing an abstraction for
files required for IEEE 802.15.4 driver to be built.

The variables are meant to be used by a higher project layer. Introduction
of this variables in current form is an intermediate step for moving IEEE 802.15.4
driver to a separate repository.

Signed-off-by: Pawel Kwiek <pawel.kwiek@nordicsemi.no>