### PR TITLE
build: Fix long path build problem on Windows

### DIFF
--- a/drivers/nrf_802154_serialization/CMakeLists.txt
+++ b/drivers/nrf_802154_serialization/CMakeLists.txt
@@ -28,7 +28,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-zephyr_library()
+zephyr_library_named(nrf_802154_ser)
 
 zephyr_library_sources(
     spinel_base/spinel.c


### PR DESCRIPTION
The paths to nrf_802154_serialization could have previously
exceeded the Windows limit on the path name, causing the build
to fail.

The zephyr_library() autogenerate library names, which may result
in very long build paths. Naming the library manually works around
this problem.

Signed-off-by: Rafał Kuźnia <rafal.kuznia@nordicsemi.no>