### PR TITLE
drivers: nrf_802514_serialization: Fix unused function warning

### DIFF
--- a/drivers/nrf_802154_serialization/src/platform/zephyr/nrf_802154_spinel_backend_ipc.c
+++ b/drivers/nrf_802154_serialization/src/platform/zephyr/nrf_802154_spinel_backend_ipc.c
@@ -20,11 +20,6 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 static K_SEM_DEFINE(ready_sem, 0, 1);
 static int endpoint_id;
 
-static bool endpoint_is_bound(void)
-{
-	return rpmsg_service_endpoint_is_bound(endpoint_id);
-}
-
 static int endpoint_cb(struct rpmsg_endpoint *ept,
 		       void                  *data,
 		       size_t                 len,
@@ -44,7 +39,7 @@ static int endpoint_cb(struct rpmsg_endpoint *ept,
 nrf_802154_ser_err_t nrf_802154_backend_init(void)
 {
 #if IPC_MASTER
-	while (!endpoint_is_bound()) {
+	while (!rpmsg_service_endpoint_is_bound(endpoint_id)) {
 		k_sleep(K_MSEC(1));
 	}
 #endif


### PR DESCRIPTION
This commit removes an unused function and fixes related warning.

Signed-off-by: Jedrzej Ciupis <jedrzej.ciupis@nordicsemi.no>