### PR TITLE
nrfx_usbd: Do not abort endpoints on suspend

### DIFF
--- a/nrfx/drivers/src/nrfx_usbd.c
+++ b/nrfx/drivers/src/nrfx_usbd.c
@@ -1865,8 +1865,6 @@ bool nrfx_usbd_suspend(void)
     NRFX_CRITICAL_SECTION_ENTER();
     if (m_bus_suspend)
     {
-        usbd_ep_abort_all();
-
         if (!(nrf_usbd_eventcause_get(NRF_USBD) & NRF_USBD_EVENTCAUSE_RESUME_MASK))
         {
             nrf_usbd_lowpower_enable(NRF_USBD);


### PR DESCRIPTION
Aborting endpoints on suspend contradicts Universal Serial Bus Specification Revision 2.0, 9.1.1.6 Suspended:
  * When suspended, the USB device maintains any internal status, including its address and configuration.

The internal status definitely includes any pending USB transfers. Even if the developer wants the transfers to be aborted when bus is suspended (as far as I know, no standard class expects such behavior), USBD driver is the wrong layer to do so.

Remove offending call to usbd_ep_abort_all() in order to allow Zephyr to properly support suspend and get rid of workarounds to multiple suspend related problems that accumulated over the years.

Signed-off-by: Tomasz Moń <tomasz.mon@nordicsemi.no>