### PR TITLE
drivers: nrfx_twis: adding user-defined context to be used in callbacks

### DIFF
--- a/nrfx/drivers/include/nrfx_twis.h
+++ b/nrfx/drivers/include/nrfx_twis.h
@@ -118,7 +118,8 @@ typedef enum
 /** @brief TWIS driver event structure. */
 typedef struct
 {
-    nrfx_twis_evt_type_t type; ///< Event type.
+    nrfx_twis_evt_type_t type;    ///< Event type.
+    void *               context; ///< User defined context.
     union
     {
         bool buf_req;       ///< Flag for @ref NRFX_TWIS_EVT_READ_REQ and @ref NRFX_TWIS_EVT_WRITE_REQ.
@@ -192,6 +193,33 @@ typedef struct
 nrfx_err_t nrfx_twis_init(nrfx_twis_t const *        p_instance,
                           nrfx_twis_config_t const * p_config,
                           nrfx_twis_event_handler_t  event_handler);
+
+/**
+ * @brief Function for initializing the TWIS driver instance with a context.
+ *
+ * Function initializes and enables the TWIS driver with a custom context that
+ * will the passed to callback functions.
+ * @attention After driver initialization enable it with @ref nrfx_twis_enable.
+ *
+ * @param[in] p_instance    Pointer to the driver instance structure.
+ * @attention               @em p_instance has to be global object.
+ *                          It will be used by interrupts so make it sure that object
+ *                          is not destroyed when function is leaving.
+ * @param[in] p_config      Pointer to the structure with the initial configuration.
+ * @param[in] event_handler Event handler provided by the user.
+ * @param[in] context       Custom context provided by the user.
+ *
+ * @retval NRFX_SUCCESS             Initialization is successful.
+ * @retval NRFX_ERROR_INVALID_STATE The driver is already initialized.
+ * @retval NRFX_ERROR_BUSY          Some other peripheral with the same
+ *                                  instance ID is already in use. This is
+ *                                  possible only if NRFX_PRS_ENABLED
+ *                                  is set to a value other than zero.
+ */
+nrfx_err_t nrfx_twis_init_with_ctx(nrfx_twis_t const *        p_instance,
+                                   nrfx_twis_config_t const * p_config,
+                                   nrfx_twis_event_handler_t  event_handler,
+                                   void *                     context);
 
 /**
  * @brief Function for uninitializing the TWIS driver instance.


### PR DESCRIPTION
The callback called each time there is an event in the twis module is not context-aware as it is impossible to give it any contextual data.

When this module is used with Zephyr (even if not officially supported), this is an issue as it is impossible to get
back the pointer to the device structure corresponding to the device which fired the event.

If only 1 twis module is used, it is not an issue as we can define a static variable that can be directly called in the event handler.

However, if multiple driver instances are defined, it becomes impossible to know which instance fired the event.

The changes are meant to be backward compatible as it does not change any function or ```typedef``` definition

This commit allows to write such driver, like for example:
```c
static int init_twis(const struct device *dev)
{
	struct itl_i2c_nrfx_twis_data *dev_data = dev->data;
	const struct itl_i2c_nrfx_twis_config *config = dev->config;

	nrfx_err_t result = nrfx_twis_init_with_ctx(&config->twis,
		&config->config, event_handler, (void *)dev);
	if (result != NRFX_SUCCESS) {
		LOG_ERR("Failed to initialize device: %s",
			dev->name);
		return -ENOTSUP;
	}

	nrfx_twis_enable(&config->twis);
	dev_data->first_write = true;

	return 0;
}
```

and use the context in the event handler:
```c
static void event_handler(nrfx_twis_evt_t const *event)
{
	int err = 0;
	const struct device *dev = event->context;
	struct itl_i2c_nrfx_twis_data *dev_data = dev->data;

	switch (event->type) {
	case NRFX_TWIS_EVT_READ_REQ:
		if (event->data.buf_req) {
			err = slave_read_requested(dev);
		}
		break;
	case NRFX_TWIS_EVT_READ_DONE:
		err = slave_read_processed(dev, event->data.tx_amount);
		break;
	case NRFX_TWIS_EVT_WRITE_REQ:
		if (event->data.buf_req) {
			err = slave_write_requested(dev);
		}
		break;
	case NRFX_TWIS_EVT_WRITE_DONE:
		err = slave_write_received(dev, event->data.rx_amount);
		break;

	case NRFX_TWIS_EVT_READ_ERROR:
	case NRFX_TWIS_EVT_WRITE_ERROR:
	case NRFX_TWIS_EVT_GENERAL_ERROR:
		dev_data->first_write = false;
		break;
	default:
		break;
	}

	/* TODO: error management */
	if (err) {
		LOG_ERR("Error %d for event %d", err, event->type);
	}
}
```