### PR TITLE
nrfx: Update to version 2.8.0

### DIFF
--- a/nrfx/CHANGELOG.md
+++ b/nrfx/CHANGELOG.md
@@ -1,6 +1,22 @@
 # Changelog
 All notable changes to this project are documented in this file.
 
+## [2.8.0] - 2022-04-05
+### Added
+- Added function for getting the currently configured channels in the SAADC driver.
+- Added callback for the RXFRAMESTART event in the NFCT driver.
+- Added function for transmitting the NFC frame with specified number of bits in the NFCT driver.
+- Added functions for getting and setting SEL_RES auto response configuration in the NFCT HAL.
+
+### Changed
+- Refactored calibration procedure in the SAADC driver, so it retains previously configured mode.
+- Improved management of low frequency clock source during initialization in the CLOCK driver. Compatible source that already runs or is starting during initialization is now used without reconfiguration.
+- Improved software-managed triggering of the START task on an END event in the SAADC driver.
+
+### Fixed
+- Fixed event processing order in the SAADC driver. Previously, incorrect buffer might have been filled when double-buffered sampling was used with END event and START task being connected through (D)PPI.
+- Fixed the limits feature that could be spuriously triggered during calibration procedure in the SAADC driver.
+
 ## [2.7.0] - 2021-12-16
 ### Added
 - Added new fields in the driver configuration structures to allow skipping GPIO and/or PSEL register configuration. Affected drivers: I2S, PDM, PWM, QDEC, QSPI, SPI, SPIM, SPIS, TWI, TWIM, TWIS, UART, UARTE.

--- a/nrfx/README
+++ b/nrfx/README
@@ -2,10 +2,10 @@ nrfx
 ####
 
 Origin:
-   https://github.com/NordicSemiconductor/nrfx/tree/v2.7.0
+   https://github.com/NordicSemiconductor/nrfx/tree/v2.8.0
 
 Status:
-   v2.7.0
+   v2.8.0
 
 Purpose:
    With added proper shims adapting it to Zephyr's APIs, nrfx will provide
@@ -32,7 +32,7 @@ URL:
    https://github.com/NordicSemiconductor/nrfx
 
 commit:
-   3521c97df0b9549daecf867fb588f62819c317b4
+   55305292a2a8e4149869951451311452f4566e9a
 
 Maintained-by:
    External
@@ -41,4 +41,4 @@ License:
    BSD-3-Clause
 
 License Link:
-   https://github.com/NordicSemiconductor/nrfx/blob/v2.7.0/LICENSE
+   https://github.com/NordicSemiconductor/nrfx/blob/v2.8.0/LICENSE

--- a/nrfx/doc/nrfx.doxyfile
+++ b/nrfx/doc/nrfx.doxyfile
@@ -40,7 +40,7 @@ PROJECT_NAME           = "nrfx"
 
 ### EDIT THIS ###
 
-PROJECT_NUMBER         = "2.7"
+PROJECT_NUMBER         = "2.8"
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/nrfx/doc/sphinx/nrfx_api/atomic.rst
+++ b/nrfx/doc/sphinx/nrfx_api/atomic.rst
@@ -1,0 +1,6 @@
+Atomic operations API
+=====================
+
+.. doxygengroup:: nrfx_atomic
+   :project: nrfx
+   :members:

