### PR TITLE
nrfx: doc: remove references to nrfx_atomic Doxygen group

### DIFF
--- a/nrfx/doc/sphinx/nrfx_api/atomic.rst
+++ b/nrfx/doc/sphinx/nrfx_api/atomic.rst
@@ -1,6 +1,0 @@
-Atomic operations API
-=====================
-
-.. doxygengroup:: nrfx_atomic
-   :project: nrfx
-   :members:


### PR DESCRIPTION
Building documentation in .rst format causes warnings due to
missing `nrfx_atomic` which is not used in `hal_nordic`.

Signed-off-by: Nikodem Kastelik <nikodem.kastelik@nordicsemi.no>