### PR TITLE
mdk: Fix bitfield names in system_nrf53_approtect.h

### DIFF
--- a/nrfx/mdk/system_nrf53_approtect.h
+++ b/nrfx/mdk/system_nrf53_approtect.h
@@ -46,7 +46,7 @@ static inline void nrf53_handle_approtect(void)
     #if defined(NRF_APPLICATION)
         #if defined (ENABLE_APPROTECT)
             /* Prevent processor from unlocking APPROTECT soft branch after this point. */
-            NRF_CTRLAP_S->APPROTECT.LOCK = NRF_CTRLAP_S_APPROTECT_LOCK_LOCK_Locked;
+            NRF_CTRLAP_S->APPROTECT.LOCK = CTRLAPPERI_APPROTECT_LOCK_LOCK_Locked;
 
         #elif  defined (ENABLE_APPROTECT_USER_HANDLING)
                 /* Do nothing, allow user code to handle APPROTECT. Use this if you want to enable authenticated debug. */
@@ -60,7 +60,7 @@ static inline void nrf53_handle_approtect(void)
         /* Secure APPROTECT is only available for Application core. */
         #if defined (ENABLE_SECURE_APPROTECT)
             /* Prevent processor from unlocking SECURE APPROTECT soft branch after this point. */
-            NRF_CTRLAP_S->SECUREAPPROTECT.LOCK = NRF_CTRLAP_S_SECUREAPPROTECT_LOCK_LOCK_Locked;
+            NRF_CTRLAP_S->SECUREAPPROTECT.LOCK = CTRLAPPERI_SECUREAPPROTECT_LOCK_LOCK_Locked;
 
         #elif  defined (ENABLE_SECURE_APPROTECT_USER_HANDLING)
                 /* Do nothing, allow user code to handle SECURE APPROTECT. Use this if you want to enable authenticated debug. */
@@ -74,7 +74,7 @@ static inline void nrf53_handle_approtect(void)
     #if defined(NRF_NETWORK)
         #if defined (ENABLE_APPROTECT)
             /* Prevent processor from unlocking APPROTECT soft branch after this point. */
-            NRF_CTRLAP_NS->APPROTECT.LOCK = NRF_CTRLAP_NS_APPROTECT_LOCK_LOCK_Locked;
+            NRF_CTRLAP_NS->APPROTECT.LOCK = CTRLAPPERI_APPROTECT_LOCK_LOCK_Locked;
 
         #elif  defined (ENABLE_APPROTECT_USER_HANDLING)
                 /* Do nothing, allow user code to handle APPROTECT. Use this if you want to enable authenticated debug. */


### PR DESCRIPTION
This is a temporary change in a file imported from the nrfx repository
and it is supposed to be overwritten by the next update of nrfx.

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>