--- a/nrfx/drivers/include/nrf_bitmask.h
+++ b/nrfx/drivers/include/nrf_bitmask.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2016 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/drivers/include/nrfx_adc.h
+++ b/nrfx/drivers/include/nrfx_adc.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2015 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/drivers/include/nrfx_clock.h
+++ b/nrfx/drivers/include/nrfx_clock.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2016 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/drivers/include/nrfx_comp.h
+++ b/nrfx/drivers/include/nrfx_comp.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2015 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/drivers/include/nrfx_dppi.h
+++ b/nrfx/drivers/include/nrfx_dppi.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2018 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/drivers/include/nrfx_egu.h
+++ b/nrfx/drivers/include/nrfx_egu.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2019 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/drivers/include/nrfx_gpiote.h
+++ b/nrfx/drivers/include/nrfx_gpiote.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2015 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/drivers/include/nrfx_i2s.h
+++ b/nrfx/drivers/include/nrfx_i2s.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2015 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/drivers/include/nrfx_ipc.h
+++ b/nrfx/drivers/include/nrfx_ipc.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2019 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/drivers/include/nrfx_lpcomp.h
+++ b/nrfx/drivers/include/nrfx_lpcomp.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2014 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/drivers/include/nrfx_nfct.h
+++ b/nrfx/drivers/include/nrfx_nfct.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2018 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
@@ -238,6 +238,20 @@ void nrfx_nfct_rx(nrfx_nfct_data_desc_t const * p_rx_data);
  */
 nrfx_err_t nrfx_nfct_tx(nrfx_nfct_data_desc_t const * p_tx_data,
                         nrf_nfct_frame_delay_mode_t   delay_mode);
+
+/**
+ * @brief Function for transmitting an NFC frame with a specified number of bits.
+ *
+ * @param[in] p_tx_data   Pointer to the TX buffer. Unlike in @ref nrfx_nfct_tx, @p data_size is
+ *                        used as the number of bits to transmit, rather than bytes.
+ * @param[in] delay_mode  Delay mode of the NFCT frame timer.
+ *
+ * @retval NRFX_SUCCESS              The operation was successful.
+ * @retval NRFX_ERROR_INVALID_LENGTH The TX buffer size is invalid.
+ * @retval NRFX_ERROR_BUSY           Driver is already transferring.
+ */
+nrfx_err_t nrfx_nfct_bits_tx(nrfx_nfct_data_desc_t const * p_tx_data,
+                             nrf_nfct_frame_delay_mode_t   delay_mode);
 
 /**
  * @brief Function for moving the NFCT to a new state.

--- a/nrfx/drivers/include/nrfx_nvmc.h
+++ b/nrfx/drivers/include/nrfx_nvmc.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2019 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/drivers/include/nrfx_pdm.h
+++ b/nrfx/drivers/include/nrfx_pdm.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2015 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/drivers/include/nrfx_power.h
+++ b/nrfx/drivers/include/nrfx_power.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/drivers/include/nrfx_power_clock.h
+++ b/nrfx/drivers/include/nrfx_power_clock.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2015 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/drivers/include/nrfx_power_compat.h
+++ b/nrfx/drivers/include/nrfx_power_compat.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2019 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/drivers/include/nrfx_ppi.h
+++ b/nrfx/drivers/include/nrfx_ppi.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2015 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/drivers/include/nrfx_pwm.h
+++ b/nrfx/drivers/include/nrfx_pwm.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2015 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/drivers/include/nrfx_qdec.h
+++ b/nrfx/drivers/include/nrfx_qdec.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2015 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/drivers/include/nrfx_qspi.h
+++ b/nrfx/drivers/include/nrfx_qspi.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2016 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/drivers/include/nrfx_rng.h
+++ b/nrfx/drivers/include/nrfx_rng.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2016 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/drivers/include/nrfx_rtc.h
+++ b/nrfx/drivers/include/nrfx_rtc.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2014 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/drivers/include/nrfx_saadc.h
+++ b/nrfx/drivers/include/nrfx_saadc.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2015 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
@@ -260,7 +260,17 @@ nrfx_err_t nrfx_saadc_channels_config(nrfx_saadc_channel_t const * p_channels,
 nrfx_err_t nrfx_saadc_channel_config(nrfx_saadc_channel_t const * p_channel);
 
 /**
+ * @brief Function for getting the currently configured SAADC channels.
+ *
+ * @return Bitmask of configured channels.
+ */
+uint32_t nrfx_saadc_channels_configured_get(void);
+
+/**
  * @brief Function for deconfiguring the specified SAADC channels.
+ *
+ * @warning Pins associated with the deconfigured channels will be released after
+ *          next @ref nrfx_saadc_simple_mode_set() or @ref nrfx_saadc_advanced_mode_set() call.
  *
  * @param[in] channel_mask Bitmask of channels to be deconfigured.
  *
@@ -351,13 +361,16 @@ nrfx_err_t nrfx_saadc_buffer_set(nrf_saadc_value_t * p_buffer, uint16_t size);
  *                                  Call the function again to continue the conversion.
  * @retval NRFX_ERROR_NO_MEM        There is no buffer provided.
  *                                  Supply the buffer using @ref nrfx_saadc_buffer_set() and try again.
- * @retval NRFX_ERROR_INVALID_STATE There is an ongoing conversion being performed in the non-blocking manner
- *                                  or the driver is in the idle mode.
+ * @retval NRFX_ERROR_INVALID_STATE There is an ongoing conversion or calibration being performed
+ *                                  in the non-blocking manner or the driver is in the idle mode.
  */
 nrfx_err_t nrfx_saadc_mode_trigger(void);
 
 /**
  * @brief Function for aborting the ongoing and buffered conversions.
+ *
+ * @warning Aborting blocking conversion or calibration from different context is not supported.
+ *          Perform the operation in non-blocking manner instead.
  *
  * @note @ref NRFX_SAADC_EVT_DONE event will be generated if there is a conversion in progress.
  *       Event will contain number of words in the sample buffer.
@@ -391,17 +404,14 @@ nrfx_err_t nrfx_saadc_limits_set(uint8_t channel, int16_t limit_low, int16_t lim
 /**
  * @brief Function for starting the SAADC offset calibration.
  *
- * @note This function cancels the currently selected driver operation mode, if any.
- *       The desired mode (simple or advanced) must be set after the calibration process completes.
- *
- * @param[in] event_handler Event handler provided by the user. In case of providing NULL,
- *                          the calibration will be performed in the blocking manner.
+ * @param[in] calib_event_handler Calibration event handler provided by the user. In case of providing NULL,
+ *                                the calibration will be performed in the blocking manner.
  *
  * @retval NRFX_SUCCESS    Calibration finished successfully in the blocking manner
  *                         or started successfully in the non-blocking manner.
  * @retval NRFX_ERROR_BUSY There is a conversion or calibration ongoing.
  */
