### PR TITLE
drivers: nrfx_usbreg: clear events on initialization

### DIFF
--- a/nrfx/drivers/src/nrfx_usbreg.c
+++ b/nrfx/drivers/src/nrfx_usbreg.c
@@ -51,6 +51,9 @@ void nrfx_usbreg_init(nrfx_usbreg_config_t const * p_config)
 
     nrfx_usbreg_uninit();
     m_usbevt_handler = p_config->handler;
+    nrf_usbreg_event_clear(NRF_USBREGULATOR, NRF_USBREG_EVENT_USBDETECTED);
+    nrf_usbreg_event_clear(NRF_USBREGULATOR, NRF_USBREG_EVENT_USBPWRRDY);
+    nrf_usbreg_event_clear(NRF_USBREGULATOR, NRF_USBREG_EVENT_USBREMOVED);
 
     NRFX_IRQ_PRIORITY_SET(nrfx_get_irq_number(NRF_USBREGULATOR), p_config->irq_priority);
     NRFX_IRQ_ENABLE(nrfx_get_irq_number(NRF_USBREGULATOR));


### PR DESCRIPTION
Clear USBREG events on driver initialization and
prevent spurious USBPWRRDY event right after initialization.