### PR TITLE
include: add "zephyr/" include prefix

### DIFF
--- a/drivers/nrf_802154/sl/sl_opensource/src/nrf_802154_sl_timer.c
+++ b/drivers/nrf_802154/sl/sl_opensource/src/nrf_802154_sl_timer.c
@@ -37,7 +37,7 @@
 #include <stdlib.h>
 #include <stdint.h>
 
-#include <kernel.h>
+#include <zephyr/kernel.h>
 #include <assert.h>
 
 #include "nrf_802154_sl_timer.h"


### PR DESCRIPTION
Add relevant "zephyr/" prefixes to allow building with LEGACY_INCLUDE_PATH=n.