-nrfx_err_t nrfx_saadc_offset_calibrate(nrfx_saadc_event_handler_t event_handler);
+nrfx_err_t nrfx_saadc_offset_calibrate(nrfx_saadc_event_handler_t calib_event_handler);
 
 /** @} */
 

--- a/nrfx/drivers/include/nrfx_spi.h
+++ b/nrfx/drivers/include/nrfx_spi.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2015 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/drivers/include/nrfx_spim.h
+++ b/nrfx/drivers/include/nrfx_spim.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2015 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/drivers/include/nrfx_spis.h
+++ b/nrfx/drivers/include/nrfx_spis.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2015 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/drivers/include/nrfx_systick.h
+++ b/nrfx/drivers/include/nrfx_systick.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2016 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/drivers/include/nrfx_temp.h
+++ b/nrfx/drivers/include/nrfx_temp.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2019 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/drivers/include/nrfx_timer.h
+++ b/nrfx/drivers/include/nrfx_timer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2015 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/drivers/include/nrfx_twi.h
+++ b/nrfx/drivers/include/nrfx_twi.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2015 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/drivers/include/nrfx_twi_twim.h
+++ b/nrfx/drivers/include/nrfx_twi_twim.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2019 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/drivers/include/nrfx_twim.h
+++ b/nrfx/drivers/include/nrfx_twim.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2015 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/drivers/include/nrfx_twis.h
+++ b/nrfx/drivers/include/nrfx_twis.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2015 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/drivers/include/nrfx_uart.h
+++ b/nrfx/drivers/include/nrfx_uart.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2015 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/drivers/include/nrfx_uarte.h
+++ b/nrfx/drivers/include/nrfx_uarte.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2015 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/drivers/include/nrfx_usbd.h
+++ b/nrfx/drivers/include/nrfx_usbd.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2016 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/drivers/include/nrfx_usbreg.h
+++ b/nrfx/drivers/include/nrfx_usbreg.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2019 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/drivers/include/nrfx_wdt.h
+++ b/nrfx/drivers/include/nrfx_wdt.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2014 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/drivers/nrfx_common.h
+++ b/nrfx/drivers/nrfx_common.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/drivers/nrfx_errors.h
+++ b/nrfx/drivers/nrfx_errors.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/drivers/src/nrfx_adc.c
+++ b/nrfx/drivers/src/nrfx_adc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2015 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/drivers/src/nrfx_comp.c
+++ b/nrfx/drivers/src/nrfx_comp.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2015 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/drivers/src/nrfx_dppi.c
+++ b/nrfx/drivers/src/nrfx_dppi.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2018 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/drivers/src/nrfx_egu.c
+++ b/nrfx/drivers/src/nrfx_egu.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2019 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/drivers/src/nrfx_gpiote.c
+++ b/nrfx/drivers/src/nrfx_gpiote.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2015 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/drivers/src/nrfx_i2s.c
+++ b/nrfx/drivers/src/nrfx_i2s.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2015 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/drivers/src/nrfx_ipc.c
+++ b/nrfx/drivers/src/nrfx_ipc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2019 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/drivers/src/nrfx_lpcomp.c
+++ b/nrfx/drivers/src/nrfx_lpcomp.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2015 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/drivers/src/nrfx_nvmc.c
+++ b/nrfx/drivers/src/nrfx_nvmc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2019 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/drivers/src/nrfx_pdm.c
+++ b/nrfx/drivers/src/nrfx_pdm.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2015 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/drivers/src/nrfx_power.c
+++ b/nrfx/drivers/src/nrfx_power.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/drivers/src/nrfx_ppi.c
+++ b/nrfx/drivers/src/nrfx_ppi.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2015 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/drivers/src/nrfx_pwm.c
+++ b/nrfx/drivers/src/nrfx_pwm.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2015 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/drivers/src/nrfx_qdec.c
+++ b/nrfx/drivers/src/nrfx_qdec.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2015 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/drivers/src/nrfx_qspi.c
+++ b/nrfx/drivers/src/nrfx_qspi.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2016 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/drivers/src/nrfx_rng.c
+++ b/nrfx/drivers/src/nrfx_rng.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2016 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/drivers/src/nrfx_rtc.c
+++ b/nrfx/drivers/src/nrfx_rtc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2014 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/drivers/src/nrfx_spi.c
+++ b/nrfx/drivers/src/nrfx_spi.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2015 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/drivers/src/nrfx_spim.c
+++ b/nrfx/drivers/src/nrfx_spim.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2015 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/drivers/src/nrfx_spis.c
+++ b/nrfx/drivers/src/nrfx_spis.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2013 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/drivers/src/nrfx_systick.c
+++ b/nrfx/drivers/src/nrfx_systick.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2016 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/drivers/src/nrfx_temp.c
+++ b/nrfx/drivers/src/nrfx_temp.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2019 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/drivers/src/nrfx_timer.c
+++ b/nrfx/drivers/src/nrfx_timer.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2015 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/drivers/src/nrfx_twi.c
+++ b/nrfx/drivers/src/nrfx_twi.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2015 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/drivers/src/nrfx_twi_twim.c
+++ b/nrfx/drivers/src/nrfx_twi_twim.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2019 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/drivers/src/nrfx_twim.c
+++ b/nrfx/drivers/src/nrfx_twim.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2015 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/drivers/src/nrfx_twis.c
+++ b/nrfx/drivers/src/nrfx_twis.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2015 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/drivers/src/nrfx_uart.c
+++ b/nrfx/drivers/src/nrfx_uart.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2015 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/drivers/src/nrfx_uarte.c
+++ b/nrfx/drivers/src/nrfx_uarte.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2015 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/drivers/src/nrfx_usbd.c
+++ b/nrfx/drivers/src/nrfx_usbd.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2016 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/drivers/src/nrfx_usbd_errata.h
+++ b/nrfx/drivers/src/nrfx_usbd_errata.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2016 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/drivers/src/nrfx_usbreg.c
+++ b/nrfx/drivers/src/nrfx_usbreg.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2019 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/drivers/src/nrfx_wdt.c
+++ b/nrfx/drivers/src/nrfx_wdt.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2015 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/drivers/src/prs/nrfx_prs.c
+++ b/nrfx/drivers/src/prs/nrfx_prs.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/drivers/src/prs/nrfx_prs.h
+++ b/nrfx/drivers/src/prs/nrfx_prs.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/hal/nrf_aar.h
+++ b/nrfx/hal/nrf_aar.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2019 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/hal/nrf_acl.h
+++ b/nrfx/hal/nrf_acl.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2018 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/hal/nrf_adc.h
+++ b/nrfx/hal/nrf_adc.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2014 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/hal/nrf_bprot.h
+++ b/nrfx/hal/nrf_bprot.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2019 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/hal/nrf_cache.h
+++ b/nrfx/hal/nrf_cache.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2019 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/hal/nrf_ccm.h
+++ b/nrfx/hal/nrf_ccm.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2018 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/hal/nrf_clock.h
+++ b/nrfx/hal/nrf_clock.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2015 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/hal/nrf_common.h
+++ b/nrfx/hal/nrf_common.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2020 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/hal/nrf_comp.h
+++ b/nrfx/hal/nrf_comp.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2015 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/hal/nrf_dcnf.h
+++ b/nrfx/hal/nrf_dcnf.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2019 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/hal/nrf_dppi.h
+++ b/nrfx/hal/nrf_dppi.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2018 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/hal/nrf_ecb.h
+++ b/nrfx/hal/nrf_ecb.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2012 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/hal/nrf_egu.h
+++ b/nrfx/hal/nrf_egu.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2015 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/hal/nrf_ficr.h
+++ b/nrfx/hal/nrf_ficr.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2018 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/hal/nrf_fpu.h
+++ b/nrfx/hal/nrf_fpu.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2019 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/hal/nrf_gpio.h
+++ b/nrfx/hal/nrf_gpio.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2015 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/hal/nrf_gpiote.h
+++ b/nrfx/hal/nrf_gpiote.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2015 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/hal/nrf_i2s.h
+++ b/nrfx/hal/nrf_i2s.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2015 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/hal/nrf_ipc.h
+++ b/nrfx/hal/nrf_ipc.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2019 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/hal/nrf_kmu.h
+++ b/nrfx/hal/nrf_kmu.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2018 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/hal/nrf_lpcomp.h
+++ b/nrfx/hal/nrf_lpcomp.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2014 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/hal/nrf_mpu.h
+++ b/nrfx/hal/nrf_mpu.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2019 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/hal/nrf_mutex.h
+++ b/nrfx/hal/nrf_mutex.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2019 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/hal/nrf_mwu.h
+++ b/nrfx/hal/nrf_mwu.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2019 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/hal/nrf_nfct.h
+++ b/nrfx/hal/nrf_nfct.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2018 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
@@ -247,13 +247,6 @@ typedef enum
     /**< SENS_RES 'Platform Config' field (b7-b6) value for any platform except Type 1 Tag platform. */
     NRF_NFCT_SENSRES_PLATFORM_CONFIG_OTHER = 0 << NFCT_SENSRES_PLATFCONFIG_Pos
 } nrf_nfct_sensres_platform_config_t;
