### PR TITLE
CMakeLists.txt: Add nrf51 MDK defines needed to apply nrf51 erratas

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,9 @@ if(CONFIG_HAS_NRFX)
 
   # Define MDK defines globally
   zephyr_compile_definitions_ifdef(CONFIG_SOC_SERIES_NRF51X       NRF51)
+  zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF51822_QFAA       NRF51422_XXAA)
+  zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF51822_QFAB       NRF51422_XXAB)
+  zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF51822_QFAC       NRF51422_XXAC)
   zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF52805            NRF52805_XXAA)
   zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF52810            NRF52810_XXAA)
   zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF52811            NRF52811_XXAA)


### PR DESCRIPTION
Add nrf51 MDK defines needed to correctly select the nrf51 needes on
the specific SoCs. The nrf51_erratas.h header file only uses these
defines to check which erratas should be applied.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>