### PR TITLE
mdk: fix DPPI_CH_NUM to 32 for nRF5340 Network

### DIFF
--- a/nrfx/mdk/nrf5340_network_peripherals.h
+++ b/nrfx/mdk/nrf5340_network_peripherals.h
@@ -115,7 +115,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #define DPPI_PRESENT
 #define DPPI_COUNT 1
 
-#define DPPI_CH_NUM 16
+#define DPPI_CH_NUM 32
 #define DPPI_GROUP_NUM 6
 
 /* Event Generator Unit */


### PR DESCRIPTION
This is a temporary change in a file imported from the nrfx repository
and it is supposed to be overwritten by the next update of nrfx.

Signed-off-by: Nikodem Kastelik <nikodem.kastelik@nordicsemi.no>