### PR TITLE
drivers: nrf_802154: nrf_802154_irq_init negative `prio` ZLI

### DIFF
--- a/drivers/nrf_802154/sl/include/platform/nrf_802154_irq.h
+++ b/drivers/nrf_802154/sl/include/platform/nrf_802154_irq.h
@@ -79,8 +79,11 @@ typedef void (* nrf_802154_isr_t)();
  * @param[in] irqn  IRQ line number.
  * @param[in] prio  Priority of the IRQ.
  * @param[in] isr   Pointer to ISR.
+ *
+ * @note Interpretation of the value represented by @p prio is platform-dependent and defined by
+ *       the implementation.
  */
-void nrf_802154_irq_init(uint32_t irqn, uint32_t prio, nrf_802154_isr_t isr);
+void nrf_802154_irq_init(uint32_t irqn, int32_t prio, nrf_802154_isr_t isr);
 
 /**
  * @brief Enables an interrupt.


### PR DESCRIPTION
This commit changes public API of `nrf_802154_irq_init` to allows
passing negative values of `prio` parameter. Negative values will
be used to encode ZLI priority.

Signed-off-by: Andrzej Kuros <andrzej.kuros@nordicsemi.no>