### PR TITLE
nrfx_qspi: Correct IO3 line level used in nrfx_qspi_mem_busy_check()

### DIFF
--- a/nrfx/drivers/include/nrfx_qspi.h
+++ b/nrfx/drivers/include/nrfx_qspi.h
@@ -343,6 +343,13 @@ nrfx_err_t nrfx_qspi_mem_busy_check(void);
  * Pointers can be addresses from flash memory.
  * This function is a synchronous function and should be used only if necessary.
  *
+ * @note Please note that the @ref NRFX_QSPI_DEFAULT_CINSTR macro provides default values
+ *       for the @p io2_level and @p io3_level fields that cause the IO2 and IO3 lines
+ *       to be kept low during the custom instruction transfer. Such configuration may not
+ *       be suitable in certain circumstances and memory devices can interpret such levels
+ *       of those lines as active WP# and HOLD#/RESET# signals, respectively. Hence, it is
+ *       safer to use a configuration that will keep the lines high during the transfer.
+ *
  * @param[in]  p_config    Pointer to the structure with opcode and transfer configuration.
  * @param[in]  p_tx_buffer Pointer to the array with data to send. Can be NULL if only opcode is transmitted.
  * @param[out] p_rx_buffer Pointer to the array for data to receive. Can be NULL if there is nothing to receive.
@@ -378,6 +385,13 @@ nrfx_err_t nrfx_qspi_cinstr_quick_send(uint8_t               opcode,
  * The long frame mode is a mechanism that allows for arbitrary byte length custom instructions.
  * Use this function to initiate a custom transaction by sending custom instruction opcode.
  * To send and receive data, use @ref nrfx_qspi_lfm_xfer.
+ *
+ * @note Please note that the @ref NRFX_QSPI_DEFAULT_CINSTR macro provides default values
+ *       for the @p io2_level and @p io3_level fields that cause the IO2 and IO3 lines
+ *       to be kept low during the custom instruction transfer. Such configuration may not
+ *       be suitable in certain circumstances and memory devices can interpret such levels
+ *       of those lines as active WP# and HOLD#/RESET# signals, respectively. Hence, it is
+ *       safer to use a configuration that will keep the lines high during the transfer.
  *
  * @param[in] p_config Pointer to the structure with custom instruction opcode and transfer
  *                     configuration. Transfer length must be set to @ref NRF_QSPI_CINSTR_LEN_1B.

--- a/nrfx/drivers/src/nrfx_qspi.c
+++ b/nrfx/drivers/src/nrfx_qspi.c
@@ -480,9 +480,16 @@ nrfx_err_t nrfx_qspi_mem_busy_check(void)
     nrfx_err_t ret_code;
     uint8_t status_value = 0;
 
-    nrf_qspi_cinstr_conf_t const config =
-        NRFX_QSPI_DEFAULT_CINSTR(QSPI_STD_CMD_RDSR,
-                                 NRF_QSPI_CINSTR_LEN_2B);
+    nrf_qspi_cinstr_conf_t const config = {
+        .opcode = QSPI_STD_CMD_RDSR,
+        .length = NRF_QSPI_CINSTR_LEN_2B,
+        // Keep the IO3 line high during the transfer. Otherwise, its low level
+        // can be interpreted by the memory chip as an active HOLD#/RESET#
+        // signal and the status register value may not be output.
+        // Such configuration is also consistent with what the QSPI peripheral
+        // uses when it sends the Read Status Register command itself.
+        .io3_level = true,
+    };
     ret_code = nrfx_qspi_cinstr_xfer(&config, &status_value, &status_value);
 
     if (ret_code != NRFX_SUCCESS)


### PR DESCRIPTION
Keep the line high during the custom instruction transfer. Otherwise,
its low level can be interpreted by the memory chip as an active
HOLD#/RESET# signal and in consequence the memory status can be read
incorrectly.
Add also related notes to descriptions of nrfx_qspi_cinstr_xfer() and
nrfx_qspi_lfm_start() to warn users that the default configuration
provided by NRFX_QSPI_DEFAULT_CINSTR() may not always be suitable.

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>