-
-/** @brief Bit masks for SEL_RES NFC frame configuration. */
-typedef enum
-{
-    NRF_NFCT_SELRES_CASCADE_MASK  = NFCT_SELRES_CASCADE_Msk,  /**< SEL_RES Cascade field bit mask. */
-    NRF_NFCT_SELRES_PROTOCOL_MASK = NFCT_SELRES_PROTOCOL_Msk  /**< SEL_RES Protocol field bit mask. */
-} nrf_nfct_selres_t;
 
 /**
  * @brief Protocol NFC field (bits b7 and b6) configuration for the SEL_RES frame according to
@@ -881,6 +874,27 @@ nrf_nfct_selres_protocol_t nrf_nfct_selres_protocol_get(NRF_NFCT_Type const * p_
 NRF_STATIC_INLINE void nrf_nfct_selres_protocol_set(NRF_NFCT_Type *            p_reg,
                                                     nrf_nfct_selres_protocol_t sel_res_protocol);
 
+/**
+ * @brief Function for getting the SEL_RES frame configuration.
+ *
+ * @details The SEL_RES frame is handled automatically by the NFCT hardware.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ *
+ * @return SEL_RES frame configuration.
+ */
+NRF_STATIC_INLINE uint32_t nrf_nfct_selres_get(NRF_NFCT_Type const * p_reg);
+
+/**
+ * @brief Function for setting the SEL_RES frame configuration.
+ *
+ * @details The SEL_RES frame is handled automatically by the NFCT hardware.
+ *
+ * @param[in] p_reg  Pointer to the structure of registers of the peripheral.
+ * @param[in] selres SEL_RES frame configuration.
+ */
+NRF_STATIC_INLINE void nrf_nfct_selres_set(NRF_NFCT_Type * p_reg, uint32_t selres);
+
 #ifndef NRF_DECLARE_ONLY
 NRF_STATIC_INLINE void nrf_nfct_task_trigger(NRF_NFCT_Type * p_reg, nrf_nfct_task_t task)
 {
@@ -1259,6 +1273,16 @@ NRF_STATIC_INLINE void nrf_nfct_selres_protocol_set(NRF_NFCT_Type *            p
 {
     p_reg->SELRES = (p_reg->SELRES & ~NFCT_SELRES_PROTOCOL_Msk) |
                     ((uint32_t)sel_res_protocol << NFCT_SELRES_PROTOCOL_Pos);
+}
+
+NRF_STATIC_INLINE uint32_t nrf_nfct_selres_get(NRF_NFCT_Type const * p_reg)
+{
+    return p_reg->SELRES;
+}
+
+NRF_STATIC_INLINE void nrf_nfct_selres_set(NRF_NFCT_Type * p_reg, uint32_t selres)
+{
+    p_reg->SELRES = (p_reg->SELRES & NFCT_SELRES_CASCADE_Msk) | (selres & ~NFCT_SELRES_CASCADE_Msk);
 }
 #endif /* NRF_DECLARE_ONLY */
 

--- a/nrfx/hal/nrf_nvmc.h
+++ b/nrfx/hal/nrf_nvmc.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2012 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/hal/nrf_oscillators.h
+++ b/nrfx/hal/nrf_oscillators.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2019 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/hal/nrf_pdm.h
+++ b/nrfx/hal/nrf_pdm.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2015 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/hal/nrf_power.h
+++ b/nrfx/hal/nrf_power.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/hal/nrf_ppi.h
+++ b/nrfx/hal/nrf_ppi.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2015 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/hal/nrf_pwm.h
+++ b/nrfx/hal/nrf_pwm.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2015 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/hal/nrf_qdec.h
+++ b/nrfx/hal/nrf_qdec.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2014 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/hal/nrf_qspi.h
+++ b/nrfx/hal/nrf_qspi.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2016 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/hal/nrf_radio.h
+++ b/nrfx/hal/nrf_radio.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2018 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/hal/nrf_regulators.h
+++ b/nrfx/hal/nrf_regulators.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2018 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/hal/nrf_reset.h
+++ b/nrfx/hal/nrf_reset.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2019 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/hal/nrf_rng.h
+++ b/nrfx/hal/nrf_rng.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2014 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/hal/nrf_rtc.h
+++ b/nrfx/hal/nrf_rtc.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2014 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/hal/nrf_saadc.h
+++ b/nrfx/hal/nrf_saadc.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2015 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/hal/nrf_spi.h
+++ b/nrfx/hal/nrf_spi.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2015 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/hal/nrf_spim.h
+++ b/nrfx/hal/nrf_spim.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2015 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/hal/nrf_spis.h
+++ b/nrfx/hal/nrf_spis.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2015 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/hal/nrf_spu.h
+++ b/nrfx/hal/nrf_spu.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2018 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/hal/nrf_systick.h
+++ b/nrfx/hal/nrf_systick.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2016 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/hal/nrf_temp.h
+++ b/nrfx/hal/nrf_temp.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2012 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/hal/nrf_timer.h
+++ b/nrfx/hal/nrf_timer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2014 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/hal/nrf_twi.h
+++ b/nrfx/hal/nrf_twi.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2015 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/hal/nrf_twim.h
+++ b/nrfx/hal/nrf_twim.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2015 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/hal/nrf_twis.h
+++ b/nrfx/hal/nrf_twis.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2015 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/hal/nrf_uart.h
+++ b/nrfx/hal/nrf_uart.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2015 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/hal/nrf_uarte.h
+++ b/nrfx/hal/nrf_uarte.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2015 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/hal/nrf_usbd.h
+++ b/nrfx/hal/nrf_usbd.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/hal/nrf_usbreg.h
+++ b/nrfx/hal/nrf_usbreg.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2019 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/hal/nrf_vmc.h
+++ b/nrfx/hal/nrf_vmc.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2018 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/hal/nrf_vreqctrl.h
+++ b/nrfx/hal/nrf_vreqctrl.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2019 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/hal/nrf_wdt.h
+++ b/nrfx/hal/nrf_wdt.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2015 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/helpers/nrfx_flag32_allocator.c
+++ b/nrfx/helpers/nrfx_flag32_allocator.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2021 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/helpers/nrfx_flag32_allocator.h
+++ b/nrfx/helpers/nrfx_flag32_allocator.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2021 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/helpers/nrfx_gppi.h
+++ b/nrfx/helpers/nrfx_gppi.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2019 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/helpers/nrfx_reset_reason.h
+++ b/nrfx/helpers/nrfx_reset_reason.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2020 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/nrfx.h
+++ b/nrfx/nrfx.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/soc/nrfx_coredep.h
+++ b/nrfx/soc/nrfx_coredep.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2018 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/templates/nrfx_config.h
+++ b/nrfx/templates/nrfx_config.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2019 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/templates/nrfx_config_nrf51.h
+++ b/nrfx/templates/nrfx_config_nrf51.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/templates/nrfx_config_nrf52805.h
+++ b/nrfx/templates/nrfx_config_nrf52805.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2020 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/templates/nrfx_config_nrf52810.h
+++ b/nrfx/templates/nrfx_config_nrf52810.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/templates/nrfx_config_nrf52811.h
+++ b/nrfx/templates/nrfx_config_nrf52811.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2018 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/templates/nrfx_config_nrf52820.h
+++ b/nrfx/templates/nrfx_config_nrf52820.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2020 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/templates/nrfx_config_nrf52832.h
+++ b/nrfx/templates/nrfx_config_nrf52832.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/templates/nrfx_config_nrf52833.h
+++ b/nrfx/templates/nrfx_config_nrf52833.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2019 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/templates/nrfx_config_nrf52840.h
+++ b/nrfx/templates/nrfx_config_nrf52840.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/templates/nrfx_config_nrf5340_application.h
+++ b/nrfx/templates/nrfx_config_nrf5340_application.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2019 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/templates/nrfx_config_nrf5340_network.h
+++ b/nrfx/templates/nrfx_config_nrf5340_network.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2019 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/templates/nrfx_config_nrf9160.h
+++ b/nrfx/templates/nrfx_config_nrf9160.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2018 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/templates/nrfx_glue.h
+++ b/nrfx/templates/nrfx_glue.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrfx/templates/nrfx_log.h
+++ b/nrfx/templates/nrfx_log.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause


### PR DESCRIPTION
Update nrfx to the recently released version. See
https://github.com/NordicSemiconductor/nrfx/blob/v2.8.0/CHANGELOG.md
for a list of changes that this version introduces.

Origin: nrfx
License: BSD 3-Clause
URL: https://github.com/NordicSemiconductor/nrfx/tree/v2.8.0
commit: 55305292a2a8e4149869951451311452f4566e9a
Purpose: Provide peripheral drivers for Nordic SoCs
Maintained-by: External

Signed-off-by: Nikodem Kastelik <nikodem.kastelik@nordicsemi.no>