### PR TITLE
nrfx: Update to version 3.0.0

### DIFF
--- a/nrfx/CHANGELOG.md
+++ b/nrfx/CHANGELOG.md
@@ -1,6 +1,58 @@
 # Changelog
 All notable changes to this project are documented in this file.
 
+## [3.0.0] - 2023-04-25
+### Added
+- Added the HALY layer for the following peripherals: COMP, DPPI, GPIO, GPIOTE, I2S, LPCOMP, PDM, PWM, QDEC, RTC, SAADC, SPIM, TEMP, TIMER, TWIM, UARTE, WDT. HALY is an extension of the HAL layer that aggregates basic hardware use cases within single functions. Now it is used instead of HAL in the corresponding drivers.
+- Added functions for reconfiguring a peripheral outside of the initialization process in the following drivers: COMP, PDM, PWM, QDEC, QSPI, SPI, SPIM, SPIS, TIMER, TWI, TWIM, TWIS, UART, UARTE, WDT.
+- Added multi-instance support for the I2S and QDEC drivers. Now a pointer to the driver instance needs to be specified in all relevant functions.
+- Added the reportper_inten member to the configuration structure for the QDEC driver. It allows to explicitly enable interrupts associated with the REPORTRDY peripheral event.
+- Added the NRFX_ERROR_FORBIDDEN error being returned from the nrfx_spim_init() function when a user attempts to configure a hardware-controlled and software-controlled chip select simultaneously.
+- Added the NRFX_TIMER_FREQUENCY_STATIC_CHECK() macro to statically check if the given frequency is achievable for the specified TIMER instance.
+- Added the NRFX_TWIM_XFER_DESC() macro to support creation of any type of TWIM transaction for the TWIM driver.
+- Added auxiliary macros NRFX_KHZ_TO_HZ() and NRFX_MHZ_TO_HZ() for converting specified frequency value to Hertz.
+- Added auxiliary macros for sophisticated handling of the preprocessor symbols to `nrfx_utils.h`.
+- Added functions for getting the number of available channels and groups for a given peripheral instance in the DPPIC HAL.
+- Added functions for getting the SEQSTART tasks and SEQEND events associated with a specified sequence index in the PWM HAL.
+- Added the nrf_rtc_capture_task_get() function for getting the CAPTURE task associated with the specified CC channel in the RTC HAL.
+- Added functions for managing the non-maskable watchdog interrupts in the WDT HAL.
+- Added functions for getting the address of peripheral tasks and events in the EGU HAL.
+- Added a function for enabling the watchdog STOP task in the WDT HAL.
+- Added a function for getting the bitmask of all watchdog requests' statuses in the WDT HAL.
+- Added a function for clearing the event and task endpoints for a given channel in the GPPI helper.
+
+### Changed
+- Renamed a macro from NRFX_VOLTAGE_THRESHOLD_TO_INT() to NRFX_COMP_VOLTAGE_THRESHOLD_TO_INT() in the COMP HAL.
+- Renamed functions for getting the task of event address in the following drivers: CLOCK, GPIOTE, PPI, SPIM, TWIM. Now they follow a common scheme.
+- Renamed configuration structure members `hal` and `hal_config`, containing low-level peripheral settings, to `config` in the LPCOMP and UARTE drivers.
+- Renamed a function from nrfx_pwm_is_stopped() to nrfx_pwm_stopped_check() in the PWM driver.
+- Renamed a symbol from NRF_QDEC_LED_NOT_CONNECTED to NRF_QDEC_PIN_NOT_CONNECTED in the QDEC HAL. Now it is consistent with other, similar symbols.
+- Changed the way the API version to be used is specified. Now the following dedicated symbols shall be defined to form the API version as a numerical value: NRFX_CONFIG_API_VER_MAJOR, NRFX_CONFIG_API_VER_MINOR, NRFX_CONFIG_API_VER_MICRO.
+- Changed prototypes of several functions in the UARTE driver. Now all functions have a return value, and some of them accept additional parameters.
+- Changed a type of configuration structure members that hold a pin number from `uint8_t` to `uint32_t` in the following drivers: I2S, PWM, SPIM.
+- Changed the prototypes of the nrf_i2s_pins_set() and nrf_i2s_configure() functions in the I2S HAL. Now they accept a pointer to the configuration structure instead of several individual parameters.
+- Changed a default value of the `gain` structure member from `1/6` to `1` in the SAADC driver configuration structure.
+- Changed a type of the configuration structure member specifying the clock frequency from an enumeration to an unsigned integer in the TIMER driver. Now the timer clock frequency must be specified in Hertz. Use the NRFX_TIMER_FREQUENCY_STATIC_CHECK() macro to check if the requested frequency is achievable for a given TIMER instance.
+- Changed a type of the configuration structure member specifying the clock frequency from an enumeration to an unsigned integer in the SPIM driver. Now the clock signal frequency must be specified in Hertz. Use the NRFX_SPIM_FREQUENCY_STATIC_CHECK() macro to check if the requested frequency is achievable for a given SPIM instance.
+- Changed the prototype of the NRFX_TIMER_DEFAULT_CONFIG() macro in the TIMER driver. Now the desired timer clock frequency in Hertz needs to be specified as a parameter.
+- Changed a prototype of the WDT driver callback. Now a bitmask specifying which reload request caused the timeout is provided.
+- Changed the prototype of the initialization and callback functions of the QDEC driver. Now the user context can be provided and accessed during the interrupt handler execution.
+- Removed the deprecated nrf_gpio_pin_mcu_select() function and the corresponding nrf_gpio_pin_mcusel_t enumerator. Use the nrf_gpio_pin_control_select() function and the nrf_gpio_pin_sel_t enumerator instead.
+- Removed the deprecated and spurious NRF_QDEC_REPORTPER_DISABLED symbol from the QDEC HAL.
+- Removed the deprecated nrf_qdec_pio_assign() function from the QDEC HAL. Use the nrf_qdec_pins_set() function instead.
+- Removed the deprecated nrf_timer_frequency_set() and nrf_timer_frequency_get() functions in the TIMER HAL. Use nrf_timer_prescaler_set() and nrf_timer_prescaler_get() instead.
+- Removed symbols that mark a pin as unused in the following drivers: I2S, PWM, SPIM, SPIS. Now the HAL variant should be used instead.
+- Removed deprecated functions from the GPIOTE driver. Use new functions instead.
+- Removed the deprecated callback prototype in the IPC driver. Use a new variant instead.
+- Removed the following redundant functions from the PWM driver: nrfx_pwm_sequence_values_update(), nrfx_pwm_sequence_length_update(), nrfx_pwm_sequence_repeats_update(), nrfx_pwm_sequence_end_delay_update(). Use the nrfx_pwm_sequence_update() function instead.
+- Moved static inline functions from the header file to the source file in the GPPI helper.
+- Refactored the method of configuring pins that should use inverted polarity in the PWM driver. Now an array inside driver configuration structure needs to be used instead of masking the pin number value. As a consequence, the NRFX_PWM_PIN_INVERTED symbol was removed.
+- Renamed configuration structure members used for setting peripheral pins in the following drivers: PDM, TWIM, TWIS, UARTE. Now they use a common scheme.
+- Renamed the nrf_wdt_started() and nrf_wdt_request_status() functions in the WDT HAL. Now they are named as nrf_wdt_started_check() and nrf_wdt_request_status_check() respectively.
+
+### Fixed
+- Fixed a misleading description for the nrf_rtc_event_disable() function in the RTC HAL. It accepts a bitmask of events instead of a single event.
+
 ## [2.11.0] - 2023-04-07
 ### Added
 - Added support for the nRF9161 and nRF9131 SiPs. Use `NRF9120_XXAA` as the compilation symbol.

--- a/nrfx/README
+++ b/nrfx/README
@@ -2,10 +2,10 @@ nrfx
 ####
 
 Origin:
-   https://github.com/NordicSemiconductor/nrfx/tree/v2.11.0
+   https://github.com/NordicSemiconductor/nrfx/tree/v3.0.0
 
 Status:
-   v2.11.0
+   v3.0.0
 
 Purpose:
    With added proper shims adapting it to Zephyr's APIs, nrfx will provide
@@ -32,7 +32,7 @@ URL:
    https://github.com/NordicSemiconductor/nrfx
 
 commit:
-   2527e3c8449cfd38aee41598e8af8492f410ed15
+   1c721175f22dbb1bf125a570a427b53f810881bb
 
 Maintained-by:
    External
@@ -41,4 +41,4 @@ License:
    BSD-3-Clause
 
 License Link:
-   https://github.com/NordicSemiconductor/nrfx/blob/v2.11.0/LICENSE
+   https://github.com/NordicSemiconductor/nrfx/blob/v3.0.0/LICENSE

--- a/nrfx/doc/config_dox/nrfx_common_dox_config.h
+++ b/nrfx/doc/config_dox/nrfx_common_dox_config.h
@@ -1,0 +1,16 @@
+/**
+ * @defgroup nrfx_common_config Common configuration
+ * @{
+ * @ingroup nrfx
+ */
+
+/** @brief Symbol specifying major version of the nrfx API to be used. */
+#define NRFX_CONFIG_API_VER_MAJOR
+
+/** @brief Symbol specifying minor version of the nrfx API to be used. */
+#define NRFX_CONFIG_API_VER_MINOR
+
+/** @brief Symbol specifying micro version of the nrfx API to be used. */
+#define NRFX_CONFIG_API_VER_MICRO
+
+/** @} */

--- a/nrfx/doc/drv_supp_matrix.dox
+++ b/nrfx/doc/drv_supp_matrix.dox
@@ -46,7 +46,7 @@ The following matrix provides a comparative overview of which drivers are suppor
 | @ref nrf_dppi    |@tagRedCross  |@tagRedCross  |@tagRedCross          |@tagRedCross  |@tagRedCross  |@tagRedCross  |@tagRedCross  |@tagGreenTick |@tagGreenTick |
 | @ref nrf_ecb     |@tagGreenTick |@tagGreenTick |@tagGreenTick         |@tagGreenTick |@tagGreenTick |@tagGreenTick |@tagGreenTick |@tagGreenTick |@tagRedCross  |
 | @ref nrf_egu     |@tagRedCross  |@tagGreenTick |@tagGreenTick         |@tagGreenTick |@tagGreenTick |@tagGreenTick |@tagGreenTick |@tagGreenTick |@tagGreenTick |
-| @ref nrf_ficr    |@tagGreenTick |@tagGreenTick |@tagGreenTick         |@tagGreenTick |@tagGreenTick |@tagGreenTick |@tagGreenTick |@tagGreenTick |@tagGreenTick |
+| @ref nrf_icr     |@tagGreenTick |@tagGreenTick |@tagGreenTick         |@tagGreenTick |@tagGreenTick |@tagGreenTick |@tagGreenTick |@tagGreenTick |@tagGreenTick |
 | @ref nrf_fpu     |@tagRedCross  |@tagRedCross  |@tagRedCross          |@tagRedCross  |@tagRedCross  |@tagRedCross  |@tagRedCross  |@tagGreenTick |@tagRedCross  |
 | @ref nrf_gpio    |@tagGreenTick |@tagGreenTick |@tagGreenTick         |@tagGreenTick |@tagGreenTick |@tagGreenTick |@tagGreenTick |@tagGreenTick |@tagGreenTick |
 | @ref nrf_gpiote  |@tagGreenTick |@tagGreenTick |@tagGreenTick         |@tagGreenTick |@tagGreenTick |@tagGreenTick |@tagGreenTick |@tagGreenTick |@tagGreenTick |

--- a/nrfx/doc/nrf51_series.dox
+++ b/nrfx/doc/nrf51_series.dox
@@ -16,7 +16,7 @@ For a complete overview, see @ref nrfx_drv_supp_matrix.
 
 @ref nrf_ecb
 
-@ref nrf_ficr
+@ref nrf_icr
 
 @ref nrf_gpio
 

--- a/nrfx/doc/nrf52805.dox
+++ b/nrfx/doc/nrf52805.dox
@@ -20,7 +20,7 @@ For a complete overview, see @ref nrfx_drv_supp_matrix.
 
 @ref nrf_egu
 
-@ref nrf_ficr
+@ref nrf_icr
 
 @ref nrf_gpio
 

--- a/nrfx/doc/nrf52810.dox
+++ b/nrfx/doc/nrf52810.dox
@@ -22,7 +22,7 @@ For a complete overview, see @ref nrfx_drv_supp_matrix.
 
 @ref nrf_egu
 
-@ref nrf_ficr
+@ref nrf_icr
 
 @ref nrf_gpio
 

--- a/nrfx/doc/nrf52820.dox
+++ b/nrfx/doc/nrf52820.dox
@@ -22,7 +22,7 @@ For a complete overview, see @ref nrfx_drv_supp_matrix.
 
 @ref nrf_egu
 
-@ref nrf_ficr
+@ref nrf_icr
 
 @ref nrf_gpio
 

--- a/nrfx/doc/nrf52832.dox
+++ b/nrfx/doc/nrf52832.dox
@@ -22,7 +22,7 @@ For a complete overview, see @ref nrfx_drv_supp_matrix.
 
 @ref nrf_egu
 
-@ref nrf_ficr
+@ref nrf_icr
 
 @ref nrf_gpio
 

--- a/nrfx/doc/nrf52833.dox
+++ b/nrfx/doc/nrf52833.dox
@@ -22,7 +22,7 @@ For a complete overview, see @ref nrfx_drv_supp_matrix.
 
 @ref nrf_egu
 
-@ref nrf_ficr
+@ref nrf_icr
 
 @ref nrf_gpio
 

--- a/nrfx/doc/nrf52840.dox
+++ b/nrfx/doc/nrf52840.dox
@@ -22,7 +22,7 @@ For a complete overview, see @ref nrfx_drv_supp_matrix.
 
 @ref nrf_egu
 
-@ref nrf_ficr
+@ref nrf_icr
 
 @ref nrf_gpio
 

--- a/nrfx/doc/nrf5340.dox
+++ b/nrfx/doc/nrf5340.dox
@@ -28,7 +28,7 @@ For a complete overview, see @ref nrfx_drv_supp_matrix.
 
 @ref nrf_egu
 
-@ref nrf_ficr
+@ref nrf_icr
 
 @ref nrf_fpu
 

--- a/nrfx/doc/nrf91_series.dox
+++ b/nrfx/doc/nrf91_series.dox
@@ -14,7 +14,7 @@ For a complete overview, see @ref nrfx_drv_supp_matrix.
 
 @ref nrf_egu
 
-@ref nrf_ficr
+@ref nrf_icr
 
 @ref nrf_gpio
 

--- a/nrfx/doc/nrfx.doxyfile
+++ b/nrfx/doc/nrfx.doxyfile
@@ -50,7 +50,7 @@ PROJECT_NAME           = "nrfx"
 
 ### EDIT THIS ###
 
-PROJECT_NUMBER         = "2.11"
+PROJECT_NUMBER         = "3.0"
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a
@@ -281,7 +281,8 @@ TAB_SIZE               = 4
 
 ALIASES                = "tagGreenTick=\htmlonly<CENTER><font color=\"green\">✔</font></CENTER>\endhtmlonly \xmlonly<verbatim>embed:rst:inline :green:`✔`</verbatim>\endxmlonly" \
                          "tagRedCross=\htmlonly<CENTER><font color=\"red\">✖</font></CENTER>\endhtmlonly \xmlonly<verbatim>embed:rst:inline :red:`✖`</verbatim>\endxmlonly" \
-                         "nRF5340pinAssignmentsURL=\"https://infocenter.nordicsemi.com/index.jsp?topic=%2Fps_nrf5340%2Fchapters%2Fpin.html\""
+                         "nRF5340pinAssignmentsURL=\"https://infocenter.nordicsemi.com/index.jsp?topic=%2Fps_nrf5340%2Fchapters%2Fpin.html\"" \
+                         "refhal{1}=\sa \1 \copydoc \1"
 
 # Set the OPTIMIZE_OUTPUT_FOR_C tag to YES if your project consists of C sources
 # only. Doxygen will then generate output that is more tailored for C. For
@@ -917,14 +918,15 @@ WARN_LOGFILE           = warnings_nrfx.txt
 
 ### EDIT THIS ###
 
-INPUT                  = ../helpers \
+INPUT                  = config_dox \
+                         ../helpers \
                          ../drivers \
                          ../hal \
+                         ../haly \
                          ../soc \
                          ../templates/nrfx_glue.h \
                          ../templates/nrfx_log.h \
                          ../CHANGELOG.md \
-                         config_dox \
                          .
 
 # This tag can be used to specify the character encoding of the source files
@@ -2297,7 +2299,8 @@ INCLUDE_FILE_PATTERNS  =
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
 PREDEFINED             = SUPPRESS_INLINE_IMPLEMENTATION \
-                         __NRFX_DOXYGEN__
+                         __NRFX_DOXYGEN__ \
+                         __PACKED=
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/nrfx/doc/nrfx_api.dox
+++ b/nrfx/doc/nrfx_api.dox
@@ -29,8 +29,6 @@
 
 @defgroup nrf_egu EGU
 
-@defgroup nrf_ficr FICR
-
 @defgroup nrf_fpu FPU
 
 @defgroup nrf_gpio GPIO
@@ -38,6 +36,8 @@
 @defgroup nrf_gpiote GPIOTE
 
 @defgroup nrf_i2s I2S
+
+@defgroup nrf_icr ICR
 
 @defgroup nrf_ipc IPC
 
@@ -102,6 +102,7 @@
 @defgroup nrf_vmc VMC
 
 @defgroup nrf_wdt WDT
+
 @}
 
 @defgroup nrfx nrfx API

--- a/nrfx/doc/sphinx/conf.py
+++ b/nrfx/doc/sphinx/conf.py
@@ -41,11 +41,11 @@ breathe_separate_member_pages = True
 
 c_id_attributes = [
     "NRF_STATIC_INLINE",
+    "NRFY_STATIC_INLINE",
     "NRFX_STATIC_INLINE",
     "__STATIC_INLINE",
 ]
 cpp_id_attributes = c_id_attributes
-
 
 def setup(app):
     app.add_css_file("css/nrfx.css")

--- a/nrfx/doc/sphinx/drivers/comp/haly.rst
+++ b/nrfx/doc/sphinx/drivers/comp/haly.rst
@@ -1,0 +1,6 @@
+COMP HALY
+=========
+
+.. doxygengroup:: nrfy_comp
+   :project: nrfx
+   :members:

--- a/nrfx/doc/sphinx/drivers/dppi/haly.rst
+++ b/nrfx/doc/sphinx/drivers/dppi/haly.rst
@@ -1,0 +1,6 @@
+DPPI HALY
+=========
+
+.. doxygengroup:: nrfy_dppi
+   :project: nrfx
+   :members:

--- a/nrfx/doc/sphinx/drivers/ficr/index.rst
+++ b/nrfx/doc/sphinx/drivers/ficr/index.rst
@@ -1,9 +1,0 @@
-FICR
-====
-
-.. doxygengroup:: nrf_ficr
-
-.. toctree::
-   :glob:
-
-   *

--- a/nrfx/doc/sphinx/drivers/gpio/haly.rst
+++ b/nrfx/doc/sphinx/drivers/gpio/haly.rst
@@ -1,0 +1,6 @@
+GPIO HALY
+=========
+
+.. doxygengroup:: nrfy_gpio
+   :project: nrfx
+   :members:

--- a/nrfx/doc/sphinx/drivers/gpiote/haly.rst
+++ b/nrfx/doc/sphinx/drivers/gpiote/haly.rst
@@ -1,0 +1,6 @@
+GPIOTE HALY
+===========
+
+.. doxygengroup:: nrfy_gpiote
+   :project: nrfx
+   :members:

--- a/nrfx/doc/sphinx/drivers/i2s/haly.rst
+++ b/nrfx/doc/sphinx/drivers/i2s/haly.rst
@@ -1,0 +1,6 @@
+I2S HALY
+========
+
+.. doxygengroup:: nrfy_i2s
+   :project: nrfx
+   :members:

--- a/nrfx/doc/sphinx/drivers/icr/index.rst
+++ b/nrfx/doc/sphinx/drivers/icr/index.rst
@@ -1,0 +1,9 @@
+ICR
+===
+
+.. doxygengroup:: nrf_icr
+
+.. toctree::
+   :glob:
+
+   ../ficr/hal.rst

--- a/nrfx/doc/sphinx/drivers/lpcomp/haly.rst
+++ b/nrfx/doc/sphinx/drivers/lpcomp/haly.rst
@@ -1,0 +1,6 @@
+LPCOMP HALY
+===========
+
+.. doxygengroup:: nrfy_lpcomp
+   :project: nrfx
+   :members:

--- a/nrfx/doc/sphinx/drivers/pdm/haly.rst
+++ b/nrfx/doc/sphinx/drivers/pdm/haly.rst
@@ -1,0 +1,6 @@
+PDM HALY
+========
+
+.. doxygengroup:: nrfy_pdm
+   :project: nrfx
+   :members:

--- a/nrfx/doc/sphinx/drivers/pwm/haly.rst
+++ b/nrfx/doc/sphinx/drivers/pwm/haly.rst
@@ -1,0 +1,6 @@
+PWM HALY
+========
+
+.. doxygengroup:: nrfy_pwm
+   :project: nrfx
+   :members:

--- a/nrfx/doc/sphinx/drivers/qdec/haly.rst
+++ b/nrfx/doc/sphinx/drivers/qdec/haly.rst
@@ -1,0 +1,6 @@
+QDEC HALY
+=========
+
+.. doxygengroup:: nrfy_qdec
+   :project: nrfx
+   :members:

--- a/nrfx/doc/sphinx/drivers/rtc/haly.rst
+++ b/nrfx/doc/sphinx/drivers/rtc/haly.rst
@@ -1,0 +1,6 @@
+RTC HALY
+========
+
+.. doxygengroup:: nrfy_rtc
+   :project: nrfx
+   :members:

--- a/nrfx/doc/sphinx/drivers/saadc/haly.rst
+++ b/nrfx/doc/sphinx/drivers/saadc/haly.rst
@@ -1,0 +1,6 @@
+SAADC HALY
+==========
+
+.. doxygengroup:: nrfy_saadc
+   :project: nrfx
+   :members:

--- a/nrfx/doc/sphinx/drivers/spim/haly.rst
+++ b/nrfx/doc/sphinx/drivers/spim/haly.rst
@@ -1,0 +1,6 @@
+SPIM HALY
+=========
+
+.. doxygengroup:: nrfy_spim
+   :project: nrfx
+   :members:

--- a/nrfx/doc/sphinx/drivers/temp/haly.rst
+++ b/nrfx/doc/sphinx/drivers/temp/haly.rst
@@ -1,0 +1,6 @@
+TEMP HALY
+=========
+
+.. doxygengroup:: nrfy_temp
+   :project: nrfx
+   :members:

--- a/nrfx/doc/sphinx/drivers/timer/haly.rst
+++ b/nrfx/doc/sphinx/drivers/timer/haly.rst
@@ -1,0 +1,6 @@
+TIMER HALY
+==========
+
+.. doxygengroup:: nrfy_timer
+   :project: nrfx
+   :members:

--- a/nrfx/doc/sphinx/drivers/twim/haly.rst
+++ b/nrfx/doc/sphinx/drivers/twim/haly.rst
@@ -1,0 +1,6 @@
+TWIM HALY
+=========
+
+.. doxygengroup:: nrfy_twim
+   :project: nrfx
+   :members:

--- a/nrfx/doc/sphinx/drivers/uarte/haly.rst
+++ b/nrfx/doc/sphinx/drivers/uarte/haly.rst
@@ -1,0 +1,6 @@
+UARTE HALY
+==========
+
+.. doxygengroup:: nrfy_uarte
+   :project: nrfx
+   :members:

--- a/nrfx/doc/sphinx/drivers/wdt/haly.rst
+++ b/nrfx/doc/sphinx/drivers/wdt/haly.rst
@@ -1,0 +1,6 @@
+WDT HALY
+========
+
+.. doxygengroup:: nrfy_wdt
+   :project: nrfx
+   :members:

--- a/nrfx/doc/sphinx/nrfx_api/common_configuration.rst
+++ b/nrfx/doc/sphinx/nrfx_api/common_configuration.rst
@@ -1,0 +1,6 @@
+Common configuration
+====================
+
+.. doxygengroup:: nrfx_common_config
+   :project: nrfx
+   :members:

--- a/nrfx/doc/sphinx/nrfx_api/common_nrfy.rst
+++ b/nrfx/doc/sphinx/nrfx_api/common_nrfy.rst
@@ -1,0 +1,6 @@
+Common nrfy module
+==================
+
+.. doxygengroup:: nrfy_common
+   :project: nrfx
+   :members:

--- a/nrfx/drivers/include/nrfx_clock.h
+++ b/nrfx/drivers/include/nrfx_clock.h
@@ -54,6 +54,7 @@ typedef enum
 {
     NRFX_CLOCK_EVT_HFCLK_STARTED,      ///< HFCLK has been started.
     NRFX_CLOCK_EVT_LFCLK_STARTED,      ///< LFCLK has been started.
+    NRFX_CLOCK_EVT_PLL_STARTED,        ///< PLL has been started.
     NRFX_CLOCK_EVT_CTTO,               ///< Calibration timeout.
     NRFX_CLOCK_EVT_CAL_DONE,           ///< Calibration has been done.
     NRFX_CLOCK_EVT_HFCLKAUDIO_STARTED, ///< HFCLKAUDIO has been started.
@@ -261,7 +262,7 @@ void nrfx_clock_calibration_timer_stop(void);
  *
  * @return Task address.
  */
-NRFX_STATIC_INLINE uint32_t nrfx_clock_ppi_task_addr(nrf_clock_task_t task);
+NRFX_STATIC_INLINE uint32_t nrfx_clock_task_address_get(nrf_clock_task_t task);
 
 /**
  * @brief Function for returning a requested event address for the clock driver module.
@@ -270,7 +271,7 @@ NRFX_STATIC_INLINE uint32_t nrfx_clock_ppi_task_addr(nrf_clock_task_t task);
  *
  * @return Event address.
  */
-NRFX_STATIC_INLINE uint32_t nrfx_clock_ppi_event_addr(nrf_clock_event_t event);
+NRFX_STATIC_INLINE uint32_t nrfx_clock_event_address_get(nrf_clock_event_t event);
 
 #ifndef NRFX_DECLARE_ONLY
 
@@ -314,12 +315,12 @@ NRFX_STATIC_INLINE void nrfx_clock_hfclk_stop(void)
     nrfx_clock_stop(NRF_CLOCK_DOMAIN_HFCLK);
 }
 
-NRFX_STATIC_INLINE uint32_t nrfx_clock_ppi_task_addr(nrf_clock_task_t task)
+NRFX_STATIC_INLINE uint32_t nrfx_clock_task_address_get(nrf_clock_task_t task)
 {
     return nrf_clock_task_address_get(NRF_CLOCK, task);
 }
 
-NRFX_STATIC_INLINE uint32_t nrfx_clock_ppi_event_addr(nrf_clock_event_t event)
+NRFX_STATIC_INLINE uint32_t nrfx_clock_event_address_get(nrf_clock_event_t event)
 {
     return nrf_clock_event_address_get(NRF_CLOCK, event);
 }

--- a/nrfx/drivers/include/nrfx_comp.h
+++ b/nrfx/drivers/include/nrfx_comp.h
@@ -35,7 +35,7 @@
 #define NRFX_COMP_H__
 
 #include <nrfx.h>
-#include <hal/nrf_comp.h>
+#include <haly/nrfy_comp.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -56,7 +56,7 @@ extern "C" {
  *                must not be smaller than reference voltage divided by 64.
  * @param[in] ref Reference voltage.
  */
-#define NRFX_VOLTAGE_THRESHOLD_TO_INT(vol, ref) \
+#define NRFX_COMP_VOLTAGE_THRESHOLD_TO_INT(vol, ref) \
     (uint8_t)(((vol) > ((ref) / 64)) ? (NRFX_ROUNDED_DIV((vol) * 64,(ref)) - 1) : 0)
 
 /**
@@ -70,40 +70,40 @@ typedef void (* nrfx_comp_event_handler_t)(nrf_comp_event_t event);
 typedef enum
 {
     NRFX_COMP_SHORT_STOP_AFTER_CROSS_EVT = COMP_SHORTS_CROSS_STOP_Msk, /*!< Shortcut between the CROSS event and the STOP task. */
-    NRFX_COMP_SHORT_STOP_AFTER_UP_EVT = COMP_SHORTS_UP_STOP_Msk,       /*!< Shortcut between the UP event and the STOP task. */
-    NRFX_COMP_SHORT_STOP_AFTER_DOWN_EVT = COMP_SHORTS_DOWN_STOP_Msk    /*!< Shortcut between the DOWN event and the STOP task. */
+    NRFX_COMP_SHORT_STOP_AFTER_UP_EVT    = COMP_SHORTS_UP_STOP_Msk,    /*!< Shortcut between the UP event and the STOP task. */
+    NRFX_COMP_SHORT_STOP_AFTER_DOWN_EVT  = COMP_SHORTS_DOWN_STOP_Msk   /*!< Shortcut between the DOWN event and the STOP task. */
 } nrfx_comp_short_mask_t;
 
 /** @brief COMP events masks. */
 typedef enum
 {
     NRFX_COMP_EVT_EN_CROSS_MASK = COMP_INTENSET_CROSS_Msk, /*!< CROSS event (generated after VIN+ == VIN-). */
-    NRFX_COMP_EVT_EN_UP_MASK = COMP_INTENSET_UP_Msk,       /*!< UP event (generated when VIN+ crosses VIN- while increasing). */
-    NRFX_COMP_EVT_EN_DOWN_MASK = COMP_INTENSET_DOWN_Msk,   /*!< DOWN event (generated when VIN+ crosses VIN- while decreasing). */
+    NRFX_COMP_EVT_EN_UP_MASK    = COMP_INTENSET_UP_Msk,    /*!< UP event (generated when VIN+ crosses VIN- while increasing). */
+    NRFX_COMP_EVT_EN_DOWN_MASK  = COMP_INTENSET_DOWN_Msk,  /*!< DOWN event (generated when VIN+ crosses VIN- while decreasing). */
     NRFX_COMP_EVT_EN_READY_MASK = COMP_INTENSET_READY_Msk  /*!< READY event (generated when the module is ready). */
 } nrfx_comp_evt_en_mask_t;
 
 /** @brief COMP configuration. */
 typedef struct
 {
-    nrf_comp_ref_t          reference;          /**< Reference selection. */
-    nrf_comp_ext_ref_t      ext_ref;            /**< External analog reference selection. */
-    nrf_comp_main_mode_t    main_mode;          /**< Main operation mode. */
-    nrf_comp_th_t           threshold;          /**< Structure holding THDOWN and THUP values needed by the COMP_TH register. */
-    nrf_comp_sp_mode_t      speed_mode;         /**< Speed and power mode. */
-    nrf_comp_hyst_t         hyst;               /**< Comparator hysteresis. */
-#if defined (COMP_ISOURCE_ISOURCE_Msk) || defined (__NRFX_DOXYGEN__)
-    nrf_isource_t           isource;            /**< Current source selected on analog input. */
+    nrf_comp_ref_t       reference;          ///< Reference selection.
+    nrf_comp_ext_ref_t   ext_ref;            ///< External analog reference selection.
+    nrf_comp_main_mode_t main_mode;          ///< Main operation mode.
+    nrf_comp_th_t        threshold;          ///< Structure holding THDOWN and THUP values needed by the COMP_TH register.
+    nrf_comp_sp_mode_t   speed_mode;         ///< Speed and power mode.
+    nrf_comp_hyst_t      hyst;               ///< Comparator hysteresis.
+#if NRF_COMP_HAS_ISOURCE
+    nrf_isource_t        isource;            ///< Current source selected on analog input.
 #endif
-    nrf_comp_input_t        input;              /**< Input to be monitored. */
-    uint8_t                 interrupt_priority; /**< Interrupt priority. */
+    nrf_comp_input_t     input;              ///< Input to be monitored.
+    uint8_t              interrupt_priority; ///< Interrupt priority.
 } nrfx_comp_config_t;
 
 /** @brief COMP threshold default configuration. */
-#define NRFX_COMP_CONFIG_TH                             \
-{                                                       \
-    .th_down = NRFX_VOLTAGE_THRESHOLD_TO_INT(0.5, 1.8), \
-    .th_up   = NRFX_VOLTAGE_THRESHOLD_TO_INT(1.5, 1.8)  \
+#define NRFX_COMP_CONFIG_TH                                  \
+{                                                            \
+    .th_down = NRFX_COMP_VOLTAGE_THRESHOLD_TO_INT(0.5, 1.8), \
+    .th_up   = NRFX_COMP_VOLTAGE_THRESHOLD_TO_INT(1.5, 1.8)  \
 }
 
 /**
@@ -120,30 +120,17 @@ typedef struct
  *
  * @param[in] _input Analog input.
  */
-#if defined (COMP_ISOURCE_ISOURCE_Msk) || defined (__NRFX_DOXYGEN__)
-#define NRFX_COMP_DEFAULT_CONFIG(_input)                         \
-{                                                                \
-    .reference          = NRF_COMP_REF_Int1V8,                   \
-    .main_mode          = NRF_COMP_MAIN_MODE_SE,                 \
-    .threshold          = NRFX_COMP_CONFIG_TH,                   \
-    .speed_mode         = NRF_COMP_SP_MODE_High,                 \
-    .hyst               = NRF_COMP_HYST_NoHyst,                  \
-    .isource            = NRF_COMP_ISOURCE_Off,                  \
-    .input              = (nrf_comp_input_t)_input,              \
-    .interrupt_priority = NRFX_COMP_DEFAULT_CONFIG_IRQ_PRIORITY  \
+#define NRFX_COMP_DEFAULT_CONFIG(_input)                                           \
+{                                                                                  \
+    .reference          = NRF_COMP_REF_INT_1V8,                                    \
+    .main_mode          = NRF_COMP_MAIN_MODE_SE,                                   \
+    .threshold          = NRFX_COMP_CONFIG_TH,                                     \
+    .speed_mode         = NRF_COMP_SP_MODE_HIGH,                                   \
+    .hyst               = NRF_COMP_HYST_NO_HYST,                                   \
+    NRFX_COND_CODE_1(NRF_COMP_HAS_ISOURCE, (.isource = NRF_COMP_ISOURCE_OFF,), ()) \
+    .input              = (nrf_comp_input_t)_input,                                \
+    .interrupt_priority = NRFX_COMP_DEFAULT_CONFIG_IRQ_PRIORITY                    \
 }
-#else
-#define NRFX_COMP_DEFAULT_CONFIG(_input)                         \
-{                                                                \
-    .reference          = NRF_COMP_REF_Int1V8,                   \
-    .main_mode          = NRF_COMP_MAIN_MODE_SE,                 \
-    .threshold          = NRFX_COMP_CONFIG_TH,                   \
-    .speed_mode         = NRF_COMP_SP_MODE_High,                 \
-    .hyst               = NRF_COMP_HYST_NoHyst,                  \
-    .input              = (nrf_comp_input_t)_input,              \
-    .interrupt_priority = NRFX_COMP_DEFAULT_CONFIG_IRQ_PRIORITY  \
-}
-#endif
 
 /**
  * @brief Function for initializing the COMP driver.
@@ -163,6 +150,17 @@ typedef struct
  */
 nrfx_err_t nrfx_comp_init(nrfx_comp_config_t const * p_config,
                           nrfx_comp_event_handler_t  event_handler);
+
+/**
+ * @brief Function for reconfiguring the COMP driver.
+ *
+ * @param[in] p_config Pointer to the structure with the configuration.
+ *
+ * @retval NRFX_SUCCESS             Reconfiguration was successful.
+ * @retval NRFX_ERROR_BUSY          The driver is running and cannot be reconfigured.
+ * @retval NRFX_ERROR_INVALID_STATE The driver is uninitialized.
+ */
+nrfx_err_t nrfx_comp_reconfigure(nrfx_comp_config_t const * p_config);
 
 /**
  * @brief Function for uninitializing the COMP driver.
@@ -236,12 +234,12 @@ NRFX_STATIC_INLINE uint32_t nrfx_comp_event_address_get(nrf_comp_event_t event);
 #ifndef NRFX_DECLARE_ONLY
 NRFX_STATIC_INLINE uint32_t nrfx_comp_task_address_get(nrf_comp_task_t task)
 {
-    return nrf_comp_task_address_get(NRF_COMP, task);
+    return nrfy_comp_task_address_get(NRF_COMP, task);
 }
 
 NRFX_STATIC_INLINE uint32_t nrfx_comp_event_address_get(nrf_comp_event_t event)
 {
-    return nrf_comp_event_address_get(NRF_COMP, event);
+    return nrfy_comp_event_address_get(NRF_COMP, event);
 }
 #endif // NRFX_DECLARE_ONLY
 

--- a/nrfx/drivers/include/nrfx_dppi.h
+++ b/nrfx/drivers/include/nrfx_dppi.h
@@ -35,7 +35,7 @@
 #define NRFX_DPPI_H__
 
 #include <nrfx.h>
-#include <hal/nrf_dppi.h>
+#include <haly/nrfy_dppi.h>
 
 /**
  * @defgroup nrfx_dppi DPPI allocator

--- a/nrfx/drivers/include/nrfx_egu.h
+++ b/nrfx/drivers/include/nrfx_egu.h
@@ -58,24 +58,8 @@ typedef struct
 
 #ifndef __NRFX_DOXYGEN__
 enum {
-#if NRFX_CHECK(NRFX_EGU0_ENABLED)
-    NRFX_EGU0_INST_IDX,
-#endif
-#if NRFX_CHECK(NRFX_EGU1_ENABLED)
-    NRFX_EGU1_INST_IDX,
-#endif
-#if NRFX_CHECK(NRFX_EGU2_ENABLED)
-    NRFX_EGU2_INST_IDX,
-#endif
-#if NRFX_CHECK(NRFX_EGU3_ENABLED)
-    NRFX_EGU3_INST_IDX,
-#endif
-#if NRFX_CHECK(NRFX_EGU4_ENABLED)
-    NRFX_EGU4_INST_IDX,
-#endif
-#if NRFX_CHECK(NRFX_EGU5_ENABLED)
-    NRFX_EGU5_INST_IDX,
-#endif
+    /* List all enabled driver instances (in the format NRFX_\<instance_name\>_INST_IDX). */
+    NRFX_INSTANCE_ENUM_LIST(EGU)
     NRFX_EGU_ENABLED_COUNT
 };
 #endif
@@ -121,6 +105,28 @@ nrfx_err_t nrfx_egu_init(nrfx_egu_t const *       p_instance,
 void nrfx_egu_int_enable(nrfx_egu_t const * p_instance, uint32_t mask);
 
 /**
+ * @brief Function for getting the address of the specified EGU task.
+ *
+ * @param[in] p_instance Pointer to the driver instance structure.
+ * @param[in] task       EGU task.
+ *
+ * @return Task address.
+ */
+NRFX_STATIC_INLINE uint32_t nrfx_egu_task_address_get(nrfx_egu_t const * p_instance,
+                                                      nrf_egu_task_t     task);
+
+/**
+ * @brief Function for getting the address of the specified EGU event.
+ *
+ * @param[in] p_instance Pointer to the driver instance structure.
+ * @param[in] event      EGU event.
+ *
+ * @return Event address.
+ */
+NRFX_STATIC_INLINE uint32_t nrfx_egu_event_address_get(nrfx_egu_t const * p_instance,
+                                                       nrf_egu_event_t    event);
+
+/**
  * @brief Function for disabling interrupts on specified events of a given EGU driver instance.
  *
  * @param[in] p_instance Pointer to the driver instance structure.
@@ -152,14 +158,36 @@ void nrfx_egu_uninit(nrfx_egu_t const * p_instance);
  */
 #define NRFX_EGU_INST_HANDLER_GET(idx) NRFX_CONCAT_3(nrfx_egu_, idx, _irq_handler)
 
+#ifndef NRFX_DECLARE_ONLY
+NRFX_STATIC_INLINE uint32_t nrfx_egu_task_address_get(nrfx_egu_t const * p_instance,
+                                                      nrf_egu_task_t     task)
+{
+    return nrf_egu_task_address_get(p_instance->p_reg, task);
+}
+
+NRFX_STATIC_INLINE uint32_t nrfx_egu_event_address_get(nrfx_egu_t const * p_instance,
+                                                       nrf_egu_event_t    event)
+{
+    return nrf_egu_event_address_get(p_instance->p_reg, event);
+}
+#endif // NRFX_DECLARE_ONLY
+
 /** @} */
 
-void nrfx_egu_0_irq_handler(void);
-void nrfx_egu_1_irq_handler(void);
-void nrfx_egu_2_irq_handler(void);
-void nrfx_egu_3_irq_handler(void);
-void nrfx_egu_4_irq_handler(void);
-void nrfx_egu_5_irq_handler(void);
+/*
+ * Declare interrupt handlers for all enabled driver instances in the following format:
+ * nrfx_\<periph_name\>_\<idx\>_irq_handler (for example, nrfx_egu_0_irq_handler).
+ *
+ * A specific interrupt handler for the driver instance can be retrieved by using
+ * the NRFX_EGU_INST_HANDLER_GET macro.
+ *
+ * Here is a sample of using the NRFX_EGU_INST_HANDLER_GET macro to directly map
+ * an interrupt handler in a Zephyr application:
+ *
+ * IRQ_DIRECT_CONNECT(NRFX_IRQ_NUMBER_GET(NRF_EGU_INST_GET(\<instance_index\>)), \<priority\>,
+ *                    NRFX_EGU_INST_HANDLER_GET(\<instance_index\>), 0);
+ */
+NRFX_INSTANCE_IRQ_HANDLERS_DECLARE(EGU, egu)
 
 #ifdef __cplusplus
 }

--- a/nrfx/drivers/include/nrfx_gpiote.h
+++ b/nrfx/drivers/include/nrfx_gpiote.h
@@ -35,8 +35,8 @@
 #define NRFX_GPIOTE_H__
 
 #include <nrfx.h>
-#include <hal/nrf_gpiote.h>
-#include <hal/nrf_gpio.h>
+#include <haly/nrfy_gpiote.h>
+#include <haly/nrfy_gpio.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -121,16 +121,6 @@ typedef struct
     void *                          p_context; ///< Context passed to the event handler.
 } nrfx_gpiote_handler_config_t;
 
-/** @brief Input pin configuration. */
-typedef struct
-{
-    nrf_gpiote_polarity_t sense;               /**< Transition that triggers the interrupt. */
-    nrf_gpio_pin_pull_t   pull;                /**< Pulling mode. */
-    bool                  is_watcher      : 1; /**< True when the input pin is tracking an output pin. */
-    bool                  hi_accuracy     : 1; /**< True when high accuracy (IN_EVENT) is used. */
-    bool                  skip_gpio_setup : 1; /**< Do not change GPIO configuration */
-} nrfx_gpiote_in_config_t;
-
 /** @brief Output pin default configuration. */
 #define NRFX_GPIOTE_DEFAULT_OUTPUT_CONFIG           \
 {                                                   \
@@ -145,137 +135,6 @@ typedef struct
     .pull = NRF_GPIO_PIN_NOPULL          \
 }
 
-/**
- * @brief Macro for configuring a pin to use a GPIO IN or PORT EVENT to detect low-to-high transition.
- * @details Set hi_accu to true to use IN_EVENT.
- */
-#define NRFX_GPIOTE_CONFIG_IN_SENSE_LOTOHI(hi_accu) \
-{                                                   \
-    .sense = NRF_GPIOTE_POLARITY_LOTOHI,            \
-    .pull = NRF_GPIO_PIN_NOPULL,                    \
-    .is_watcher = false,                            \
-    .hi_accuracy = hi_accu,                         \
-    .skip_gpio_setup = false,                       \
-}
-
-/**
- * @brief Macro for configuring a pin to use a GPIO IN or PORT EVENT to detect high-to-low transition.
- * @details Set hi_accu to true to use IN_EVENT.
- */
-#define NRFX_GPIOTE_CONFIG_IN_SENSE_HITOLO(hi_accu) \
-{                                                   \
-    .sense = NRF_GPIOTE_POLARITY_HITOLO,            \
-    .pull = NRF_GPIO_PIN_NOPULL,                    \
-    .is_watcher = false,                            \
-    .hi_accuracy = hi_accu,                         \
-    .skip_gpio_setup = false,                       \
-}
-
-/**
- * @brief Macro for configuring a pin to use a GPIO IN or PORT EVENT to detect any change on the pin.
- * @details Set hi_accu to true to use IN_EVENT.
- */
-#define NRFX_GPIOTE_CONFIG_IN_SENSE_TOGGLE(hi_accu) \
-{                                                   \
-    .sense = NRF_GPIOTE_POLARITY_TOGGLE,            \
-    .pull = NRF_GPIO_PIN_NOPULL,                    \
-    .is_watcher = false,                            \
-    .hi_accuracy = hi_accu,                         \
-    .skip_gpio_setup = false,                       \
-}
-
-/**
- * @brief Macro for configuring a pin to use a GPIO IN or PORT EVENT to detect low-to-high transition.
- * @details Set hi_accu to true to use IN_EVENT.
- * @note This macro prepares configuration that skips the GPIO setup.
- */
-#define NRFX_GPIOTE_RAW_CONFIG_IN_SENSE_LOTOHI(hi_accu) \
-{                                                       \
-    .sense = NRF_GPIOTE_POLARITY_LOTOHI,                \
-    .pull = NRF_GPIO_PIN_NOPULL,                        \
-    .is_watcher = false,                                \
-    .hi_accuracy = hi_accu,                             \
-    .skip_gpio_setup = true,                            \
-}
-
-/**
- * @brief Macro for configuring a pin to use a GPIO IN or PORT EVENT to detect high-to-low transition.
- * @details Set hi_accu to true to use IN_EVENT.
- * @note This macro prepares configuration that skips the GPIO setup.
- */
-#define NRFX_GPIOTE_RAW_CONFIG_IN_SENSE_HITOLO(hi_accu) \
-{                                                       \
-    .sense = NRF_GPIOTE_POLARITY_HITOLO,                \
-    .pull = NRF_GPIO_PIN_NOPULL,                        \
-    .is_watcher = false,                                \
-    .hi_accuracy = hi_accu,                             \
-    .skip_gpio_setup = true,                            \
-}
-
-/**
- * @brief Macro for configuring a pin to use a GPIO IN or PORT EVENT to detect any change on the pin.
- * @details Set hi_accu to true to use IN_EVENT.
- * @note This macro prepares configuration that skips the GPIO setup.
- */
-#define NRFX_GPIOTE_RAW_CONFIG_IN_SENSE_TOGGLE(hi_accu) \
-{                                                       \
-    .sense = NRF_GPIOTE_POLARITY_TOGGLE,                \
-    .pull = NRF_GPIO_PIN_NOPULL,                        \
-    .is_watcher = false,                                \
-    .hi_accuracy = hi_accu,                             \
-    .skip_gpio_setup = true,                            \
-}
-
-
-/** @brief Output pin configuration. */
-typedef struct
-{
-    nrf_gpiote_polarity_t action;     /**< Configuration of the pin task. */
-    nrf_gpiote_outinit_t  init_state; /**< Initial state of the output pin. */
-    bool                  task_pin;   /**< True if the pin is controlled by a GPIOTE task. */
-} nrfx_gpiote_out_config_t;
-
-/** @brief Macro for configuring a pin to use as output. GPIOTE is not used for the pin. */
-#define NRFX_GPIOTE_CONFIG_OUT_SIMPLE(init_high)                                                \
-    {                                                                                           \
-        .action     = NRF_GPIOTE_POLARITY_LOTOHI,                                               \
-        .init_state = init_high ? NRF_GPIOTE_INITIAL_VALUE_HIGH : NRF_GPIOTE_INITIAL_VALUE_LOW, \
-        .task_pin   = false,                                                                    \
-    }
-
-/**
- * @brief Macro for configuring a pin to use the GPIO OUT TASK to change the state from high to low.
- * @details The task will clear the pin. Therefore, the pin is set initially.
- */
-#define NRFX_GPIOTE_CONFIG_OUT_TASK_LOW              \
-    {                                                \
-        .action     = NRF_GPIOTE_POLARITY_HITOLO,    \
-        .init_state = NRF_GPIOTE_INITIAL_VALUE_HIGH, \
-        .task_pin   = true,                          \
-    }
-
-/**
- * @brief Macro for configuring a pin to use the GPIO OUT TASK to change the state from low to high.
- * @details The task will set the pin. Therefore, the pin is cleared initially.
- */
-#define NRFX_GPIOTE_CONFIG_OUT_TASK_HIGH            \
-    {                                               \
-        .action     = NRF_GPIOTE_POLARITY_LOTOHI,   \
-        .init_state = NRF_GPIOTE_INITIAL_VALUE_LOW, \
-        .task_pin   = true,                         \
-    }
-
-/**
- * @brief Macro for configuring a pin to use the GPIO OUT TASK to toggle the pin state.
- * @details The initial pin state must be provided.
- */
-#define NRFX_GPIOTE_CONFIG_OUT_TASK_TOGGLE(init_high)                                           \
-    {                                                                                           \
-        .action     = NRF_GPIOTE_POLARITY_TOGGLE,                                               \
-        .init_state = init_high ? NRF_GPIOTE_INITIAL_VALUE_HIGH : NRF_GPIOTE_INITIAL_VALUE_LOW, \
-        .task_pin   = true,                                                                     \
-    }
-
 #if !defined (NRFX_GPIOTE_CHANNELS_USED) && !defined(__NRFX_DOXYGEN__)
 /* Bitmask that defines GPIOTE channels that are reserved for use outside of the nrfx library. */
 #define NRFX_GPIOTE_CHANNELS_USED 0
@@ -283,14 +142,6 @@ typedef struct
 
 /** @brief Bitfield representing all GPIOTE channels available to the application. */
 #define NRFX_GPIOTE_APP_CHANNELS_MASK (NRFX_BIT_MASK(GPIOTE_CH_NUM) & ~NRFX_GPIOTE_CHANNELS_USED)
-
-/**
- * @brief Legacy pin event handler prototype.
- *
- * @param[in] pin    Pin that triggered this event.
- * @param[in] action Action that led to triggering this event.
- */
-typedef void (*nrfx_gpiote_evt_handler_t)(nrfx_gpiote_pin_t pin, nrf_gpiote_polarity_t action);
 
 /**
  * @brief Function for initializing the GPIOTE module.
@@ -463,58 +314,6 @@ void nrfx_gpiote_global_callback_set(nrfx_gpiote_interrupt_handler_t handler,
 nrfx_err_t nrfx_gpiote_channel_get(nrfx_gpiote_pin_t pin, uint8_t *p_channel);
 
 /**
- * @brief Function for initializing a GPIOTE output pin.
- * @details The output pin can be controlled by the CPU or by PPI. The initial
- * configuration specifies which mode is used. If PPI mode is used, the driver
- * attempts to allocate one of the available GPIOTE channels. If no channel is
- * available, an error is returned.
- *
- * @note This function is deprecated. Use @ref nrfx_gpiote_output_configure
- *       preceded by @ref nrfx_gpiote_channel_alloc (provided that GPIOTE task is to be utilized) instead.
- *
- * @param[in] pin      Pin.
- * @param[in] p_config Initial configuration.
- *
- * @retval NRFX_SUCCESS      Initialization was successful.
- * @retval NRFX_ERROR_BUSY   The pin is already used.
- * @retval NRFX_ERROR_NO_MEM No GPIOTE channel is available.
- */
-nrfx_err_t nrfx_gpiote_out_init(nrfx_gpiote_pin_t                pin,
-                                nrfx_gpiote_out_config_t const * p_config);
-
-/**
- * @brief Function for initializing a GPIOTE output pin with preallocated channel.
- * @details The output pin can be controlled by PPI.
- *
- * @param[in] pin      Pin.
- * @param[in] p_config Initial configuration.
- * @param[in] channel  GPIOTE channel allocated with @ref nrfx_gpiote_channel_alloc.
- *
- * @note This function is deprecated. Use @ref nrfx_gpiote_output_configure instead.
- *
- * @retval NRFX_SUCCESS             Initialization was successful.
- * @retval NRFX_ERROR_BUSY          The pin is already used.
- * @retval NRFX_ERROR_INVALID_PARAM Pin is configured to not be controlled by
-                                    the GPIOTE task and cannot be used with
-                                    preallocated channel.
-                                    Use @ref nrfx_gpiote_out_init instead.
- */
-nrfx_err_t nrfx_gpiote_out_prealloc_init(nrfx_gpiote_pin_t                pin,
-                                         nrfx_gpiote_out_config_t const * p_config,
-                                         uint8_t                          channel);
-
-/**
- * @brief Function for uninitializing a GPIOTE output pin.
- * @details The driver frees the GPIOTE channel if the output pin was using one.
- *
- * @note This function is deprecated. Use @ref nrfx_gpiote_pin_uninit,
- *       followed by @ref nrfx_gpiote_channel_free (provided that GPIOTE task was utilized) instead.
- *
- * @param[in] pin Pin.
- */
-void nrfx_gpiote_out_uninit(nrfx_gpiote_pin_t pin);
-
-/**
  * @brief Function for setting a GPIOTE output pin.
  *
  * @param[in] pin Pin.
@@ -568,7 +367,7 @@ nrf_gpiote_task_t nrfx_gpiote_out_task_get(nrfx_gpiote_pin_t pin);
  *
  * @return Address of OUT task.
  */
-uint32_t nrfx_gpiote_out_task_addr_get(nrfx_gpiote_pin_t pin);
+uint32_t nrfx_gpiote_out_task_address_get(nrfx_gpiote_pin_t pin);
 
 #if defined(GPIOTE_FEATURE_SET_PRESENT) || defined(__NRFX_DOXYGEN__)
 /**
@@ -590,7 +389,7 @@ nrf_gpiote_task_t nrfx_gpiote_set_task_get(nrfx_gpiote_pin_t pin);
  *
  * @return Address of SET task.
  */
-uint32_t nrfx_gpiote_set_task_addr_get(nrfx_gpiote_pin_t pin);
+uint32_t nrfx_gpiote_set_task_address_get(nrfx_gpiote_pin_t pin);
 #endif // defined(GPIOTE_FEATURE_SET_PRESENT) || defined(__NRFX_DOXYGEN__)
 
 #if defined(GPIOTE_FEATURE_CLR_PRESENT) || defined(__NRFX_DOXYGEN__)
@@ -613,96 +412,8 @@ nrf_gpiote_task_t nrfx_gpiote_clr_task_get(nrfx_gpiote_pin_t pin);
  *
  * @return Address of CLR task.
  */
-uint32_t nrfx_gpiote_clr_task_addr_get(nrfx_gpiote_pin_t pin);
+uint32_t nrfx_gpiote_clr_task_address_get(nrfx_gpiote_pin_t pin);
 #endif // defined(GPIOTE_FEATURE_CLR_PRESENT) || defined(__NRFX_DOXYGEN__)
-
-/**
- * @brief Function for initializing a GPIOTE input pin.
- * @details The input pin can act in two ways:
- * - lower accuracy but low power (high frequency clock not needed)
- * - higher accuracy (high frequency clock required)
- *
- * The initial configuration specifies which mode is used.
- * If high-accuracy mode is used, the driver attempts to allocate one
- * of the available GPIOTE channels. If no channel is
- * available, an error is returned.
- * In low accuracy mode SENSE feature is used. In this case, only one active pin
- * can be detected at a time. It can be worked around by setting all of the used
- * low accuracy pins to toggle mode.
- * For more information about SENSE functionality, refer to Product Specification.
- *
- * @note This function is deprecated. Use @ref nrfx_gpiote_input_configure
- *       preceded by @ref nrfx_gpiote_channel_alloc (provided that IN event is to be utilized) instead.
- *
- * @param[in] pin         Pin.
- * @param[in] p_config    Initial configuration.
- * @param[in] evt_handler User function to be called when the configured transition occurs.
- *
- * @retval NRFX_SUCCESS      Initialization was successful.
- * @retval NRFX_ERROR_BUSY   The pin is already used.
- * @retval NRFX_ERROR_NO_MEM No GPIOTE channel is available.
- */
-nrfx_err_t nrfx_gpiote_in_init(nrfx_gpiote_pin_t               pin,
-                               nrfx_gpiote_in_config_t const * p_config,
-                               nrfx_gpiote_evt_handler_t       evt_handler);
-
-/**
- * @brief Function for initializing a GPIOTE input pin with preallocated channel.
- * @details The input pin can act in higher accuracy (high frequency clock required)
- * mode.
- *
- * @param[in] pin         Pin.
- * @param[in] p_config    Initial configuration.
- * @param[in] channel     GPIOTE channel allocated with @ref nrfx_gpiote_channel_alloc.
- * @param[in] evt_handler User function to be called when the configured transition occurs.
- *
- * @note This function is deprecated. Use @ref nrfx_gpiote_input_configure instead.
- *
- * @retval NRFX_SUCCESS             Initialization was successful.
- * @retval NRFX_ERROR_BUSY          The pin is already used.
- * @retval NRFX_ERROR_INVALID_PARAM Pin is configured to not be controlled by
-                                    the GPIOTE task and cannot be used with
-                                    preallocated channel.
-                                    Use @ref nrfx_gpiote_in_init instead.
- */
-nrfx_err_t nrfx_gpiote_in_prealloc_init(nrfx_gpiote_pin_t               pin,
-                                        nrfx_gpiote_in_config_t const * p_config,
-                                        uint8_t                         channel,
-                                        nrfx_gpiote_evt_handler_t       evt_handler);
-
-/**
- * @brief Function for uninitializing a GPIOTE input pin.
- * @details The driver frees the GPIOTE channel if the input pin was using one.
- *
- * @note This function is deprecated. Use @ref nrfx_gpiote_pin_uninit,
- *       followed by @ref nrfx_gpiote_channel_free (provided that IN event was utilized) instead.
- *
- * @param[in] pin Pin.
- */
-void nrfx_gpiote_in_uninit(nrfx_gpiote_pin_t pin);
-
-/**
- * @brief Function for enabling sensing of a GPIOTE input pin.
- *
- * @details If the input pin is configured as high-accuracy pin, the function
- * enables an IN_EVENT. Otherwise, the function enables the GPIO sense mechanism.
- * The PORT event is shared between multiple pins, therefore the interrupt is always enabled.
- *
- * @note This function is deprecated. Use @ref nrfx_gpiote_trigger_enable instead.
- *
- * @param[in] pin        Pin.
- * @param[in] int_enable True to enable the interrupt. Always valid for a high-accuracy pin.
- */
-NRFX_STATIC_INLINE void nrfx_gpiote_in_event_enable(nrfx_gpiote_pin_t pin, bool int_enable);
-
-/**
- * @brief Function for disabling a GPIOTE input pin.
- *
- * @note This function is deprecated. Use @ref nrfx_gpiote_trigger_disable instead.
- *
- * @param[in] pin Pin.
- */
-NRFX_STATIC_INLINE void nrfx_gpiote_in_event_disable(nrfx_gpiote_pin_t pin);
 
 /**
  * @brief Function for checking if a GPIOTE input pin is set.
@@ -736,7 +447,7 @@ nrf_gpiote_event_t nrfx_gpiote_in_event_get(nrfx_gpiote_pin_t pin);
  *
  * @return Address of the specified input pin event.
  */
-uint32_t nrfx_gpiote_in_event_addr_get(nrfx_gpiote_pin_t pin);
+uint32_t nrfx_gpiote_in_event_address_get(nrfx_gpiote_pin_t pin);
 
 /**
  * @brief Function for forcing a specific state on the pin configured as task.
@@ -792,25 +503,15 @@ NRFX_STATIC_INLINE nrf_gpiote_latency_t nrfx_gpiote_latency_get(void);
 
 #ifndef NRFX_DECLARE_ONLY
 
-NRFX_STATIC_INLINE void nrfx_gpiote_in_event_enable(nrfx_gpiote_pin_t pin, bool int_enable)
-{
-    nrfx_gpiote_trigger_enable(pin, int_enable);
-}
-
-NRFX_STATIC_INLINE void nrfx_gpiote_in_event_disable(nrfx_gpiote_pin_t pin)
-{
-    nrfx_gpiote_trigger_disable(pin);
-}
-
 #if NRF_GPIOTE_HAS_LATENCY
 NRFX_STATIC_INLINE void nrfx_gpiote_latency_set(nrf_gpiote_latency_t latency)
 {
-    nrf_gpiote_latency_set(NRF_GPIOTE, latency);
+    nrfy_gpiote_latency_set(NRF_GPIOTE, latency);
 }
 
 NRFX_STATIC_INLINE nrf_gpiote_latency_t nrfx_gpiote_latency_get(void)
 {
-    return nrf_gpiote_latency_get(NRF_GPIOTE);
+    return nrfy_gpiote_latency_get(NRF_GPIOTE);
 }
 #endif // NRF_GPIOTE_HAS_LATENCY
 

--- a/nrfx/drivers/include/nrfx_ipc.h
+++ b/nrfx/drivers/include/nrfx_ipc.h
@@ -47,7 +47,6 @@ extern "C" {
  * @brief   Interprocessor Communication (IPC) peripheral driver.
  */
 
-#if NRFX_CHECK(NRFX_CONFIG_API_VER_2_10) || defined(__NRFX_DOXYGEN__)
 /**
  * @brief IPC driver handler type.
  *
@@ -55,17 +54,6 @@ extern "C" {
  * @param[in] p_context Context passed to the interrupt handler, set on initialization.
  */
 typedef void (*nrfx_ipc_handler_t)(uint8_t event_idx, void * p_context);
-#elif NRFX_CHECK(NRFX_CONFIG_API_VER_2_9)
-/**
- * @brief IPC driver handler type.
- *
- * @note This function is deprecated. Use @ref NRFX_CONFIG_API_VER_2_10 variant instead.
- *
- * @param[in] event_mask Bitmask with events that triggered the interrupt.
- * @param[in] p_context  Context passed to the interrupt handler, set on initialization.
- */
-typedef void (*nrfx_ipc_handler_t)(uint32_t event_mask, void * p_context);
-#endif
 
 /** @brief IPC configuration structure. */
 typedef struct
@@ -112,7 +100,6 @@ NRFX_STATIC_INLINE void nrfx_ipc_signal(uint8_t send_index);
  */
 NRFX_STATIC_INLINE void nrfx_ipc_gpmem_set(uint8_t mem_index, uint32_t data);
 
-#if NRFX_CHECK(NRFX_CONFIG_API_VER_2_10) || defined(__NRFX_DOXYGEN__)
 /**
  * @brief Function for getting data from the general purpose memory register.
  *
@@ -121,18 +108,6 @@ NRFX_STATIC_INLINE void nrfx_ipc_gpmem_set(uint8_t mem_index, uint32_t data);
  * @return Saved data.
  */
 NRFX_STATIC_INLINE uint32_t nrfx_ipc_gpmem_get(uint8_t mem_index);
-#elif NRFX_CHECK(NRFX_CONFIG_API_VER_2_9)
-/**
- * @brief Function for getting data from the GPMEM register in the IPC peripheral.
- *
- * @note This function is deprecated. Use @ref nrfx_ipc_gpmem_get instead.
- *
- * @param mem_index Index of the memory cell.
- *
- * @return Saved data.
- */
-NRFX_STATIC_INLINE uint32_t nrfx_ipc_mem_get(uint8_t mem_index);
-#endif
 
 /** @brief Function for uninitializing the IPC module. */
 void nrfx_ipc_uninit(void);
@@ -208,11 +183,7 @@ NRFX_STATIC_INLINE void nrfx_ipc_gpmem_set(uint8_t mem_index, uint32_t data)
     nrf_ipc_gpmem_set(NRF_IPC, mem_index, data);
 }
 
-#if NRFX_CHECK(NRFX_CONFIG_API_VER_2_10)
 NRFX_STATIC_INLINE uint32_t nrfx_ipc_gpmem_get(uint8_t mem_index)
-#elif NRFX_CHECK(NRFX_CONFIG_API_VER_2_9)
-NRFX_STATIC_INLINE uint32_t nrfx_ipc_mem_get(uint8_t mem_index)
-#endif
 {
     NRFX_ASSERT(mem_index < NRFX_ARRAY_SIZE(NRF_IPC->GPMEM));
     return nrf_ipc_gpmem_get(NRF_IPC, mem_index);

--- a/nrfx/drivers/include/nrfx_lpcomp.h
+++ b/nrfx/drivers/include/nrfx_lpcomp.h
@@ -35,7 +35,7 @@
 #define NRFX_LPCOMP_H__
 
 #include <nrfx.h>
-#include <hal/nrf_lpcomp.h>
+#include <haly/nrfy_lpcomp.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -57,9 +57,9 @@ typedef void (* nrfx_lpcomp_event_handler_t)(nrf_lpcomp_event_t event);
 /** @brief LPCOMP configuration. */
 typedef struct
 {
-    nrf_lpcomp_config_t hal;                /**< LPCOMP HAL configuration. */
-    nrf_lpcomp_input_t  input;              /**< Input to be monitored. */
-    uint8_t             interrupt_priority; /**< LPCOMP interrupt priority. */
+    nrf_lpcomp_config_t config;             ///< Peripheral configuration.
+    nrf_lpcomp_input_t  input;              ///< Input to be monitored.
+    uint8_t             interrupt_priority; ///< LPCOMP interrupt priority.
 } nrfx_lpcomp_config_t;
 
 /**
@@ -72,24 +72,17 @@ typedef struct
  *
  * @param[in] _input Comparator input pin.
  */
-#if defined(LPCOMP_FEATURE_HYST_PRESENT)
-#define NRFX_LPCOMP_DEFAULT_CONFIG(_input)                         \
-{                                                                  \
-    .hal    = {  NRF_LPCOMP_REF_SUPPLY_4_8,                        \
-                 NRF_LPCOMP_DETECT_CROSS,                          \
-                 NRF_LPCOMP_HYST_NOHYST },                         \
-    .input  = (nrf_lpcomp_input_t)_input,                          \
-    .interrupt_priority = NRFX_LPCOMP_DEFAULT_CONFIG_IRQ_PRIORITY  \
+#define NRFX_LPCOMP_DEFAULT_CONFIG(_input)                                                   \
+{                                                                                            \
+    .config =                                                                                \
+    {                                                                                        \
+        .reference = NRF_LPCOMP_REF_SUPPLY_4_8,                                              \
+        .detection = NRF_LPCOMP_DETECT_CROSS,                                                \
+        NRFX_COND_CODE_1(LPCOMP_FEATURE_HYST_PRESENT, (.hyst = NRF_LPCOMP_HYST_NOHYST,), ()) \
+    },                                                                                       \
+    .input = (nrf_lpcomp_input_t)_input,                                                     \
+    .interrupt_priority = NRFX_LPCOMP_DEFAULT_CONFIG_IRQ_PRIORITY                            \
 }
-#else
-#define NRFX_LPCOMP_DEFAULT_CONFIG(_input)                         \
-{                                                                  \
-    .hal    = {  NRF_LPCOMP_REF_SUPPLY_4_8,                        \
-                 NRF_LPCOMP_DETECT_CROSS },                        \
-    .input  = (nrf_lpcomp_input_t)_input,                          \
-    .interrupt_priority = NRFX_LPCOMP_DEFAULT_CONFIG_IRQ_PRIORITY  \
-}
-#endif
 
 /**
  * @brief Function for initializing the LPCOMP driver.

--- a/nrfx/drivers/include/nrfx_ppi.h
+++ b/nrfx/drivers/include/nrfx_ppi.h
@@ -282,7 +282,7 @@ nrfx_err_t nrfx_ppi_group_disable(nrf_ppi_channel_group_t group);
  *
  * @return Task address.
  */
-NRFX_STATIC_INLINE uint32_t nrfx_ppi_task_addr_get(nrf_ppi_task_t task);
+NRFX_STATIC_INLINE uint32_t nrfx_ppi_task_address_get(nrf_ppi_task_t task);
 
 /**
  * @brief Function for getting the address of the enable task of a PPI group.
@@ -291,7 +291,7 @@ NRFX_STATIC_INLINE uint32_t nrfx_ppi_task_addr_get(nrf_ppi_task_t task);
  *
  * @return Task address.
  */
-NRFX_STATIC_INLINE uint32_t nrfx_ppi_task_addr_group_enable_get(nrf_ppi_channel_group_t group);
+NRFX_STATIC_INLINE uint32_t nrfx_ppi_task_group_enable_address_get(nrf_ppi_channel_group_t group);
 
 /**
  * @brief Function for getting the address of the enable task of a PPI group.
@@ -300,7 +300,7 @@ NRFX_STATIC_INLINE uint32_t nrfx_ppi_task_addr_group_enable_get(nrf_ppi_channel_
  *
  * @return Task address.
  */
-NRFX_STATIC_INLINE uint32_t nrfx_ppi_task_addr_group_disable_get(nrf_ppi_channel_group_t group);
+NRFX_STATIC_INLINE uint32_t nrfx_ppi_task_group_disable_address_get(nrf_ppi_channel_group_t group);
 
 #ifndef NRFX_DECLARE_ONLY
 NRFX_STATIC_INLINE uint32_t nrfx_ppi_channel_to_mask(nrf_ppi_channel_t channel)
@@ -325,17 +325,17 @@ NRFX_STATIC_INLINE nrfx_err_t nrfx_ppi_group_clear(nrf_ppi_channel_group_t group
     return nrfx_ppi_channels_remove_from_group(NRFX_PPI_ALL_APP_CHANNELS_MASK, group);
 }
 
-NRFX_STATIC_INLINE uint32_t nrfx_ppi_task_addr_get(nrf_ppi_task_t task)
+NRFX_STATIC_INLINE uint32_t nrfx_ppi_task_address_get(nrf_ppi_task_t task)
 {
     return nrf_ppi_task_address_get(NRF_PPI, task);
 }
 
-NRFX_STATIC_INLINE uint32_t nrfx_ppi_task_addr_group_enable_get(nrf_ppi_channel_group_t group)
+NRFX_STATIC_INLINE uint32_t nrfx_ppi_task_group_enable_address_get(nrf_ppi_channel_group_t group)
 {
     return nrf_ppi_task_group_enable_address_get(NRF_PPI, group);
 }
 
-NRFX_STATIC_INLINE uint32_t nrfx_ppi_task_addr_group_disable_get(nrf_ppi_channel_group_t group)
+NRFX_STATIC_INLINE uint32_t nrfx_ppi_task_group_disable_address_get(nrf_ppi_channel_group_t group)
 {
     return nrf_ppi_task_group_disable_address_get(NRF_PPI, group);
 }

--- a/nrfx/drivers/include/nrfx_pwm.h
+++ b/nrfx/drivers/include/nrfx_pwm.h
@@ -35,7 +35,7 @@
 #define NRFX_PWM_H__
 
 #include <nrfx.h>
-#include <hal/nrf_pwm.h>
+#include <haly/nrfy_pwm.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -51,71 +51,51 @@ extern "C" {
 /** @brief PWM driver instance data structure. */
 typedef struct
 {
-    NRF_PWM_Type * p_registers;  ///< Pointer to the structure with PWM peripheral instance registers.
-    uint8_t        drv_inst_idx; ///< Index of the driver instance. For internal use only.
+    NRF_PWM_Type * p_reg;       ///< Pointer to the structure with PWM peripheral instance registers.
+    uint8_t        instance_id; ///< Index of the driver instance. For internal use only.
 } nrfx_pwm_t;
 
 /** @brief Macro for creating a PWM driver instance. */
-#define NRFX_PWM_INSTANCE(id)                               \
-{                                                           \
-    .p_registers  = NRFX_CONCAT_2(NRF_PWM, id),             \
-    .drv_inst_idx = NRFX_CONCAT_3(NRFX_PWM, id, _INST_IDX), \
+#define NRFX_PWM_INSTANCE(id)                              \
+{                                                          \
+    .p_reg       = NRFX_CONCAT_2(NRF_PWM, id),             \
+    .instance_id = NRFX_CONCAT_3(NRFX_PWM, id, _INST_IDX), \
 }
 
 #ifndef __NRFX_DOXYGEN__
 enum {
-#if NRFX_CHECK(NRFX_PWM0_ENABLED)
-    NRFX_PWM0_INST_IDX,
-#endif
-#if NRFX_CHECK(NRFX_PWM1_ENABLED)
-    NRFX_PWM1_INST_IDX,
-#endif
-#if NRFX_CHECK(NRFX_PWM2_ENABLED)
-    NRFX_PWM2_INST_IDX,
-#endif
-#if NRFX_CHECK(NRFX_PWM3_ENABLED)
-    NRFX_PWM3_INST_IDX,
-#endif
+    /* List all enabled driver instances (in the format NRFX_\<instance_name\>_INST_IDX). */
+    NRFX_INSTANCE_ENUM_LIST(PWM)
     NRFX_PWM_ENABLED_COUNT
 };
 #endif
 
-/**
- * @brief This value can be provided instead of a pin number for any channel
- *        to specify that its output is not used and therefore does not need
- *        to be connected to a pin.
- */
-#define NRFX_PWM_PIN_NOT_USED    0xFF
-
-/** @brief This value can be added to a pin number to invert its polarity (set idle state = 1). */
-#define NRFX_PWM_PIN_INVERTED    0x80
-
 /** @brief PWM driver configuration structure. */
 typedef struct
 {
-    uint8_t output_pins[NRF_PWM_CHANNEL_COUNT]; ///< Pin numbers for individual output channels (optional).
-                                                /**< Use @ref NRFX_PWM_PIN_NOT_USED
-                                                 *   if a given output channel is not needed. */
-    uint8_t            irq_priority;  ///< Interrupt priority.
-    nrf_pwm_clk_t      base_clock;    ///< Base clock frequency.
-    nrf_pwm_mode_t     count_mode;    ///< Operating mode of the pulse generator counter.
-    uint16_t           top_value;     ///< Value up to which the pulse generator counter counts.
-    nrf_pwm_dec_load_t load_mode;     ///< Mode of loading sequence data from RAM.
-    nrf_pwm_dec_step_t step_mode;     ///< Mode of advancing the active sequence.
-    bool               skip_gpio_cfg; ///< Skip GPIO configuration of pins.
-                                      /**< When set to true, the driver does not modify
-                                       *   any GPIO parameters of the used pins. Those
-                                       *   parameters are supposed to be configured
-                                       *   externally before the driver is initialized. */
-    bool               skip_psel_cfg; ///< Skip pin selection configuration.
-                                      /**< When set to true, the driver does not modify
-                                       *   pin select registers in the peripheral.
-                                       *   Those registers are supposed to be set up
-                                       *   externally before the driver is initialized.
-                                       *   @note When both GPIO configuration and pin
-                                       *   selection are to be skipped, the structure
-                                       *   fields that specify pins can be omitted,
-                                       *   as they are ignored anyway. */
+    uint32_t           output_pins[NRF_PWM_CHANNEL_COUNT];  ///< Pin numbers for individual output channels (optional).
+                                                            /**< Use @ref NRF_PWM_PIN_NOT_CONNECTED
+                                                             *   if a given output channel is not needed. */
+    bool               pin_inverted[NRF_PWM_CHANNEL_COUNT]; ///< Inverted pin polarity (idle state = 1).
+    uint8_t            irq_priority;                        ///< Interrupt priority.
+    nrf_pwm_clk_t      base_clock;                          ///< Base clock frequency.
+    nrf_pwm_mode_t     count_mode;                          ///< Operating mode of the pulse generator counter.
+    uint16_t           top_value;                           ///< Value up to which the pulse generator counter counts.
+    nrf_pwm_dec_load_t load_mode;                           ///< Mode of loading sequence data from RAM.
+    nrf_pwm_dec_step_t step_mode;                           ///< Mode of advancing the active sequence.
+    bool               skip_gpio_cfg;                       ///< Skip the GPIO configuration
+                                                            /**< When this flag is set, the user is responsible for
+                                                             *   providing the proper configuration of the output pins,
+                                                             *   as the driver does not touch it at all. */
+    bool               skip_psel_cfg;                       ///< Skip pin selection configuration.
+                                                            /**< When set to true, the driver does not modify
+                                                             *   pin select registers in the peripheral.
+                                                             *   Those registers are supposed to be set up
+                                                             *   externally before the driver is initialized.
+                                                             *   @note When both GPIO configuration and pin
+                                                             *   selection are to be skipped, the structure
+                                                             *   fields that specify pins can be omitted,
+                                                             *   as they are ignored anyway. */
 } nrfx_pwm_config_t;
 
 /**
@@ -135,11 +115,18 @@ typedef struct
  */
 #define NRFX_PWM_DEFAULT_CONFIG(_out_0, _out_1, _out_2, _out_3) \
 {                                                               \
-    .output_pins   = { _out_0,                                  \
-                       _out_1,                                  \
-                       _out_2,                                  \
-                       _out_3                                   \
-                     },                                         \
+    .output_pins   = {                                          \
+        _out_0,                                                 \
+        _out_1,                                                 \
+        _out_2,                                                 \
+        _out_3,                                                 \
+    },                                                          \
+    .pin_inverted  = {                                          \
+        false,                                                  \
+        false,                                                  \
+        false,                                                  \
+        false,                                                  \
+    },                                                          \
     .irq_priority  = NRFX_PWM_DEFAULT_CONFIG_IRQ_PRIORITY,      \
     .base_clock    = NRF_PWM_CLK_1MHz,                          \
     .count_mode    = NRF_PWM_MODE_UP,                           \
@@ -214,6 +201,8 @@ typedef void (* nrfx_pwm_handler_t)(nrfx_pwm_evt_type_t event_type, void * p_con
  *
  * @param[in] p_instance Pointer to the driver instance structure.
  * @param[in] p_config   Pointer to the structure with the initial configuration.
+ *                       NULL if configuration is to be skipped and will be done later
+ *                       using @ref nrfx_pwm_reconfigure.
  * @param[in] handler    Event handler provided by the user. If NULL is passed
  *                       instead, event notifications are not done and PWM
  *                       interrupts are disabled.
@@ -226,6 +215,18 @@ nrfx_err_t nrfx_pwm_init(nrfx_pwm_t const *        p_instance,
                          nrfx_pwm_config_t const * p_config,
                          nrfx_pwm_handler_t        handler,
                          void *                    p_context);
+
+/**
+ * @brief Function for reconfiguring the PWM driver.
+ *
+ * @param[in] p_instance Pointer to the driver instance structure.
+ * @param[in] p_config   Pointer to the structure with the configuration.
+ *
+ * @retval NRFX_SUCCESS             Reconfiguration was successful.
+ * @retval NRFX_ERROR_BUSY          The driver is during playback.
+ * @retval NRFX_ERROR_INVALID_STATE The driver is uninitialized.
+ */
+nrfx_err_t nrfx_pwm_reconfigure(nrfx_pwm_t const * p_instance, nrfx_pwm_config_t const * p_config);
 
 /**
  * @brief Function for uninitializing the PWM driver.
@@ -322,7 +323,7 @@ NRFX_STATIC_INLINE void nrfx_pwm_step(nrfx_pwm_t const * p_instance);
  * @note This function can be instructed to wait until the playback is stopped
  *       (by setting @p wait_until_stopped to true). Depending on
  *       the length of the PMW period, this might take a significant amount of
- *       time. Alternatively, the @ref nrfx_pwm_is_stopped function can be
+ *       time. Alternatively, the @ref nrfx_pwm_stopped_check function can be
  *       used to poll the status, or the @ref NRFX_PWM_EVT_STOPPED event can
  *       be used to get the notification when the playback is stopped, provided
  *       the event handler is defined.
@@ -344,7 +345,7 @@ bool nrfx_pwm_stop(nrfx_pwm_t const * p_instance, bool wait_until_stopped);
  * @retval true  The PWM peripheral is stopped.
  * @retval false The PWM peripheral is not stopped.
  */
-bool nrfx_pwm_is_stopped(nrfx_pwm_t const * p_instance);
+bool nrfx_pwm_stopped_check(nrfx_pwm_t const * p_instance);
 
 /**
  * @brief Function for updating the sequence data during playback.
@@ -356,54 +357,6 @@ bool nrfx_pwm_is_stopped(nrfx_pwm_t const * p_instance);
 NRFX_STATIC_INLINE void nrfx_pwm_sequence_update(nrfx_pwm_t const *         p_instance,
                                                  uint8_t                    seq_id,
                                                  nrf_pwm_sequence_t const * p_sequence);
-
-/**
- * @brief Function for updating the pointer to the duty cycle values
- *        in the specified sequence during playback.
- *
- * @param[in] p_instance Pointer to the driver instance structure.
- * @param[in] seq_id     Identifier of the sequence (0 or 1).
- * @param[in] values     New pointer to the duty cycle values.
- */
-NRFX_STATIC_INLINE void nrfx_pwm_sequence_values_update(nrfx_pwm_t const * p_instance,
-                                                        uint8_t            seq_id,
-                                                        nrf_pwm_values_t   values);
-
-/**
- * @brief Function for updating the number of duty cycle values
- *        in the specified sequence during playback.
- *
- * @param[in] p_instance Pointer to the driver instance structure.
- * @param[in] seq_id     Identifier of the sequence (0 or 1).
- * @param[in] length     New number of the duty cycle values.
- */
-NRFX_STATIC_INLINE void nrfx_pwm_sequence_length_update(nrfx_pwm_t const * p_instance,
-                                                        uint8_t            seq_id,
-                                                        uint16_t           length);
-
-/**
- * @brief Function for updating the number of repeats for duty cycle values
- *        in the specified sequence during playback.
- *
- * @param[in] p_instance Pointer to the driver instance structure.
- * @param[in] seq_id     Identifier of the sequence (0 or 1).
- * @param[in] repeats    New number of repeats.
- */
-NRFX_STATIC_INLINE void nrfx_pwm_sequence_repeats_update(nrfx_pwm_t const * p_instance,
-                                                         uint8_t            seq_id,
-                                                         uint32_t           repeats);
-
-/**
- * @brief Function for updating the additional delay after the specified
- *        sequence during playback.
- *
- * @param[in] p_instance Pointer to the driver instance structure.
- * @param[in] seq_id     Identifier of the sequence (0 or 1).
- * @param[in] end_delay  New end delay value (in PWM periods).
- */
-NRFX_STATIC_INLINE void nrfx_pwm_sequence_end_delay_update(nrfx_pwm_t const * p_instance,
-                                                           uint8_t            seq_id,
-                                                           uint32_t           end_delay);
 
 /**
  * @brief Function for returning the address of a specified PWM task that can
@@ -432,54 +385,26 @@ NRFX_STATIC_INLINE uint32_t nrfx_pwm_event_address_get(nrfx_pwm_t const * p_inst
 #ifndef NRFX_DECLARE_ONLY
 NRFX_STATIC_INLINE void nrfx_pwm_step(nrfx_pwm_t const * p_instance)
 {
-    nrf_pwm_task_trigger(p_instance->p_registers, NRF_PWM_TASK_NEXTSTEP);
+    nrfy_pwm_task_trigger(p_instance->p_reg, NRF_PWM_TASK_NEXTSTEP);
 }
 
 NRFX_STATIC_INLINE void nrfx_pwm_sequence_update(nrfx_pwm_t const *         p_instance,
                                                  uint8_t                    seq_id,
                                                  nrf_pwm_sequence_t const * p_sequence)
 {
-    nrf_pwm_sequence_set(p_instance->p_registers, seq_id, p_sequence);
-}
-
-NRFX_STATIC_INLINE void nrfx_pwm_sequence_values_update(nrfx_pwm_t const * p_instance,
-                                                        uint8_t            seq_id,
-                                                        nrf_pwm_values_t   values)
-{
-    nrf_pwm_seq_ptr_set(p_instance->p_registers, seq_id, values.p_raw);
-}
-
-NRFX_STATIC_INLINE void nrfx_pwm_sequence_length_update(nrfx_pwm_t const * p_instance,
-                                                        uint8_t            seq_id,
-                                                        uint16_t           length)
-{
-    nrf_pwm_seq_cnt_set(p_instance->p_registers, seq_id, length);
-}
-
-NRFX_STATIC_INLINE void nrfx_pwm_sequence_repeats_update(nrfx_pwm_t const * p_instance,
-                                                         uint8_t            seq_id,
-                                                         uint32_t           repeats)
-{
-    nrf_pwm_seq_refresh_set(p_instance->p_registers, seq_id, repeats);
-}
-
-NRFX_STATIC_INLINE void nrfx_pwm_sequence_end_delay_update(nrfx_pwm_t const * p_instance,
-                                                           uint8_t            seq_id,
-                                                           uint32_t           end_delay)
-{
-    nrf_pwm_seq_end_delay_set(p_instance->p_registers, seq_id, end_delay);
+    nrfy_pwm_sequence_set(p_instance->p_reg, seq_id, p_sequence);
 }
 
 NRFX_STATIC_INLINE uint32_t nrfx_pwm_task_address_get(nrfx_pwm_t const * p_instance,
                                                       nrf_pwm_task_t     task)
 {
-    return nrf_pwm_task_address_get(p_instance->p_registers, task);
+    return nrfy_pwm_task_address_get(p_instance->p_reg, task);
 }
 
 NRFX_STATIC_INLINE uint32_t nrfx_pwm_event_address_get(nrfx_pwm_t const * p_instance,
                                                        nrf_pwm_event_t    event)
 {
-    return nrf_pwm_event_address_get(p_instance->p_registers, event);
+    return nrfy_pwm_event_address_get(p_instance->p_reg, event);
 }
 #endif // NRFX_DECLARE_ONLY
 
@@ -494,11 +419,20 @@ NRFX_STATIC_INLINE uint32_t nrfx_pwm_event_address_get(nrfx_pwm_t const * p_inst
 
 /** @} */
 
-
-void nrfx_pwm_0_irq_handler(void);
-void nrfx_pwm_1_irq_handler(void);
-void nrfx_pwm_2_irq_handler(void);
-void nrfx_pwm_3_irq_handler(void);
+/*
+ * Declare interrupt handlers for all enabled driver instances in the following format:
+ * nrfx_\<periph_name\>_\<idx\>_irq_handler (for example, nrfx_pwm_0_irq_handler).
+ *
+ * A specific interrupt handler for the driver instance can be retrieved by using
+ * the NRFX_PWM_INST_HANDLER_GET macro.
+ *
+ * Here is a sample of using the NRFX_PWM_INST_HANDLER_GET macro to directly map
+ * an interrupt handler in a Zephyr application:
+ *
+ * IRQ_DIRECT_CONNECT(NRFX_IRQ_NUMBER_GET(NRF_PWM_INST_GET(\<instance_index\>)), \<priority\>,
+ *                    NRFX_PWM_INST_HANDLER_GET(\<instance_index\>), 0);
+ */
+NRFX_INSTANCE_IRQ_HANDLERS_DECLARE(PWM, pwm)
 
 
 #ifdef __cplusplus

--- a/nrfx/drivers/include/nrfx_qdec.h
+++ b/nrfx/drivers/include/nrfx_qdec.h
@@ -35,10 +35,15 @@
 #define NRFX_QDEC_H__
 
 #include <nrfx.h>
-#include <hal/nrf_qdec.h>
+#include <haly/nrfy_qdec.h>
 
 #ifdef __cplusplus
 extern "C" {
+#endif
+
+/* On devices with single instance (with no id) use instance 0. */
+#if defined(NRF_QDEC) && defined(NRFX_QDEC_ENABLED) && !defined(NRFX_QDEC0_ENABLED)
+#define NRFX_QDEC0_ENABLED 1
 #endif
 
 /**
@@ -48,7 +53,14 @@ extern "C" {
  * @brief   Quadrature Decoder (QDEC) peripheral driver.
  */
 
-/** @brief QDEC configuration structure. */
+/** @brief Data structure of the Quadrature Decoder (QDEC) driver instance. */
+typedef struct
+{
+    NRF_QDEC_Type * p_reg;        ///< Pointer to a structure with QDEC registers.
+    uint8_t         drv_inst_idx; ///< Index of the driver instance. For internal use only.
+} nrfx_qdec_t;
+
+/** @brief QDEC driver instance configuration structure. */
 typedef struct
 {
     nrf_qdec_reportper_t reportper;          ///< Report period in samples.
@@ -60,6 +72,7 @@ typedef struct
     nrf_qdec_ledpol_t    ledpol;             ///< Active LED polarity.
     bool                 dbfen;              ///< State of debouncing filter.
     bool                 sample_inten;       ///< Enabling sample ready interrupt.
+    bool                 reportper_inten;    ///< Enabling report ready interrupt.
     uint8_t              interrupt_priority; ///< QDEC interrupt priority.
     bool                 skip_gpio_cfg;      ///< Skip GPIO configuration of pins.
                                              /**< When set to true, the driver does not modify
@@ -77,6 +90,21 @@ typedef struct
                                               *   as they are ignored anyway. */
 } nrfx_qdec_config_t;
 
+#ifndef __NRFX_DOXYGEN__
+enum {
+    /* List all enabled driver instances (in the format NRFX_\<instance_name\>_INST_IDX). */
+    NRFX_INSTANCE_ENUM_LIST(QDEC)
+    NRFX_QDEC_ENABLED_COUNT
+};
+#endif
+
+/** @brief Macro for creating an instance of the QDEC driver. */
+#define NRFX_QDEC_INSTANCE(id)                               \
+{                                                            \
+    .p_reg        = NRF_QDEC##id,                            \
+    .drv_inst_idx = NRFX_CONCAT_3(NRFX_QDEC, id, _INST_IDX), \
+}
+
 /**
  * @brief QDEC driver default configuration.
  *
@@ -92,19 +120,20 @@ typedef struct
  * @param[in] _pin_b   Pin for B encoder channel input.
  * @param[in] _pin_led Pin for LED output.
  */
-#define NRFX_QDEC_DEFAULT_CONFIG(_pin_a, _pin_b, _pin_led)           \
-    {                                                                \
-        .reportper          = NRF_QDEC_REPORTPER_10,                 \
-        .sampleper          = NRF_QDEC_SAMPLEPER_16384us,            \
-        .psela              = _pin_a,                                \
-        .pselb              = _pin_b,                                \
-        .pselled            = _pin_led,                              \
-        .ledpre             = 500,                                   \
-        .ledpol             = NRF_QDEC_LEPOL_ACTIVE_HIGH,            \
-        .dbfen              = NRF_QDEC_DBFEN_DISABLE,                \
-        .sample_inten       = false,                                 \
-        .interrupt_priority = NRFX_QDEC_DEFAULT_CONFIG_IRQ_PRIORITY  \
-    }
+#define NRFX_QDEC_DEFAULT_CONFIG(_pin_a, _pin_b, _pin_led)       \
+{                                                                \
+    .reportper          = NRF_QDEC_REPORTPER_10,                 \
+    .sampleper          = NRF_QDEC_SAMPLEPER_16384US,            \
+    .psela              = _pin_a,                                \
+    .pselb              = _pin_b,                                \
+    .pselled            = _pin_led,                              \
+    .ledpre             = 500,                                   \
+    .ledpol             = NRF_QDEC_LEPOL_ACTIVE_HIGH,            \
+    .dbfen              = NRF_QDEC_DBFEN_DISABLE,                \
+    .sample_inten       = false,                                 \
+    .reportper_inten    = true,                                  \
+    .interrupt_priority = NRFX_QDEC_DEFAULT_CONFIG_IRQ_PRIORITY, \
+}
 
 /** @brief QDEC sample event data. */
 typedef struct
@@ -115,8 +144,8 @@ typedef struct
 /** @brief QDEC report event data. */
 typedef struct
 {
-    int16_t acc;     /**< Accumulated transitions. */
-    uint16_t accdbl; /**< Accumulated double transitions. */
+    int32_t  acc;    /**< Accumulated transitions. */
+    uint32_t accdbl; /**< Accumulated double transitions. */
 } nrfx_qdec_report_data_evt_t;
 
 /** @brief QDEC event handler structure. */
@@ -133,43 +162,66 @@ typedef struct
 /**
  * @brief QDEC event handler.
  *
- * @param[in] event QDEC event structure.
+ * @param[in] event     QDEC event structure.
+ * @param[in] p_context Context passed to event handler.
  */
-typedef void (*nrfx_qdec_event_handler_t)(nrfx_qdec_event_t event);
+typedef void (*nrfx_qdec_event_handler_t)(nrfx_qdec_event_t event, void * p_context);
 
 /**
  * @brief Function for initializing QDEC.
  *
- * @param[in] p_config      Pointer to the structure with the initial configuration.
- * @param[in] event_handler Event handler provided by the user.
- *                          Must not be NULL.
+ * @param[in] p_instance Pointer to the driver instance structure.
+ * @param[in] p_config   Pointer to the structure with the initial configuration.
+ * @param[in] handler    Event handler provided by the user. Must not be NULL.
+ * @param[in] p_context  Context passed to event handler.
  *
  * @retval NRFX_SUCCESS             Initialization was successful.
  * @retval NRFX_ERROR_INVALID_STATE The QDEC was already initialized.
  */
-nrfx_err_t nrfx_qdec_init(nrfx_qdec_config_t const * p_config,
-                          nrfx_qdec_event_handler_t  event_handler);
+nrfx_err_t nrfx_qdec_init(nrfx_qdec_t const *        p_instance,
+                          nrfx_qdec_config_t const * p_config,
+                          nrfx_qdec_event_handler_t  handler,
+                          void *                     p_context);
+
+/**
+ * @brief Function for reconfiguring QDEC.
+ *
+ * @param[in] p_instance Pointer to the driver instance structure.
+ * @param[in] p_config   Pointer to the structure with the configuration.
+ *
+ * @retval NRFX_SUCCESS             Reconfiguration was successful.
+ * @retval NRFX_ERROR_BUSY          The driver is enabled and cannot be reconfigured.
+ * @retval NRFX_ERROR_INVALID_STATE The driver is uninitialized.
+ */
+nrfx_err_t nrfx_qdec_reconfigure(nrfx_qdec_t const *        p_instance,
+                                 nrfx_qdec_config_t const * p_config);
 
 /**
  * @brief Function for uninitializing QDEC.
  *
  * @note Function asserts if module is uninitialized.
+ *
+ * @param[in]  p_instance Pointer to the driver instance structure.
  */
-void nrfx_qdec_uninit(void);
+void nrfx_qdec_uninit(nrfx_qdec_t const * p_instance);
 
 /**
  * @brief Function for enabling QDEC.
  *
  * @note Function asserts if module is uninitialized or enabled.
+ *
+ * @param[in] p_instance Pointer to the driver instance structure.
  */
-void nrfx_qdec_enable(void);
+void nrfx_qdec_enable(nrfx_qdec_t const * p_instance);
 
 /**
  * @brief Function for disabling QDEC.
  *
  * @note Function asserts if module is uninitialized or disabled.
+ *
+ * @param[in] p_instance Pointer to the driver instance structure.
  */
-void nrfx_qdec_disable(void);
+void nrfx_qdec_disable(nrfx_qdec_t const * p_instance);
 
 /**
  * @brief Function for reading accumulated transitions from the QDEC peripheral.
@@ -177,46 +229,66 @@ void nrfx_qdec_disable(void);
  * @note Function asserts if module is not enabled.
  * @note Accumulators are cleared after reading.
  *
- * @param[out] p_acc    Pointer to store the accumulated transitions.
- * @param[out] p_accdbl Pointer to store the accumulated double transitions.
+ * @param[in]  p_instance Pointer to the driver instance structure.
+ * @param[out] p_acc      Pointer to store the accumulated transitions.
+ * @param[out] p_accdbl   Pointer to store the accumulated double transitions.
  */
-void nrfx_qdec_accumulators_read(int16_t * p_acc, int16_t * p_accdbl);
+void nrfx_qdec_accumulators_read(nrfx_qdec_t const * p_instance,
+                                 int32_t *           p_acc,
+                                 uint32_t *          p_accdbl);
 
 /**
  * @brief Function for returning the address of the specified QDEC task.
  *
- * @param task QDEC task.
+ * @param[in] p_instance Pointer to the driver instance structure.
+ * @param[in] task       QDEC task.
  *
  * @return Task address.
  */
-NRFX_STATIC_INLINE uint32_t nrfx_qdec_task_address_get(nrf_qdec_task_t task);
+NRFX_STATIC_INLINE uint32_t nrfx_qdec_task_address_get(nrfx_qdec_t const * p_instance,
+                                                       nrf_qdec_task_t     task);
 
 /**
  * @brief Function for returning the address of the specified QDEC event.
  *
- * @param event QDEC event.
+ * @param[in] p_instance Pointer to the driver instance structure.
+ * @param[in] event      QDEC event.
  *
  * @return Event address.
  */
-NRFX_STATIC_INLINE uint32_t nrfx_qdec_event_address_get(nrf_qdec_event_t event);
+NRFX_STATIC_INLINE uint32_t nrfx_qdec_event_address_get(nrfx_qdec_t const * p_instance,
+                                                        nrf_qdec_event_t    event);
 
 #ifndef NRFX_DECLARE_ONLY
-NRFX_STATIC_INLINE uint32_t nrfx_qdec_task_address_get(nrf_qdec_task_t task)
+NRFX_STATIC_INLINE uint32_t nrfx_qdec_task_address_get(nrfx_qdec_t const * p_instance,
+                                                       nrf_qdec_task_t     task)
 {
-    return nrf_qdec_task_address_get(NRF_QDEC, task);
+    return nrfy_qdec_task_address_get(p_instance->p_reg, task);
 }
 
-NRFX_STATIC_INLINE uint32_t nrfx_qdec_event_address_get(nrf_qdec_event_t event)
+NRFX_STATIC_INLINE uint32_t nrfx_qdec_event_address_get(nrfx_qdec_t const * p_instance,
+                                                        nrf_qdec_event_t    event)
 {
-    return nrf_qdec_event_address_get(NRF_QDEC, event);
+    return nrfy_qdec_event_address_get(p_instance->p_reg, event);
 }
 #endif // NRFX_DECLARE_ONLY
 
 /** @} */
 
-
-void nrfx_qdec_irq_handler(void);
-
+/*
+ * Declare interrupt handlers for all enabled driver instances in the following format:
+ * nrfx_\<periph_name\>_\<idx\>_irq_handler (for example, nrfx_qdec_0_irq_handler).
+ *
+ * A specific interrupt handler for the driver instance can be retrieved by using
+ * the NRFX_QDEC_INST_HANDLER_GET macro.
+ *
+ * Here is a sample of using the NRFX_QDEC_INST_HANDLER_GET macro to directly map
+ * an interrupt handler in a Zephyr application:
+ *
+ * IRQ_DIRECT_CONNECT(NRFX_IRQ_NUMBER_GET(NRF_QDEC_INST_GET(\<instance_index\>)), \<priority\>,
+ *                    NRFX_QDEC_INST_HANDLER_GET(\<instance_index\>), 0);
+ */
+NRFX_INSTANCE_IRQ_HANDLERS_DECLARE(QDEC, qdec)
 
 #ifdef __cplusplus
 }

--- a/nrfx/drivers/include/nrfx_qspi.h
+++ b/nrfx/drivers/include/nrfx_qspi.h
@@ -201,7 +201,7 @@ typedef void (*nrfx_qspi_handler_t)(nrfx_qspi_evt_t event, void * p_context);
  *                      will be performed in blocking mode.
  * @param[in] p_context Pointer to context. Use in the interrupt handler.
  *
- * @warning On nRF5340, only the dedicated pins with @ref NRF_GPIO_PIN_MCUSEL_PERIPHERAL configuration
+ * @warning On nRF5340, only the dedicated pins with @ref NRF_GPIO_PIN_SEL_PERIPHERAL configuration
  *          are supported. See the chapter <a href=@nRF5340pinAssignmentsURL>Pin assignments</a>
  *          in the Product Specification.
  *
@@ -213,6 +213,19 @@ typedef void (*nrfx_qspi_handler_t)(nrfx_qspi_evt_t event, void * p_context);
 nrfx_err_t nrfx_qspi_init(nrfx_qspi_config_t const * p_config,
                           nrfx_qspi_handler_t        handler,
                           void *                     p_context);
+
+/**
+ * @brief Function for reconfiguring the QSPI driver instance.
+ *
+ * @param[in] p_config Pointer to the structure with the configuration.
+ *
+ * @retval NRFX_SUCCESS             Reconfiguration was successful.
+ * @retval NRFX_ERROR_BUSY          The driver is during transaction.
+ * @retval NRFX_ERROR_TIMEOUT       External memory is busy or there are connection issues.
+ * @retval NRFX_ERROR_INVALID_STATE The driver is uninitialized.
+ * @retval NRFX_ERROR_INVALID_PARAM The pin configuration was incorrect.
+ */
+nrfx_err_t nrfx_qspi_reconfigure(nrfx_qspi_config_t const * p_config);
 
 /** @brief Function for uninitializing the QSPI driver instance. */
 void nrfx_qspi_uninit(void);

--- a/nrfx/drivers/include/nrfx_saadc.h
+++ b/nrfx/drivers/include/nrfx_saadc.h
@@ -35,7 +35,7 @@
 #define NRFX_SAADC_H__
 
 #include <nrfx.h>
-#include <hal/nrf_saadc.h>
+#include <haly/nrfy_saadc.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -48,14 +48,25 @@ extern "C" {
  * @brief   Successive Approximation Analog-to-Digital Converter (SAADC) peripheral driver.
  */
 
+#if NRF_SAADC_HAS_ACQTIME_ENUM || defined(__NRFX_DOXYGEN__)
+/** @brief Auxiliary symbol specifying default value for the SAADC acquisition time. */
+#define NRFX_SAADC_DEFAULT_ACQTIME NRF_SAADC_ACQTIME_10US
+#else
+#define NRFX_SAADC_DEFAULT_ACQTIME 79
+#endif
+
+#if NRF_SAADC_HAS_CONV_TIME || defined(__NRFX_DOXYGEN__)
+/** @brief Auxiliary symbol specifying default value for the SAADC conversion time. */
+#define NRFX_SAADC_DEFAULT_CONV_TIME 7
+#endif
 
 /**
  * @brief SAADC channel default configuration for the single-ended mode.
  *
  * This configuration sets up single-ended SAADC channel with the following options:
  * - resistor ladder disabled
- * - gain: 1/6
- * - reference voltage: internal 0.6 V
+ * - gain: 1
+ * - reference voltage: internal
  * - sample acquisition time: 10 us
  * - burst disabled
  *
@@ -64,21 +75,24 @@ extern "C" {
  *
  * @sa nrfx_saadc_channel_t
  */
-#define NRFX_SAADC_DEFAULT_CHANNEL_SE(_pin_p, _index)       \
-{                                                           \
-    .channel_config =                                       \
-    {                                                       \
-        .resistor_p = NRF_SAADC_RESISTOR_DISABLED,          \
-        .resistor_n = NRF_SAADC_RESISTOR_DISABLED,          \
-        .gain       = NRF_SAADC_GAIN1_6,                    \
-        .reference  = NRF_SAADC_REFERENCE_INTERNAL,         \
-        .acq_time   = NRF_SAADC_ACQTIME_10US,               \
-        .mode       = NRF_SAADC_MODE_SINGLE_ENDED,          \
-        .burst      = NRF_SAADC_BURST_DISABLED,             \
-    },                                                      \
-    .pin_p          = (nrf_saadc_input_t)_pin_p,            \
-    .pin_n          = NRF_SAADC_INPUT_DISABLED,             \
-    .channel_index  = _index,                               \
+#define NRFX_SAADC_DEFAULT_CHANNEL_SE(_pin_p, _index)                  \
+{                                                                      \
+    .channel_config =                                                  \
+    {                                                                  \
+        .resistor_p = NRF_SAADC_RESISTOR_DISABLED,                     \
+        .resistor_n = NRF_SAADC_RESISTOR_DISABLED,                     \
+        .gain       = NRF_SAADC_GAIN1,                                 \
+        .reference  = NRF_SAADC_REFERENCE_INTERNAL,                    \
+        .acq_time   = NRFX_SAADC_DEFAULT_ACQTIME,                      \
+        NRFX_COND_CODE_1(NRF_SAADC_HAS_CONV_TIME,                      \
+                         (.conv_time = NRFX_SAADC_DEFAULT_CONV_TIME,), \
+                         ())                                           \
+        .mode       = NRF_SAADC_MODE_SINGLE_ENDED,                     \
+        .burst      = NRF_SAADC_BURST_DISABLED,                        \
+    },                                                                 \
+    .pin_p          = (nrf_saadc_input_t)_pin_p,                       \
+    .pin_n          = NRF_SAADC_INPUT_DISABLED,                        \
+    .channel_index  = _index,                                          \
 }
 
 /**
@@ -87,7 +101,7 @@ extern "C" {
  * This configuration sets up differential SAADC channel with the following options:
  * - resistor ladder disabled
  * - gain: 1/6
- * - reference voltage: internal 0.6 V
+ * - reference voltage: internal
  * - sample acquisition time: 10 us
  * - burst disabled
  *
@@ -103,9 +117,12 @@ extern "C" {
     {                                                                   \
         .resistor_p = NRF_SAADC_RESISTOR_DISABLED,                      \
         .resistor_n = NRF_SAADC_RESISTOR_DISABLED,                      \
-        .gain       = NRF_SAADC_GAIN1_6,                                \
+        .gain       = NRF_SAADC_GAIN1,                                  \
         .reference  = NRF_SAADC_REFERENCE_INTERNAL,                     \
-        .acq_time   = NRF_SAADC_ACQTIME_10US,                           \
+        .acq_time   = NRFX_SAADC_DEFAULT_ACQTIME,                       \
+        NRFX_COND_CODE_1(NRF_SAADC_HAS_CONV_TIME,                       \
+                         (.conv_time = NRFX_SAADC_DEFAULT_CONV_TIME,),  \
+                         ())                                            \
         .mode       = NRF_SAADC_MODE_DIFFERENTIAL,                      \
         .burst      = NRF_SAADC_BURST_DISABLED,                         \
     },                                                                  \

--- a/nrfx/drivers/include/nrfx_spi.h
+++ b/nrfx/drivers/include/nrfx_spi.h
@@ -58,15 +58,8 @@ typedef struct
 
 #ifndef __NRFX_DOXYGEN__
 enum {
-#if NRFX_CHECK(NRFX_SPI0_ENABLED)
-    NRFX_SPI0_INST_IDX,
-#endif
-#if NRFX_CHECK(NRFX_SPI1_ENABLED)
-    NRFX_SPI1_INST_IDX,
-#endif
-#if NRFX_CHECK(NRFX_SPI2_ENABLED)
-    NRFX_SPI2_INST_IDX,
-#endif
+    /* List all enabled driver instances (in the format NRFX_\<instance_name\>_INST_IDX). */
+    NRFX_INSTANCE_ENUM_LIST(SPI)
     NRFX_SPI_ENABLED_COUNT
 };
 #endif
@@ -237,6 +230,19 @@ nrfx_err_t nrfx_spi_init(nrfx_spi_t const *        p_instance,
                          void *                    p_context);
 
 /**
+ * @brief Function for reconfiguring the SPI master driver instance.
+ *
+ * @param[in] p_instance Pointer to the driver instance structure.
+ * @param[in] p_config   Pointer to the structure with the configuration.
+ *
+ * @retval NRFX_SUCCESS             Reconfiguration was successful.
+ * @retval NRFX_ERROR_BUSY          The driver is during transfer.
+ * @retval NRFX_ERROR_INVALID_STATE The driver is uninitialized.
+ */
+nrfx_err_t nrfx_spi_reconfigure(nrfx_spi_t const *        p_instance,
+                                nrfx_spi_config_t const * p_config);
+
+/**
  * @brief Function for uninitializing the SPI master driver instance.
  *
  * @param[in] p_instance Pointer to the driver instance structure.
@@ -282,10 +288,20 @@ void nrfx_spi_abort(nrfx_spi_t const * p_instance);
 
 /** @} */
 
-
-void nrfx_spi_0_irq_handler(void);
-void nrfx_spi_1_irq_handler(void);
-void nrfx_spi_2_irq_handler(void);
+/*
+ * Declare interrupt handlers for all enabled driver instances in the following format:
+ * nrfx_\<periph_name\>_\<idx\>_irq_handler (for example, nrfx_spi_0_irq_handler).
+ *
+ * A specific interrupt handler for the driver instance can be retrieved by using
+ * the NRFX_SPI_INST_HANDLER_GET macro.
+ *
+ * Here is a sample of using the NRFX_SPI_INST_HANDLER_GET macro to directly map
+ * an interrupt handler in a Zephyr application:
+ *
+ * IRQ_DIRECT_CONNECT(NRFX_IRQ_NUMBER_GET(NRF_SPI_INST_GET(\<instance_index\>)), \<priority\>,
+ *                    NRFX_SPI_INST_HANDLER_GET(\<instance_index\>), 0);
+ */
+NRFX_INSTANCE_IRQ_HANDLERS_DECLARE(SPI, spi)
 
 
 #ifdef __cplusplus

--- a/nrfx/drivers/include/nrfx_spim.h
+++ b/nrfx/drivers/include/nrfx_spim.h
@@ -35,8 +35,8 @@
 #define NRFX_SPIM_H__
 
 #include <nrfx.h>
-#include <hal/nrf_spim.h>
-#include <hal/nrf_gpio.h>
+#include <haly/nrfy_spim.h>
+#include <haly/nrfy_gpio.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -58,21 +58,8 @@ typedef struct
 
 #ifndef __NRFX_DOXYGEN__
 enum {
-#if NRFX_CHECK(NRFX_SPIM0_ENABLED)
-    NRFX_SPIM0_INST_IDX,
-#endif
-#if NRFX_CHECK(NRFX_SPIM1_ENABLED)
-    NRFX_SPIM1_INST_IDX,
-#endif
-#if NRFX_CHECK(NRFX_SPIM2_ENABLED)
-    NRFX_SPIM2_INST_IDX,
-#endif
-#if NRFX_CHECK(NRFX_SPIM3_ENABLED)
-    NRFX_SPIM3_INST_IDX,
-#endif
-#if NRFX_CHECK(NRFX_SPIM4_ENABLED)
-    NRFX_SPIM4_INST_IDX,
-#endif
+    /* List all enabled driver instances (in the format NRFX_\<instance_name\>_INST_IDX). */
+    NRFX_INSTANCE_ENUM_LIST(SPIM)
     NRFX_SPIM_ENABLED_COUNT
 };
 #endif
@@ -84,25 +71,18 @@ enum {
     .drv_inst_idx = NRFX_CONCAT_3(NRFX_SPIM, id, _INST_IDX), \
 }
 
-/**
- * @brief This value can be provided instead of a pin number for signals MOSI,
- *        MISO, and Slave Select to specify that the given signal is not used and
- *        therefore does not need to be connected to a pin.
- */
-#define NRFX_SPIM_PIN_NOT_USED  0xFF
-
 /** @brief Configuration structure of the SPIM driver instance. */
 typedef struct
 {
-    uint8_t              sck_pin;        ///< SCK pin number.
-    uint8_t              mosi_pin;       ///< MOSI pin number (optional).
-                                         /**< Set to @ref NRFX_SPIM_PIN_NOT_USED
+    uint32_t             sck_pin;        ///< SCK pin number.
+    uint32_t             mosi_pin;       ///< MOSI pin number (optional).
+                                         /**< Set to @ref NRF_SPIM_PIN_NOT_CONNECTED
                                           *   if this signal is not needed. */
-    uint8_t              miso_pin;       ///< MISO pin number (optional).
-                                         /**< Set to @ref NRFX_SPIM_PIN_NOT_USED
+    uint32_t             miso_pin;       ///< MISO pin number (optional).
+                                         /**< Set to @ref NRF_SPIM_PIN_NOT_CONNECTED
                                           *   if this signal is not needed. */
-    uint8_t              ss_pin;         ///< Slave Select pin number (optional).
-                                         /**< Set to @ref NRFX_SPIM_PIN_NOT_USED
+    uint32_t             ss_pin;         ///< Slave Select pin number (optional).
+                                         /**< Set to @ref NRF_SPIM_PIN_NOT_CONNECTED
                                           *   if this signal is not needed.
                                           *   @note Unlike the other fields that specify
                                           *   pin numbers, this one cannot be omitted
@@ -115,12 +95,12 @@ typedef struct
     uint8_t              orc;            ///< Overrun character.
                                          /**< This character is used when all bytes from the TX buffer are sent,
                                           *   but the transfer continues due to RX. */
-    nrf_spim_frequency_t frequency;      ///< SPIM frequency.
+    uint32_t             frequency;      ///< SPIM frequency in Hz.
     nrf_spim_mode_t      mode;           ///< SPIM mode.
     nrf_spim_bit_order_t bit_order;      ///< SPIM bit order.
     nrf_gpio_pin_pull_t  miso_pull;      ///< MISO pull up configuration.
 #if NRFX_CHECK(NRFX_SPIM_EXTENDED_ENABLED) || defined(__NRFX_DOXYGEN__)
-    uint8_t              dcx_pin;        ///< D/CX pin number (optional).
+    uint32_t             dcx_pin;        ///< D/CX pin number (optional).
     uint8_t              rx_delay;       ///< Sample delay for input serial data on MISO.
                                          /**< The value specifies the delay, in number of 64 MHz clock cycles
                                           *   (15.625 ns), from the the sampling edge of SCK (leading edge for
@@ -151,25 +131,6 @@ typedef struct
                                           *   to be controlled by hardware.*/
 } nrfx_spim_config_t;
 
-#if NRFX_CHECK(NRFX_SPIM_EXTENDED_ENABLED) || defined(__NRFX_DOXYGEN__)
-/**
- * @brief SPIM driver extended default configuration.
- *
- * This configuration sets up SPIM additional options with the following values:
- * - DCX pin disabled
- * - RX sampling delay: 2 clock cycles
- * - hardware SS disabled
- * - hardware SS duration before and after transmission: 2 clock cycles
- */
-#define NRFX_SPIM_DEFAULT_EXTENDED_CONFIG   \
-    .dcx_pin      = NRFX_SPIM_PIN_NOT_USED, \
-    .rx_delay     = 0x02,                   \
-    .use_hw_ss    = false,                  \
-    .ss_duration  = 0x02,
-#else
-    #define NRFX_SPIM_DEFAULT_EXTENDED_CONFIG
-#endif
-
 /**
  * @brief SPIM driver default configuration.
  *
@@ -177,50 +138,61 @@ typedef struct
  * - SS pin active low
  * - over-run character set to 0xFF
  * - clock frequency: 4 MHz
- * - mode: 0 (SCK active high, sample on leading edge of the clock signa;)
+ * - mode: 0 (SCK active high, sample on leading edge of the clock signal)
  * - MSB shifted out first
  * - MISO pull-up disabled
  *
  * @param[in] _pin_sck  SCK pin.
  * @param[in] _pin_mosi MOSI pin.
  * @param[in] _pin_miso MISO pin.
- * @param[in] _pin_ss   SS pin.
+ * @param[in] _pin_ss   Slave select pin.
  */
-#define NRFX_SPIM_DEFAULT_CONFIG(_pin_sck, _pin_mosi, _pin_miso, _pin_ss)   \
-{                                                                           \
-    .sck_pin        = _pin_sck,                                             \
-    .mosi_pin       = _pin_mosi,                                            \
-    .miso_pin       = _pin_miso,                                            \
-    .ss_pin         = _pin_ss,                                              \
-    .ss_active_high = false,                                                \
-    .irq_priority   = NRFX_SPIM_DEFAULT_CONFIG_IRQ_PRIORITY,                \
-    .orc            = 0xFF,                                                 \
-    .frequency      = NRF_SPIM_FREQ_4M,                                     \
-    .mode           = NRF_SPIM_MODE_0,                                      \
-    .bit_order      = NRF_SPIM_BIT_ORDER_MSB_FIRST,                         \
-    .miso_pull      = NRF_GPIO_PIN_NOPULL,                                  \
-    NRFX_SPIM_DEFAULT_EXTENDED_CONFIG                                       \
+#define NRFX_SPIM_DEFAULT_CONFIG(_pin_sck, _pin_mosi, _pin_miso, _pin_ss)                        \
+{                                                                                                \
+    .sck_pin        = _pin_sck,                                                                  \
+    .mosi_pin       = _pin_mosi,                                                                 \
+    .miso_pin       = _pin_miso,                                                                 \
+    .ss_pin         = _pin_ss,                                                                   \
+    .ss_active_high = false,                                                                     \
+    .irq_priority   = NRFX_SPIM_DEFAULT_CONFIG_IRQ_PRIORITY,                                     \
+    .orc            = 0xFF,                                                                      \
+    .frequency      = NRFX_MHZ_TO_HZ(4),                                                         \
+    .mode           = NRF_SPIM_MODE_0,                                                           \
+    .bit_order      = NRF_SPIM_BIT_ORDER_MSB_FIRST,                                              \
+    .miso_pull      = NRF_GPIO_PIN_NOPULL,                                                       \
+    NRFX_COND_CODE_1(NRFX_SPIM_EXTENDED_ENABLED, (.use_hw_ss = false, .ss_duration = 0x02,), ()) \
+    NRFX_COND_CODE_1(NRFX_SPIM_EXTENDED_ENABLED, (.rx_delay = 0x02,), ())                        \
+    NRFX_COND_CODE_1(NRFX_SPIM_EXTENDED_ENABLED, (.dcx_pin = NRF_SPIM_PIN_NOT_CONNECTED,), ())   \
 }
+
+/**
+ * @brief Macro for checking whether specified frequency can be achieved for a given SPIM instance.
+ *
+ * @note This macro uses a compile-time assertion.
+ *
+ * @param[in] id        Index of the specified SPIM instance.
+ * @param[in] frequency Desired frequency value in Hz.
+ */
+#define NRFX_SPIM_FREQUENCY_STATIC_CHECK(id, frequency) \
+         NRF_SPIM_FREQUENCY_STATIC_CHECK(NRF_SPIM_INST_GET(id), frequency)
 
 /** @brief Flag indicating that TX buffer address will be incremented after transfer. */
 #define NRFX_SPIM_FLAG_TX_POSTINC          (1UL << 0)
+
 /** @brief Flag indicating that RX buffer address will be incremented after transfer. */
 #define NRFX_SPIM_FLAG_RX_POSTINC          (1UL << 1)
+
 /** @brief Flag indicating that the interrupt after each transfer will be suppressed, and the event handler will not be called. */
 #define NRFX_SPIM_FLAG_NO_XFER_EVT_HANDLER (1UL << 2)
+
 /** @brief Flag indicating that the transfer will be set up, but not started. */
 #define NRFX_SPIM_FLAG_HOLD_XFER           (1UL << 3)
+
 /** @brief Flag indicating that the transfer will be executed multiple times. */
 #define NRFX_SPIM_FLAG_REPEATED_XFER       (1UL << 4)
 
 /** @brief Single transfer descriptor structure. */
-typedef struct
-{
-    uint8_t const * p_tx_buffer; ///< Pointer to TX buffer.
-    size_t          tx_length;   ///< TX buffer length.
-    uint8_t       * p_rx_buffer; ///< Pointer to RX buffer.
-    size_t          rx_length;   ///< RX buffer length.
-} nrfx_spim_xfer_desc_t;
+typedef nrfy_spim_xfer_desc_t nrfx_spim_xfer_desc_t;
 
 /**
  * @brief Macro for setting up single transfer descriptor.
@@ -274,12 +246,14 @@ typedef void (* nrfx_spim_evt_handler_t)(nrfx_spim_evt_t const * p_event,
  *
  * @param[in] p_instance Pointer to the driver instance structure.
  * @param[in] p_config   Pointer to the structure with the initial configuration.
+ *                       NULL if configuration is to be skipped and will be done later
+ *                       using @ref nrfx_spim_reconfigure.
  * @param[in] handler    Event handler provided by the user. If NULL, transfers
  *                       will be performed in blocking mode.
  * @param[in] p_context  Context passed to event handler.
  *
  * @warning On nRF5340, 32 MHz setting for SPIM4 peripheral instance is supported
- *          only on the dedicated pins with @ref NRF_GPIO_PIN_MCUSEL_PERIPHERAL configuration.
+ *          only on the dedicated pins with @ref NRF_GPIO_PIN_SEL_PERIPHERAL configuration.
  *          See the chapter <a href=@nRF5340pinAssignmentsURL>Pin assignments</a> in the Product Specification.
  *
  * @retval NRFX_SUCCESS             Initialization was successful.
@@ -290,12 +264,34 @@ typedef void (* nrfx_spim_evt_handler_t)(nrfx_spim_evt_t const * p_event,
  *                                  is enabled.
  * @retval NRFX_ERROR_NOT_SUPPORTED Requested configuration is not supported
  *                                  by the SPIM instance.
- * @retval NRFX_ERROR_INVALID_PARAM Requested frequency is not available on the specified pins.
+ * @retval NRFX_ERROR_INVALID_PARAM Requested frequency is not available on the specified driver instance or pins.
+ * @retval NRFX_ERROR_FORBIDDEN     Software-controlled Slave Select and hardware-controlled Slave Select
+                                    cannot be active at the same time.
  */
 nrfx_err_t nrfx_spim_init(nrfx_spim_t const *        p_instance,
                           nrfx_spim_config_t const * p_config,
                           nrfx_spim_evt_handler_t    handler,
                           void *                     p_context);
+
+/**
+ * @brief Function for reconfiguring the SPIM driver instance.
+ *
+ * @note This function can not be called during transmission.
+ *
+ * @param[in] p_instance Pointer to the driver instance structure.
+ * @param[in] p_config   Pointer to the structure with the configuration.
+ *
+ * @retval NRFX_SUCCESS             Reconfiguration was successful.
+ * @retval NRFX_ERROR_BUSY          The driver is during transfer.
+ * @retval NRFX_ERROR_INVALID_STATE The driver is uninitialized.
+ * @retval NRFX_ERROR_NOT_SUPPORTED Requested configuration is not supported
+ *                                  by the SPIM instance.
+ * @retval NRFX_ERROR_INVALID_PARAM Requested frequency is not available on the specified driver instance or pins.
+ * @retval NRFX_ERROR_FORBIDDEN     Software-controlled Slave Select and hardware-controlled Slave Select
+                                    cannot be active at the same time.
+ */
+nrfx_err_t nrfx_spim_reconfigure(nrfx_spim_t const *        p_instance,
+                                 nrfx_spim_config_t const * p_config);
 
 /**
  * @brief Function for uninitializing the SPIM driver instance.
@@ -313,14 +309,14 @@ void nrfx_spim_uninit(nrfx_spim_t const * p_instance);
  *   Post-incrementation of buffer addresses.
  * - @ref NRFX_SPIM_FLAG_HOLD_XFER - Driver is not starting the transfer. Use this
  *   flag if the transfer is triggered externally by PPI. Use
- *   @ref nrfx_spim_start_task_get to get the address of the start task.
- *   Chip select must be configured to @ref NRFX_SPIM_PIN_NOT_USED and managed outside the driver.
+ *   @ref nrfx_spim_start_task_address_get to get the address of the start task.
+ *   Chip select must be configured to @ref NRF_SPIM_PIN_NOT_CONNECTED and managed outside the driver.
  * - @ref NRFX_SPIM_FLAG_NO_XFER_EVT_HANDLER - No user event handler after transfer
  *   completion. This also means no interrupt at the end of the transfer.
  *   If @ref NRFX_SPIM_FLAG_NO_XFER_EVT_HANDLER is used, the driver does not set the instance into
  *   busy state, so you must ensure that the next transfers are set up when SPIM is not active.
- *   @ref nrfx_spim_end_event_get function can be used to detect end of transfer. Option can be used
- *   together with @ref NRFX_SPIM_FLAG_REPEATED_XFER to prepare a sequence of SPI transfers
+ *   @ref nrfx_spim_end_event_address_get function can be used to detect end of transfer. Option can
+ *   be used together with @ref NRFX_SPIM_FLAG_REPEATED_XFER to prepare a sequence of SPI transfers
  *   without interruptions.
  * - @ref NRFX_SPIM_FLAG_REPEATED_XFER - Prepare for repeated transfers. You can set
  *   up a number of transfers that will be triggered externally (for example by PPI). An example is
@@ -328,8 +324,8 @@ void nrfx_spim_uninit(nrfx_spim_t const * p_instance);
  *   @ref NRFX_SPIM_FLAG_NO_XFER_EVT_HANDLER, and @ref NRFX_SPIM_FLAG_REPEATED_XFER. After the
  *   transfer is set up, a set of transfers can be triggered by PPI that will read, for example,
  *   the same register of an external component and put it into a RAM buffer without any interrupts.
- *   @ref nrfx_spim_end_event_get can be used to get the address of the END event, which can be
- *   used to count the number of transfers. If @ref NRFX_SPIM_FLAG_REPEATED_XFER is used,
+ *   @ref nrfx_spim_end_event_address_get can be used to get the address of the END event, which can
+ *   be used to count the number of transfers. If @ref NRFX_SPIM_FLAG_REPEATED_XFER is used,
  *   the driver does not set the instance into busy state, so you must ensure that the next
  *   transfers are set up when SPIM is not active.
  *
@@ -396,7 +392,7 @@ nrfx_err_t nrfx_spim_xfer_dcx(nrfx_spim_t const *           p_instance,
  *
  * @return Start task address.
  */
-uint32_t nrfx_spim_start_task_get(nrfx_spim_t const * p_instance);
+NRFX_STATIC_INLINE uint32_t nrfx_spim_start_task_address_get(nrfx_spim_t const * p_instance);
 
 /**
  * @brief Function for returning the address of a END SPIM event.
@@ -408,7 +404,7 @@ uint32_t nrfx_spim_start_task_get(nrfx_spim_t const * p_instance);
  *
  * @return END event address.
  */
-uint32_t nrfx_spim_end_event_get(nrfx_spim_t const * p_instance);
+NRFX_STATIC_INLINE uint32_t nrfx_spim_end_event_address_get(nrfx_spim_t const * p_instance);
 
 /**
  * @brief Function for aborting ongoing transfer.
@@ -426,14 +422,33 @@ void nrfx_spim_abort(nrfx_spim_t const * p_instance);
  */
 #define NRFX_SPIM_INST_HANDLER_GET(idx) NRFX_CONCAT_3(nrfx_spim_, idx, _irq_handler)
 
+#ifndef NRFX_DECLARE_ONLY
+NRFX_STATIC_INLINE uint32_t nrfx_spim_start_task_address_get(nrfx_spim_t const * p_instance)
+{
+    return nrfy_spim_task_address_get(p_instance->p_reg, NRF_SPIM_TASK_START);
+}
+
+NRFX_STATIC_INLINE uint32_t nrfx_spim_end_event_address_get(nrfx_spim_t const * p_instance)
+{
+    return nrfy_spim_event_address_get(p_instance->p_reg, NRF_SPIM_EVENT_END);
+}
+#endif // NRFX_DECLARE_ONLY
 /** @} */
 
-
-void nrfx_spim_0_irq_handler(void);
-void nrfx_spim_1_irq_handler(void);
-void nrfx_spim_2_irq_handler(void);
-void nrfx_spim_3_irq_handler(void);
-void nrfx_spim_4_irq_handler(void);
+/*
+ * Declare interrupt handlers for all enabled driver instances in the following format:
+ * nrfx_\<periph_name\>_\<idx\>_irq_handler (for example, nrfx_spim_0_irq_handler).
+ *
+ * A specific interrupt handler for the driver instance can be retrieved by using
+ * the NRFX_SPIM_INST_HANDLER_GET macro.
+ *
+ * Here is a sample of using the NRFX_SPIM_INST_HANDLER_GET macro to directly map
+ * an interrupt handler in a Zephyr application:
+ *
+ * IRQ_DIRECT_CONNECT(NRFX_IRQ_NUMBER_GET(NRF_SPIM_INST_GET(\<instance_index\>)), \<priority\>,
+ *                    NRFX_SPIM_INST_HANDLER_GET(\<instance_index\>), 0);
+ */
+NRFX_INSTANCE_IRQ_HANDLERS_DECLARE(SPIM, spim)
 
 
 #ifdef __cplusplus

--- a/nrfx/drivers/include/nrfx_temp.h
+++ b/nrfx/drivers/include/nrfx_temp.h
@@ -35,7 +35,7 @@
 #define NRFX_TEMP_H__
 
 #include <nrfx.h>
-#include <hal/nrf_temp.h>
+#include <haly/nrfy_temp.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -138,7 +138,7 @@ nrfx_err_t nrfx_temp_measure(void);
 #ifndef NRFX_DECLARE_ONLY
 NRFX_STATIC_INLINE int32_t nrfx_temp_result_get(void)
 {
-    return nrf_temp_result_get(NRF_TEMP);
+    return nrfy_temp_result_get(NRF_TEMP);
 }
 #endif // NRFX_DECLARE_ONLY
 

--- a/nrfx/drivers/include/nrfx_twi.h
+++ b/nrfx/drivers/include/nrfx_twi.h
@@ -67,12 +67,8 @@ typedef struct
 
 #ifndef __NRFX_DOXYGEN__
 enum {
-#if NRFX_CHECK(NRFX_TWI0_ENABLED)
-    NRFX_TWI0_INST_IDX,
-#endif
-#if NRFX_CHECK(NRFX_TWI1_ENABLED)
-    NRFX_TWI1_INST_IDX,
-#endif
+    /* List all enabled driver instances (in the format NRFX_\<instance_name\>_INST_IDX). */
+    NRFX_INSTANCE_ENUM_LIST(TWI)
     NRFX_TWI_ENABLED_COUNT
 };
 #endif
@@ -234,6 +230,19 @@ nrfx_err_t nrfx_twi_init(nrfx_twi_t const *        p_instance,
                          void *                    p_context);
 
 /**
+ * @brief Function for reconfiguring the TWI instance.
+ *
+ * @param[in] p_instance Pointer to the driver instance structure.
+ * @param[in] p_config   Pointer to the structure with the configuration.
+ *
+ * @retval NRFX_SUCCESS             Reconfiguration was successful.
+ * @retval NRFX_ERROR_BUSY          The driver is during transaction.
+ * @retval NRFX_ERROR_INVALID_STATE The driver is uninitialized.
+ */
+nrfx_err_t nrfx_twi_reconfigure(nrfx_twi_t const *        p_instance,
+                                nrfx_twi_config_t const * p_config);
+
+/**
  * @brief Function for uninitializing the TWI instance.
  *
  * @param[in] p_instance Pointer to the driver instance structure.
@@ -360,10 +369,20 @@ NRFX_STATIC_INLINE nrfx_err_t nrfx_twi_bus_recover(uint32_t scl_pin, uint32_t sd
 
 /** @} */
 
-
-void nrfx_twi_0_irq_handler(void);
-void nrfx_twi_1_irq_handler(void);
-
+/*
+ * Declare interrupt handlers for all enabled driver instances in the following format:
+ * nrfx_\<periph_name\>_\<idx\>_irq_handler (for example, nrfx_twi_0_irq_handler).
+ *
+ * A specific interrupt handler for the driver instance can be retrieved by using
+ * the NRFX_TWI_INST_HANDLER_GET macro.
+ *
+ * Here is a sample of using the NRFX_TWI_INST_HANDLER_GET macro to directly map
+ * an interrupt handler in a Zephyr application:
+ *
+ * IRQ_DIRECT_CONNECT(NRFX_IRQ_NUMBER_GET(NRF_TWI_INST_GET(\<instance_index\>)), \<priority\>,
+ *                    NRFX_TWI_INST_HANDLER_GET(\<instance_index\>), 0);
+ */
+NRFX_INSTANCE_IRQ_HANDLERS_DECLARE(TWI, twi)
 
 #ifdef __cplusplus
 }

--- a/nrfx/drivers/include/nrfx_twis.h
+++ b/nrfx/drivers/include/nrfx_twis.h
@@ -58,18 +58,8 @@ typedef struct
 
 #ifndef __NRFX_DOXYGEN__
 enum {
-#if NRFX_CHECK(NRFX_TWIS0_ENABLED)
-    NRFX_TWIS0_INST_IDX,
-#endif
-#if NRFX_CHECK(NRFX_TWIS1_ENABLED)
-    NRFX_TWIS1_INST_IDX,
-#endif
-#if NRFX_CHECK(NRFX_TWIS2_ENABLED)
-    NRFX_TWIS2_INST_IDX,
-#endif
-#if NRFX_CHECK(NRFX_TWIS3_ENABLED)
-    NRFX_TWIS3_INST_IDX,
-#endif
+    /* List all enabled driver instances (in the format NRFX_\<instance_name\>_INST_IDX). */
+    NRFX_INSTANCE_ENUM_LIST(TWIS)
     NRFX_TWIS_ENABLED_COUNT
 };
 #endif
@@ -140,8 +130,8 @@ typedef void (*nrfx_twis_event_handler_t)(nrfx_twis_evt_t const * p_event);
 typedef struct
 {
     uint32_t            addr[2];            ///< Set addresses that this slave should respond. Set 0 to disable.
-    uint32_t            scl;                ///< SCL pin number.
-    uint32_t            sda;                ///< SDA pin number.
+    uint32_t            scl_pin;            ///< SCL pin number.
+    uint32_t            sda_pin;            ///< SDA pin number.
     nrf_gpio_pin_pull_t scl_pull;           ///< SCL pin pull.
     nrf_gpio_pin_pull_t sda_pull;           ///< SDA pin pull.
     uint8_t             interrupt_priority; ///< The priority of interrupt for the module to be set.
@@ -176,8 +166,8 @@ typedef struct
 #define NRFX_TWIS_DEFAULT_CONFIG(_pin_scl, _pin_sda, _addr)      \
 {                                                                \
     .addr               = { _addr, 0x00 },                       \
-    .scl                = _pin_scl,                              \
-    .sda                = _pin_sda,                              \
+    .scl_pin            = _pin_scl,                              \
+    .sda_pin            = _pin_sda,                              \
     .scl_pull           = NRF_GPIO_PIN_NOPULL,                   \
     .sda_pull           = NRF_GPIO_PIN_NOPULL,                   \
     .interrupt_priority = NRFX_TWIS_DEFAULT_CONFIG_IRQ_PRIORITY  \
@@ -206,6 +196,19 @@ typedef struct
 nrfx_err_t nrfx_twis_init(nrfx_twis_t const *        p_instance,
                           nrfx_twis_config_t const * p_config,
                           nrfx_twis_event_handler_t  event_handler);
+
+/**
+ * @brief Function for reconfiguring the TWIS driver instance.
+ *
+ * @param[in] p_instance Pointer to the driver instance structure.
+ * @param[in] p_config   Pointer to the structure with the configuration.
+ *
+ * @retval NRFX_SUCCESS             Reconfiguration was successful.
+ * @retval NRFX_ERROR_BUSY          The driver is during transaction.
+ * @retval NRFX_ERROR_INVALID_STATE The driver is uninitialized.
+ */
+nrfx_err_t nrfx_twis_reconfigure(nrfx_twis_t const *        p_instance,
+                                 nrfx_twis_config_t const * p_config);
 
 /**
  * @brief Function for uninitializing the TWIS driver instance.
@@ -415,11 +418,20 @@ NRFX_STATIC_INLINE size_t nrfx_twis_rx_amount(nrfx_twis_t const * p_instance)
 
 /** @} */
 
-
-void nrfx_twis_0_irq_handler(void);
-void nrfx_twis_1_irq_handler(void);
-void nrfx_twis_2_irq_handler(void);
-void nrfx_twis_3_irq_handler(void);
+/*
+ * Declare interrupt handlers for all enabled driver instances in the following format:
+ * nrfx_\<periph_name\>_\<idx\>_irq_handler (for example, nrfx_twis_0_irq_handler).
+ *
+ * A specific interrupt handler for the driver instance can be retrieved by using
+ * the NRFX_TWIS_INST_HANDLER_GET macro.
+ *
+ * Here is a sample of using the NRFX_TWIS_INST_HANDLER_GET macro to directly map
+ * an interrupt handler in a Zephyr application:
+ *
+ * IRQ_DIRECT_CONNECT(NRFX_IRQ_NUMBER_GET(NRF_TWIS_INST_GET(\<instance_index\>)), \<priority\>,
+ *                    NRFX_TWIS_INST_HANDLER_GET(\<instance_index\>), 0);
+ */
+NRFX_INSTANCE_IRQ_HANDLERS_DECLARE(TWIS, twis)
 
 
 #ifdef __cplusplus

--- a/nrfx/drivers/include/nrfx_uart.h
+++ b/nrfx/drivers/include/nrfx_uart.h
@@ -57,9 +57,8 @@ typedef struct
 
 #ifndef __NRFX_DOXYGEN__
 enum {
-#if NRFX_CHECK(NRFX_UART0_ENABLED)
-    NRFX_UART0_INST_IDX,
-#endif
+    /* List all enabled driver instances (in the format NRFX_\<instance_name\>_INST_IDX). */
+    NRFX_INSTANCE_ENUM_LIST(UART)
     NRFX_UART_ENABLED_COUNT
 };
 #endif
@@ -206,6 +205,19 @@ typedef void (*nrfx_uart_event_handler_t)(nrfx_uart_event_t const * p_event,
 nrfx_err_t nrfx_uart_init(nrfx_uart_t const *        p_instance,
                           nrfx_uart_config_t const * p_config,
                           nrfx_uart_event_handler_t  event_handler);
+
+/**
+ * @brief Function for reconfiguring the UART driver.
+ *
+ * @param[in] p_instance Pointer to the driver instance structure.
+ * @param[in] p_config   Pointer to the structure with the configuration.
+ *
+ * @retval NRFX_SUCCESS             Reconfiguration was successful.
+ * @retval NRFX_ERROR_BUSY          The driver is during transfer.
+ * @retval NRFX_ERROR_INVALID_STATE The driver is uninitialized.
+ */
+nrfx_err_t nrfx_uart_reconfigure(nrfx_uart_t const *        p_instance,
+                                 nrfx_uart_config_t const * p_config);
 
 /**
  * @brief Function for uninitializing the UART driver.
@@ -395,9 +407,20 @@ NRFX_STATIC_INLINE uint32_t nrfx_uart_event_address_get(nrfx_uart_t const * p_in
 
 /** @} */
 
-
-void nrfx_uart_0_irq_handler(void);
-
+/*
+ * Declare interrupt handlers for all enabled driver instances in the following format:
+ * nrfx_\<periph_name\>_\<idx\>_irq_handler (for example, nrfx_uart_0_irq_handler).
+ *
+ * A specific interrupt handler for the driver instance can be retrieved by using
+ * the NRFX_UART_INST_HANDLER_GET macro.
+ *
+ * Here is a sample of using the NRFX_UART_INST_HANDLER_GET macro to directly map
+ * an interrupt handler in a Zephyr application:
+ *
+ * IRQ_DIRECT_CONNECT(NRFX_IRQ_NUMBER_GET(NRF_UART_INST_GET(\<instance_index\>)), \<priority\>,
+ *                    NRFX_UART_INST_HANDLER_GET(\<instance_index\>), 0);
+ */
+NRFX_INSTANCE_IRQ_HANDLERS_DECLARE(UART, uart)
 
 #ifdef __cplusplus
 }

--- a/nrfx/drivers/include/nrfx_wdt.h
+++ b/nrfx/drivers/include/nrfx_wdt.h
@@ -35,10 +35,15 @@
 #define NRFX_WDT_H__
 
 #include <nrfx.h>
-#include <hal/nrf_wdt.h>
+#include <haly/nrfy_wdt.h>
 
 #ifdef __cplusplus
 extern "C" {
+#endif
+
+/* On devices with single instance (with no id) use instance 0. */
+#if defined(NRF_WDT) && defined(NRFX_WDT_ENABLED) && !defined(NRFX_WDT0_ENABLED)
+#define NRFX_WDT0_ENABLED 1
 #endif
 
 /**
@@ -55,8 +60,13 @@ extern "C" {
     #define NRFX_WDT_IRQ_CONFIG
 #endif
 
-/** @brief WDT event handler function type. */
-typedef void (*nrfx_wdt_event_handler_t)(void);
+/**
+ * @brief WDT event handler function type.
+ *
+ * @param[in] requests Value of the request status register. Set bits can be used to determine
+ *                     which RR register was the reason for timeout event.
+ */
+typedef void (*nrfx_wdt_event_handler_t)(uint32_t requests);
 
 /** @brief WDT channel ID type. */
 typedef nrf_wdt_rr_register_t nrfx_wdt_channel_id;
@@ -70,12 +80,8 @@ typedef struct
 
 #ifndef __NRFX_DOXYGEN__
 enum {
-#if NRFX_CHECK(NRFX_WDT0_ENABLED)
-    NRFX_WDT0_INST_IDX,
-#endif
-#if NRFX_CHECK(NRFX_WDT1_ENABLED)
-    NRFX_WDT1_INST_IDX,
-#endif
+    /* List all enabled driver instances (in the format NRFX_\<instance_name\>_INST_IDX). */
+    NRFX_INSTANCE_ENUM_LIST(WDT)
     NRFX_WDT_ENABLED_COUNT
 };
 #endif
@@ -90,10 +96,10 @@ enum {
 /** @brief Struct for WDT initialization. */
 typedef struct
 {
-    nrf_wdt_behaviour_t    behaviour;          /**< WDT behaviour when CPU in sleep/halt mode. */
-    uint32_t               reload_value;       /**< WDT reload value in ms. */
+    uint32_t behaviour;          /**< WDT behaviour flags bitmask, constructed from @ref nrf_wdt_behaviour_mask_t. */
+    uint32_t reload_value;       /**< WDT reload value in ms. */
 #if !NRFX_CHECK(NRFX_WDT_CONFIG_NO_IRQ) || defined(__NRFX_DOXYGEN__)
-    uint8_t                interrupt_priority; /**< WDT interrupt priority */
+    uint8_t  interrupt_priority; /**< WDT interrupt priority */
 #endif
 } nrfx_wdt_config_t;
 
@@ -104,11 +110,11 @@ typedef struct
  * - run when CPU is in SLEEP mode, pause when in HALT mode
  * - reload value: 2000 ms
  */
-#define NRFX_WDT_DEFAULT_CONFIG                          \
-{                                                        \
-    .behaviour          = NRF_WDT_BEHAVIOUR_RUN_SLEEP,   \
-    .reload_value       = 2000,                          \
-    NRFX_WDT_IRQ_CONFIG                                  \
+#define NRFX_WDT_DEFAULT_CONFIG                             \
+{                                                           \
+    .behaviour          = NRF_WDT_BEHAVIOUR_RUN_SLEEP_MASK, \
+    .reload_value       = 2000,                             \
+    NRFX_WDT_IRQ_CONFIG                                     \
 }
 
 /**
@@ -116,6 +122,8 @@ typedef struct
  *
  * @param[in] p_instance        Pointer to the driver instance structure.
  * @param[in] p_config          Pointer to the structure with the initial configuration.
+ *                              NULL if configuration is to be skipped and will be done later
+ *                              using @ref nrfx_wdt_reconfigure.
  * @param[in] wdt_event_handler Event handler provided by the user. Ignored when
  *                              @ref NRFX_WDT_CONFIG_NO_IRQ option is enabled.
  *
@@ -127,9 +135,22 @@ nrfx_err_t nrfx_wdt_init(nrfx_wdt_t const *        p_instance,
                          nrfx_wdt_event_handler_t  wdt_event_handler);
 
 /**
+ * @brief Function for reconfiguring the watchdog.
+ *
+ * @param[in] p_instance Pointer to the driver instance structure.
+ * @param[in] p_config   Pointer to the structure with the initial configuration.
+ *
+ * @retval NRFX_SUCCESS             Reconfiguration was successful.
+ * @retval NRFX_ERROR_BUSY          The watchdog is already active.
+ * @retval NRFX_ERROR_INVALID_STATE The watchdog is uninitialized.
+ */
+nrfx_err_t nrfx_wdt_reconfigure(nrfx_wdt_t const *        p_instance,
+                                nrfx_wdt_config_t const * p_config);
+
+/**
  * @brief Function for allocating a watchdog channel.
  *
- * @note This function can not be called after nrfx_wdt_start().
+ * @note This function can not be called after @ref nrfx_wdt_enable.
  *
  * @param[in]  p_instance   Pointer to the driver instance structure.
  * @param[out] p_channel_id ID of granted channel.
@@ -190,18 +211,17 @@ NRFX_STATIC_INLINE uint32_t nrfx_wdt_task_address_get(nrfx_wdt_t const * p_insta
 NRFX_STATIC_INLINE uint32_t nrfx_wdt_event_address_get(nrfx_wdt_t const * p_instance,
                                                        nrf_wdt_event_t    event);
 
-
 #ifndef NRFX_DECLARE_ONLY
 NRFX_STATIC_INLINE uint32_t nrfx_wdt_task_address_get(nrfx_wdt_t const * p_instance,
                                                       nrf_wdt_task_t     task)
 {
-    return nrf_wdt_task_address_get(p_instance->p_reg, task);
+    return nrfy_wdt_task_address_get(p_instance->p_reg, task);
 }
 
 NRFX_STATIC_INLINE uint32_t nrfx_wdt_event_address_get(nrfx_wdt_t const * p_instance,
                                                        nrf_wdt_event_t    event)
 {
-    return nrf_wdt_event_address_get(p_instance->p_reg, event);
+    return nrfy_wdt_event_address_get(p_instance->p_reg, event);
 }
 #endif // NRFX_DECLARE_ONLY
 
@@ -216,10 +236,20 @@ NRFX_STATIC_INLINE uint32_t nrfx_wdt_event_address_get(nrfx_wdt_t const * p_inst
 
 /** @} */
 
-
-void nrfx_wdt_0_irq_handler(void);
-void nrfx_wdt_1_irq_handler(void);
-
+/*
+ * Declare interrupt handlers for all enabled driver instances in the following format:
+ * nrfx_\<periph_name\>_\<idx\>_irq_handler (for example, nrfx_wdt_0_irq_handler).
+ *
+ * A specific interrupt handler for the driver instance can be retrieved by using
+ * the NRFX_WDT_INST_HANDLER_GET macro.
+ *
+ * Here is a sample of using the NRFX_WDT_INST_HANDLER_GET macro to directly map
+ * an interrupt handler in a Zephyr application:
+ *
+ * IRQ_DIRECT_CONNECT(NRFX_IRQ_NUMBER_GET(NRF_WDT_INST_GET(\<instance_index\>)), \<priority\>,
+ *                    NRFX_WDT_INST_HANDLER_GET(\<instance_index\>), 0);
+ */
+NRFX_INSTANCE_IRQ_HANDLERS_DECLARE(WDT, wdt)
 
 #ifdef __cplusplus
 }

--- a/nrfx/drivers/nrfx_common.h
+++ b/nrfx/drivers/nrfx_common.h
@@ -38,12 +38,27 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <string.h>
+#include <limits.h>
 
 #include <nrf.h>
+#include "nrfx_utils.h"
 #include <nrf_peripherals.h>
+#include "nrfx_ext.h"
 
 #ifdef __cplusplus
 extern "C" {
+#endif
+
+#if defined(__CORTEX_M) || defined(__NRFX_DOXYGEN__)
+#define ISA_ARM     1
+#elif defined(__VPR_REV)
+#define ISA_RISCV   1
+#else
+#define ISA_UNKNOWN 1
+#endif
+
+#if defined(ISA_RISCV)
+#define __STATIC_INLINE static inline
 #endif
 
 #ifndef NRFX_STATIC_INLINE
@@ -53,6 +68,8 @@ extern "C" {
 #define NRFX_STATIC_INLINE __STATIC_INLINE
 #endif
 #endif // NRFX_STATIC_INLINE
+
+#define NRFY_STATIC_INLINE __STATIC_INLINE
 
 #ifndef NRF_STATIC_INLINE
 #ifdef NRF_DECLARE_ONLY
@@ -79,7 +96,28 @@ extern "C" {
  * such warnings only in places where this macro is used for evaluation, not in
  * the whole analyzed code.
  */
-#define NRFX_CHECK(module_enabled)  (module_enabled)
+#define NRFX_CHECK(module_enabled) (module_enabled)
+
+/**
+ * @brief Macro for checking if the configured API version is greater than or equal
+ *        to the specified API version.
+ *
+ * @note API version to be used is configured using following symbols:
+ *       - @ref NRFX_CONFIG_API_VER_MAJOR
+ *       - @ref NRFX_CONFIG_API_VER_MINOR
+ *       - @ref NRFX_CONFIG_API_VER_MICRO
+ *
+ * @param[in] major Major API version.
+ * @param[in] minor Minor API version.
+ * @param[in] micro Micro API version.
+ *
+ * @retval true  Configured API version is greater than or equal to the specified API version.
+ * @retval false Configured API version is smaller than the specified API version.
+ */
+#define NRFX_API_VER_AT_LEAST(major, minor, micro) \
+    ((NRFX_CONFIG_API_VER_MAJOR >= (major)) &&     \
+     (NRFX_CONFIG_API_VER_MINOR >= (minor)) &&     \
+     (NRFX_CONFIG_API_VER_MICRO >= (micro)))
 
 /**
  * @brief Macro for creating unsigned integer with bit position @p x set.
@@ -97,7 +135,16 @@ extern "C" {
  *
  * @return Bit mask.
  */
-#define NRFX_BIT_MASK(x) (NRFX_BIT(x) - 1UL)
+#define NRFX_BIT_MASK(x) (((x) == 32) ? UINT32_MAX : ((1UL << x) - 1))
+
+/**
+ * @brief Macro for returning size in bits for given size in bytes.
+ *
+ * @param[in] x Size in bytes.
+ *
+ * @return Size in bits.
+ */
+#define NRFX_BIT_SIZE(x) ((x) << 3)
 
 /**
  * @brief Macro for concatenating two tokens in macro expansion.
@@ -114,10 +161,10 @@ extern "C" {
  *
  * @sa NRFX_CONCAT_3
  */
-#define NRFX_CONCAT_2(p1, p2)       NRFX_CONCAT_2_(p1, p2)
+#define NRFX_CONCAT_2(p1, p2) NRFX_CONCAT_2_(p1, p2)
 
 /** @brief Internal macro used by @ref NRFX_CONCAT_2 to perform the expansion in two steps. */
-#define NRFX_CONCAT_2_(p1, p2)      p1 ## p2
+#define NRFX_CONCAT_2_(p1, p2) p1 ## p2
 
 /**
  * @brief Macro for concatenating three tokens in macro expansion.
@@ -135,10 +182,10 @@ extern "C" {
  *
  * @sa NRFX_CONCAT_2
  */
-#define NRFX_CONCAT_3(p1, p2, p3)   NRFX_CONCAT_3_(p1, p2, p3)
+#define NRFX_CONCAT_3(p1, p2, p3) NRFX_CONCAT_3_(p1, p2, p3)
 
 /** @brief Internal macro used by @ref NRFX_CONCAT_3 to perform the expansion in two steps. */
-#define NRFX_CONCAT_3_(p1, p2, p3)  p1 ## p2 ## p3
+#define NRFX_CONCAT_3_(p1, p2, p3) p1 ## p2 ## p3
 
 /**
  * @brief Macro for computing the absolute value of an integer number.
@@ -148,6 +195,196 @@ extern "C" {
  * @return Absolute value.
  */
 #define NRFX_ABS(a) ((a) < (0) ? -(a) : (a))
+
+/**
+ * @brief Macro for checking whether any of the instance of the specified peripheral supports a given feature.
+ *
+ * Macro checks flags set in \<device\>_peripherals.h file.
+ *
+ * Macro supports check on instances with following names:
+ * - \<periph_name\>0 - \<periph_name\>255 - e.g. SPIM0, SPIM255
+ * - \<periph_name\>00 - \<periph_name\>099 - e.g. SPIM00, SPIM099
+ * - \<periph_name\>000 - \<periph_name\>009 - e.g. SPIM000, SPIM009
+ *
+ * @param[in] periph_name  Peripheral name, e.g. SPIM.
+ * @param[in] feature_name Feature flag name suffix following an instance name, e.g.
+ *                         _FEATURE_HARDWARE_CSN_PRESENT.
+ *
+ * @retval 1 At least one instance on current device supports a given feature.
+ * @retval 0 None of peripheral instances supports a given feature.
+ */
+#define NRFX_FEATURE_PRESENT(periph_name, feature_name)                                            \
+        NRFX_COND_CODE_0(NRFX_CONCAT(0,                                                            \
+                            _NRFX_FEATURE_PRESENT(periph_name, feature_name, 256),                 \
+                            _NRFX_FEATURE_PRESENT(NRFX_CONCAT(periph_name, 0), feature_name, 100), \
+                            _NRFX_FEATURE_PRESENT(NRFX_CONCAT(periph_name, 00), feature_name, 10)  \
+                         ),                                                                        \
+                        (0), (1))
+
+/**
+ * @brief Macro for resolving provided user macro for enabled instances of a driver.
+ *
+ * Macro checks if driver instances are enabled for all potential instaces of a
+ * peripheral. It takes peripheral name and checks whether NRFX_\<peripheral\>\<id\>_ENABLED
+ * is set to 1 and if yes then provided macro is evaluated for given instance.
+ *
+ * Macro supports check on instances with following names:
+ * - \<periph_name\>0 - \<periph_name\>255 - e.g. SPIM0, SPIM255
+ * - \<periph_name\>00 - \<periph_name\>099 - e.g. SPIM00, SPIM099
+ * - \<periph_name\>000 - \<periph_name\>009 - e.g. SPIM000, SPIM009
+ *
+ * @param[in] periph_name Peripheral name, e.g. SPIM.
+ * @param[in] macro       Macro which is resolved if driver instance is enabled. Macro has following
+ *                        arguments: macro(periph_name, prefix, i, ...).
+ * @param[in] sep         Separator added between all evaluations, in parentheses.
+ * @param[in] off_code    Code injected for disabled instances, in parentheses.
+ */
+#define NRFX_FOREACH_ENABLED(periph_name, macro, sep, off_code, ...)                  \
+        NRFX_LISTIFY(256, _NRFX_EVAL_IF_ENABLED, sep,                                 \
+                     off_code, periph_name, , macro, __VA_ARGS__) NRFX_DEBRACKET sep  \
+        NRFX_LISTIFY(100, _NRFX_EVAL_IF_ENABLED, sep,                                 \
+                     off_code, periph_name, 0, macro, __VA_ARGS__) NRFX_DEBRACKET sep \
+        NRFX_LISTIFY(10, _NRFX_EVAL_IF_ENABLED, sep,                                  \
+                     off_code, periph_name, 00, macro, __VA_ARGS__)
+
+/**
+ * @brief Macro for resolving provided user macro for present instances of a peripheral.
+ *
+ * Macro checks if peripheral instances are present by checking if there is
+ * \<peripheral\>\<id\>_PRESENT define set to 1.
+ *
+ * Macro supports check on instances with following names:
+ * - \<periph_name\>0 - \<periph_name\>255 - e.g. SPIM0, SPIM255
+ * - \<periph_name\>00 - \<periph_name\>099 - e.g. SPIM00, SPIM099
+ * - \<periph_name\>000 - \<periph_name\>009 - e.g. SPIM000, SPIM009
+ * - \<periph_name\> - e.g. SPIM
+ *
+ * @param[in] periph_name Peripheral name, e.g. SPIM.
+ * @param[in] macro       Macro which is resolved if peripheral instance is present.
+ *                        Macro has following arguments: macro(periph_name, prefix, i, ...).
+ * @param[in] sep         Separator added between all evaluations, in parentheses.
+ * @param[in] off_code    Code injected for disabled instances, in parentheses.
+ */
+#define NRFX_FOREACH_PRESENT(periph_name, macro, sep, off_code, ...)                   \
+        NRFX_LISTIFY(256, _NRFX_EVAL_IF_PRESENT, sep,                                  \
+                     off_code, periph_name, , macro, __VA_ARGS__) NRFX_DEBRACKET sep   \
+        NRFX_LISTIFY(100, _NRFX_EVAL_IF_PRESENT, sep,                                  \
+                     off_code, periph_name, 0, macro, __VA_ARGS__) NRFX_DEBRACKET sep  \
+        NRFX_LISTIFY(10, _NRFX_EVAL_IF_PRESENT, sep,                                   \
+                     off_code, periph_name, 00, macro, __VA_ARGS__) NRFX_DEBRACKET sep \
+        _NRFX_EVAL_IF_PRESENT(, off_code, periph_name, , macro, __VA_ARGS__)
+
+/**
+ * @brief Macro for resolving provided user macro on concatenated peripheral name
+ *        and instance index.
+ *
+ * Execute provided macro with single argument <instance\>
+ * that is the concatenation of @p periph_name, @p prefix and @p i.
+ *
+ * @param[in] i           Instance index.
+ * @param[in] periph_name Peripheral name, e.g. SPIM.
+ * @param[in] prefix      Prefix added before instance index, e.g. some device has
+ *                        instances named like SPIM00. First 0 is passed here as prefix.
+ * @param[in] macro       Macro which is executed.
+ * @param[in] ...         Variable length arguments passed to the @p macro. Macro has following
+ *                        arguments: macro(instance, ...).
+ */
+#define NRFX_INSTANCE_CONCAT(periph_name, prefix, i, macro, ...) \
+      macro(NRFX_CONCAT(periph_name, prefix, i), __VA_ARGS__)
+
+/**
+ * @brief Macro for creating a content for enum which is listing enabled driver instances.
+ *
+ * It creates comma separated list of entries like NRFX_\<instance_name\>_INST_IDX,
+ * e.g. (NRFX_SPIM0_INST_IDX) for all enabled instances (NRFX_\<instance_name\>_ENABLED
+ * is set to 1). It should be called within enum declaration. Created enum is used
+ * by the driver to index all enabled instances of the driver.
+ *
+ * @param[in] periph_name Peripheral name (e.g. SPIM).
+ */
+#define NRFX_INSTANCE_ENUM_LIST(periph_name) \
+        NRFX_FOREACH_ENABLED(periph_name, _NRFX_INST_ENUM, (), ())
+
+/**
+ * @brief Macro for creating an interrupt handler for all enabled driver instances.
+ *
+ * Macro creates a set of functions which calls generic @p irq_handler function with two parameters:
+ * - peripheral instance register pointer
+ * - pointer to a control block structure associated with the given instance
+ *
+ * Generic interrupt handler function with above mentioned parameters named @p irq_handler
+ * must be implemented in the driver.
+ *
+ * @note Handlers are using enum which should be generated using @ref NRFX_INSTANCE_ENUM_LIST.
+ *
+ * @param[in] periph_name       Peripheral name, e.g. SPIM.
+ * @param[in] periph_name_small Peripheral name written with small letters, e.g. spim.
+ */
+#define NRFX_INSTANCE_IRQ_HANDLERS(periph_name, periph_name_small) \
+    NRFX_FOREACH_ENABLED(periph_name, _NRFX_IRQ_HANDLER, (), (), periph_name_small)
+
+/**
+ * @brief Macro for creating an interrupt handler for all enabled driver instances
+ *        with the specified extra parameter.
+ *
+ * Macro creates set of function which calls generic @p irq_handler function with three parameters:
+ * - peripheral instance register pointer
+ * - pointer to a control block structure associated with the given instance
+ * - provided @p ext_macro called with peripheral name suffix (e.g. 01 for TIMER01)
+ *
+ * Generic interrupt handler function with above mentioned parameters named @p irq_handler
+ * must be implemented in the driver.
+ *
+ * @note Handlers are using enum which should be generated using @ref NRFX_INSTANCE_ENUM_LIST.
+ *
+ * @param[in] periph_name       Peripheral name, e.g. SPIM.
+ * @param[in] periph_name_small Peripheral name written with small letters, e.g. rtc.
+ * @param[in] ext_macro         External macro to be executed for each instance.
+ */
+#define NRFX_INSTANCE_IRQ_HANDLERS_EXT(periph_name, periph_name_small, ext_macro) \
+    NRFX_FOREACH_ENABLED(periph_name, _NRFX_IRQ_HANDLER_EXT, (), (), periph_name_small, ext_macro)
+
+/**
+ * @brief Macro for declaring an interrupt handler for all enabled driver instances.
+ *
+ * Macro creates set of function declarations. It is intended to be used in the driver header.
+ *
+ * @param[in] periph_name       Peripheral name, e.g. SPIM.
+ * @param[in] periph_name_small Peripheral name written with small letters, e.g. spim.
+ */
+#define NRFX_INSTANCE_IRQ_HANDLERS_DECLARE(periph_name, periph_name_small) \
+    NRFX_FOREACH_ENABLED(periph_name, _NRFX_IRQ_HANDLER_DECLARE, (), (), periph_name_small)
+
+/**
+ * @brief Macro for generating comma-separated list of interrupt handlers for all
+ *        enabled driver instances.
+ *
+ * Interrupt handlers are generated using @ref NRFX_INSTANCE_IRQ_HANDLERS.
+ * It is intended to be used to create a list which is used for passing an interrupt
+ * handler function to the PRS driver.
+ *
+ * @param[in] periph_name       Peripheral name, e.g. SPIM.
+ * @param[in] periph_name_small Peripheral name written with small letters, e.g. spim.
+ */
+#define NRFX_INSTANCE_IRQ_HANDLERS_LIST(periph_name, periph_name_small) \
+    NRFX_FOREACH_ENABLED(periph_name, _NRFX_IRQ_HANDLER_LIST, (), (), periph_name_small)
+
+/**
+ * @brief Macro for checking if given peripheral instance is present on the target.
+ *
+ * Macro utilizes the fact that for each existing instance a define is created which points to
+ * the memory mapped register set casted to a register set structure. It is wrapped in parenthesis
+ * and existance of parethesis wrapping is used to determine if instance exists. It if does not
+ * exist then token (e.g. NRF_SPIM10) is undefined so it does not have parenthesis wrapping.
+ *
+ * Since macro returns literal 1 it can be used by other macros.
+ *
+ * @param[in] _inst Instance, .e.g SPIM10.
+ *
+ * @retval 1 If instance is present.
+ * @retval 0 If instance is not present.
+ */
+#define NRFX_INSTANCE_PRESENT(_inst) NRFX_ARG_HAS_PARENTHESIS(NRFX_CONCAT(NRF_, _inst))
 
 /**
  * @brief Macro for getting the smaller value between two arguments.
@@ -192,7 +429,7 @@ extern "C" {
  *
  * @return Integer result of dividing @c a by @c b, rounded up.
  */
-#define NRFX_CEIL_DIV(a, b)  ((((a) - 1) / (b)) + 1)
+#define NRFX_CEIL_DIV(a, b) ((((a) - 1) / (b)) + 1)
 
 /**
  * @brief Macro for getting the number of elements in an array.
@@ -212,7 +449,27 @@ extern "C" {
  *
  * @return Member offset in bytes.
  */
-#define NRFX_OFFSETOF(type, member)  ((size_t)&(((type *)0)->member))
+#define NRFX_OFFSETOF(type, member) ((size_t) & (((type *)0)->member))
+
+/**
+ * @brief Macro for checking whether given number is power of 2.
+ *
+ * @param[in] val Tested value.
+ *
+ * @retval true  The value is power of 2.
+ * @retval false The value is not power of 2.
+ */
+#define NRFX_IS_POWER_OF_TWO(val) (((val) != 0) && ((val) & ((val) - 1)) == 0)
+
+/**
+ * @brief Macro for checking whether a given number is even.
+ *
+ * @param[in] val Tested value.
+ *
+ * @retval true  The value is even.
+ * @retval false The value is odd.
+ */
+#define NRFX_IS_EVEN(val) (((val) % 2)  == 0)
 
 /**
  * @brief Macro for checking if given lengths of EasyDMA transfers do not exceed
@@ -263,7 +520,7 @@ do {                                                         \
  *
  * @return ID number associated with the specified peripheral.
  */
-#define NRFX_PERIPHERAL_ID_GET(base_addr)  (uint8_t)((uint32_t)(base_addr) >> 12)
+#define NRFX_PERIPHERAL_ID_GET(base_addr) (uint16_t)(((uint32_t)(base_addr) >> 12) & 0x000001FF)
 
 /**
  * @brief Macro for getting the interrupt number assigned to a specific
@@ -277,7 +534,25 @@ do {                                                         \
  *
  * @return Interrupt number associated with the specified peripheral.
  */
-#define NRFX_IRQ_NUMBER_GET(base_addr)  NRFX_PERIPHERAL_ID_GET(base_addr)
+#define NRFX_IRQ_NUMBER_GET(base_addr) NRFX_PERIPHERAL_ID_GET(base_addr)
+
+/**
+ * @brief Macro for converting frequency in kHz to Hz.
+ *
+ * @param[in] freq Frequency value in kHz.
+ *
+ * @return Number of Hz in @p freq kHz.
+ */
+#define NRFX_KHZ_TO_HZ(freq) ((freq) * 1000)
+
+/**
+ * @brief Macro for converting frequency in MHz to Hz.
+ *
+ * @param[in] freq Frequency value in MHz.
+ *
+ * @return Number of Hz in @p freq MHz.
+ */
+#define NRFX_MHZ_TO_HZ(freq) ((freq) * 1000 * 1000)
 
 /** @brief IRQ handler type. */
 typedef void (* nrfx_irq_handler_t)(void);
@@ -289,7 +564,6 @@ typedef enum
     NRFX_DRV_STATE_INITIALIZED,   ///< Initialized but powered off.
     NRFX_DRV_STATE_POWERED_ON,    ///< Initialized and powered on.
 } nrfx_drv_state_t;
-
 
 /**
  * @brief Function for checking if an object is placed in the Data RAM region.
@@ -359,7 +633,6 @@ NRF_STATIC_INLINE uint32_t nrfx_bitpos_to_event(uint32_t bit);
  * @sa nrfx_bitpos_to_event
  */
 NRF_STATIC_INLINE uint32_t nrfx_event_to_bitpos(uint32_t event);
-
 
 #ifndef NRF_DECLARE_ONLY
 

--- a/nrfx/drivers/nrfx_ext.h
+++ b/nrfx/drivers/nrfx_ext.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2022 - 2023, Nordic Semiconductor ASA
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef NRFX_EXT_H__
+#define NRFX_EXT_H__
+
+#endif // NRFX_EXT_H__

--- a/nrfx/drivers/nrfx_utils.h
+++ b/nrfx/drivers/nrfx_utils.h
@@ -1,0 +1,348 @@
+/*
+ * Copyright (c) 2022 - 2023, Nordic Semiconductor ASA
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef NRFX_UTILS_H__
+#define NRFX_UTILS_H__
+
+#include "nrfx_utils_internal.h"
+
+/**
+ * @defgroup nrfx_utils Preprocessor utility macros
+ * @{
+ * @ingroup nrfx
+ * @brief Preprocessor utility macros.
+ */
+
+/**
+ * @brief Macro for inserting code depending on whether @p _flag exists and expands to 1 or not.
+ *
+ * To prevent the preprocessor from treating commas as argument
+ * separators, the @p _if_1_code and @p _else_code expressions must be
+ * inside brackets/parentheses: <tt>()</tt>. These are stripped away
+ * during macro expansion.
+ *
+ * Example:
+ *
+ *     NRFX_COND_CODE_1(CONFIG_FLAG, (uint32_t x;), (there_is_no_flag();))
+ *
+ * If @p CONFIG_FLAG is defined to 1, this expands to:
+ *
+ *     uint32_t x;
+ *
+ * It expands to <tt>there_is_no_flag();</tt> otherwise.
+ *
+ * This could be used as an alternative to:
+ *
+ *     #if defined(CONFIG_FLAG) && (CONFIG_FLAG == 1)
+ *     #define MAYBE_DECLARE(x) uint32_t x
+ *     #else
+ *     #define MAYBE_DECLARE(x) there_is_no_flag()
+ *     #endif
+ *
+ *     MAYBE_DECLARE(x);
+ *
+ * However, the advantage of COND_CODE_1() is that code is resolved in
+ * place where it is used, while the @p \#if method defines @p
+ * MAYBE_DECLARE on two lines and requires it to be invoked again on a
+ * separate line. This makes COND_CODE_1() more concise and also
+ * sometimes more useful when used within another macro's expansion.
+ *
+ * @note @p _flag can be the result of preprocessor expansion,
+ *       however @p _if_1_code is only expanded if @p _flag expands
+ *       to the integer literal 1. Integer expressions that evaluate
+ *       to 1, e.g. after doing some arithmetic, will not work.
+ *
+ * @param[in] _flag      Evaluated flag
+ * @param[in] _if_1_code Result if @p _flag expands to 1; must be in parentheses
+ * @param[in] _else_code Result otherwise; must be in parentheses
+ */
+#define NRFX_COND_CODE_1(_flag, _if_1_code, _else_code) \
+    _NRFX_COND_CODE_1(_flag, _if_1_code, _else_code)
+
+/**
+ * @brief Macro for inserting code depending on whether @p _flag exists and expands to 0 or not.
+ *
+ * This is like @ref NRFX_COND_CODE_1(), except that it tests whether @p _flag
+ * expands to the integer literal 0. It expands to @p _if_0_code if
+ * so, and @p _else_code otherwise; both of these must be enclosed in
+ * parentheses.
+ *
+ * @param[in] _flag      Evaluated flag
+ * @param[in] _if_0_code Result if @p _flag expands to 0; must be in parentheses
+ * @param[in] _else_code Result otherwise; must be in parentheses
+ */
+#define NRFX_COND_CODE_0(_flag, _if_0_code, _else_code) \
+    _NRFX_COND_CODE_0(_flag, _if_0_code, _else_code)
+
+/**
+ * @brief Macro for checking for macro definition in compiler-visible expressions
+ *
+ * It has the effect of taking a macro value that may be defined to "1"
+ * or may not be defined at all and turning it into a literal
+ * expression that can be handled by the C compiler instead of just
+ * the preprocessor.
+ *
+ * That is, it works similarly to <tt>\#if defined(CONFIG_FOO)</tt>
+ * except that its expansion is a C expression. Thus, much <tt>\#ifdef</tt>
+ * usage can be replaced with equivalents like:
+ *
+ *     if (IS_ENABLED(CONFIG_FOO)) {
+ *             do_something_with_foo
+ *     }
+ *
+ * This is cleaner since the compiler can generate errors and warnings
+ * for @p do_something_with_foo even when @p CONFIG_FOO is undefined.
+ *
+ * @param[in] config_macro Macro to check
+ *
+ * @return 1 if @p config_macro is defined to 1, 0 otherwise (including
+ *         if @p config_macro is not defined)
+ */
+#define NRFX_IS_ENABLED(config_macro) _NRFX_IS_ENABLED1(config_macro)
+
+/**
+ * @brief Macro for generating a sequence of code with configurable separator.
+ *
+ * Example:
+ *
+ *     #define FOO(i, _) MY_PWM ## i
+ *     { NRFX_LISTIFY(PWM_COUNT, FOO, (,)) }
+ *
+ * The above two lines expand to:
+ *
+ *    { MY_PWM0 , MY_PWM1 }
+ *
+ * @param[in] LEN The length of the sequence. Must be an integer literal less
+ *                than 255.
+ * @param[in] F   A macro function that accepts at least two arguments:
+ *                <tt>F(i, ...)</tt>. @p F is called repeatedly in the expansion.
+ *                Its first argument @p i is the index in the sequence, and
+ *                the variable list of arguments passed to LISTIFY are passed
+ *                through to @p F.
+ * @param[in] sep Separator (e.g. comma or semicolon). Must be in parentheses;
+ *            this is required to enable providing a comma as separator.
+ *
+ * @note Calling NRFX_LISTIFY with undefined arguments has undefined behavior.
+ */
+#define NRFX_LISTIFY(LEN, F, sep, ...) \
+    NRFX_CONCAT_2(_NRFX_LISTIFY_, LEN)(F, sep, __VA_ARGS__)
+
+/**
+ * @brief Macro for checking if input argument is empty.
+ *
+ * Empty means that nothing is provided or provided value is resolved to nothing
+ * (e.g. empty define).
+ *
+ * Macro idea is taken from P99 which is under Apache 2.0 license and described by
+ * Jens Gustedt https://gustedt.wordpress.com/2010/06/08/detect-empty-macro-arguments/
+ *
+ * @param arg Argument.
+ *
+ * @retval 1 if argument is empty.
+ * @retval 0 if argument is not empty.
+ */
+#define NRFX_IS_EMPTY(arg) _NRFX_IS_EMPTY(arg)
+
+/**
+ * @brief Macro for calculating number of arguments in the variable arguments list minus one.
+ *
+ * @param[in] ... List of arguments
+ *
+ * @return Number of variadic arguments in the argument list, minus one
+ */
+#define NRFX_NUM_VA_ARGS_LESS_1(...) \
+        _NRFX_NUM_VA_ARGS_LESS_1_IMPL(__VA_ARGS__, 63, 62, 61, \
+                    60, 59, 58, 57, 56, 55, 54, 53, 52, 51, \
+                    50, 49, 48, 47, 46, 45, 44, 43, 42, 41, \
+                    40, 39, 38, 37, 36, 35, 34, 33, 32, 31, \
+                    30, 29, 28, 27, 26, 25, 24, 23, 22, 21, \
+                    20, 19, 18, 17, 16, 15, 14, 13, 12, 11, \
+                    10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, ~)
+
+/**
+ * @brief Macro for concatenating multiple arguments.
+ *
+ * Support up to 8 arguments.
+ *
+ * @param[in] ... Arguments to concatenate.
+ */
+#define NRFX_CONCAT(...) \
+    NRFX_CONCAT_2(_NRFX_CONCAT_, NRFX_NUM_VA_ARGS_LESS_1(__VA_ARGS__))(__VA_ARGS__)
+
+/**
+ * @brief Macro for checking if argument starts with opening round bracket and contains matching
+ *        closing bracket (parenthesis).
+ *
+ * @param[in] x Input argument.
+ *
+ * @retval 1 If input argument starts with opening bracket and contains closing bracket.
+ * @retval 0 If input argument does not match above mentioned condition.
+ */
+#define NRFX_ARG_HAS_PARENTHESIS(x) _NRFX_GET_ARG3(_NRFX_EVAL(_NRFX_ARG_HAS_PARENTHESIS x, 1, 0))
+
+/**
+ * @brief Macro for calling a macro @p F on each provided argument with a given
+ *        separator between each call.
+ *
+ * Example:
+ *
+ *     #define F(x) int a##x
+ *     NRFX_FOR_EACH(F, (;), 4, 5, 6);
+ *
+ * This expands to:
+ *
+ *     int a4;
+ *     int a5;
+ *     int a6;
+ *
+ * @param F Macro to invoke
+ * @param sep Separator (e.g. comma or semicolon). Must be in parentheses;
+ *            this is required to enable providing a comma as a separator.
+ * @param ... Variable argument list. The macro @p F is invoked as
+ *            <tt>F(element)</tt> for each element in the list.
+ */
+#define NRFX_FOR_EACH(F, sep, ...) \
+    _NRFX_FOR_EACH(F, sep, NRFX_REVERSE_ARGS(__VA_ARGS__))
+
+/**
+ * @brief Call macro @p F on each provided argument, with the argument's index
+ *        as an additional parameter.
+ *
+ * This is like @ref NRFX_FOR_EACH(), except @p F should be a macro which takes two
+ * arguments: <tt>F(index, variable_arg)</tt>.
+ *
+ * Example:
+ *
+ *     #define F(idx, x) int a##idx = x
+ *     NRFX_FOR_EACH_IDX(F, (;), 4, 5, 6);
+ *
+ * This expands to:
+ *
+ *     int a0 = 4;
+ *     int a1 = 5;
+ *     int a2 = 6;
+ *
+ * @param F Macro to invoke
+ * @param sep Separator (e.g. comma or semicolon). Must be in parentheses;
+ *            this is required to enable providing a comma as a separator.
+ * @param ... Variable argument list. The macro @p F is invoked as
+ *            <tt>F(index, element)</tt> for each element in the list.
+ */
+#define NRFX_FOR_EACH_IDX(F, sep, ...) \
+    _NRFX_FOR_EACH_IDX(F, sep, NRFX_REVERSE_ARGS(__VA_ARGS__))
+
+/**
+ * @brief Macro for calling macro @p F on each provided argument, with an additional fixed
+ *        argument as a parameter.
+ *
+ * This is like @ref NRFX_FOR_EACH(), except @p F should be a macro which takes two
+ * arguments: <tt>F(variable_arg, fixed_arg)</tt>.
+ *
+ * Example:
+ *
+ *     static void func(int val, void *dev);
+ *     NRFX_FOR_EACH_FIXED_ARG(func, (;), dev, 4, 5, 6);
+ *
+ * This expands to:
+ *
+ *     func(4, dev);
+ *     func(5, dev);
+ *     func(6, dev);
+ *
+ * @param F Macro to invoke
+ * @param sep Separator (e.g. comma or semicolon). Must be in parentheses;
+ *            this is required to enable providing a comma as a separator.
+ * @param fixed_arg Fixed argument passed to @p F as the second macro parameter.
+ * @param ... Variable argument list. The macro @p F is invoked as
+ *            <tt>F(element, fixed_arg)</tt> for each element in the list.
+ */
+#define NRFX_FOR_EACH_FIXED_ARG(F, sep, fixed_arg, ...) \
+    _NRFX_FOR_EACH_FIXED_ARG(F, sep, fixed_arg, NRFX_REVERSE_ARGS(__VA_ARGS__))
+
+/**
+ * @brief Macro from calling macro @p F for each variable argument with an index and fixed
+ *        argument
+ *
+ * This is like the combination of @ref NRFX_FOR_EACH_IDX() with @ref NRFX_FOR_EACH_FIXED_ARG().
+ *
+ * Example:
+ *
+ *     #define F(idx, x, fixed_arg) int fixed_arg##idx = x
+ *     NRFX_FOR_EACH_IDX_FIXED_ARG(F, (;), a, 4, 5, 6);
+ *
+ * This expands to:
+ *
+ *     int a0 = 4;
+ *     int a1 = 5;
+ *     int a2 = 6;
+ *
+ * @param F Macro to invoke
+ * @param sep Separator (e.g. comma or semicolon). Must be in parentheses;
+ *            This is required to enable providing a comma as a separator.
+ * @param fixed_arg Fixed argument passed to @p F as the third macro parameter.
+ * @param ... Variable list of arguments. The macro @p F is invoked as
+ *            <tt>F(index, element, fixed_arg)</tt> for each element in
+ *            the list.
+ */
+#define NRFX_FOR_EACH_IDX_FIXED_ARG(F, sep, fixed_arg, ...) \
+    _NRFX_FOR_EACH_IDX_FIXED_ARG(F, sep, fixed_arg, NRFX_REVERSE_ARGS(__VA_ARGS__))
+
+/**
+ * @brief Macro for reversing arguments order.
+ *
+ * @param ... Variable argument list.
+ *
+ * @return Input arguments in reversed order.
+ */
+#define NRFX_REVERSE_ARGS(...) \
+    _NRFX_FOR_EACH_ENGINE(_NRFX_FOR_EACH_EXEC, (,), NRFX_EVAL, _, __VA_ARGS__)
+
+
+/**
+ * @brief Macro for getting the highest value from input arguments.
+ *
+ * It is similar to @ref NRFX_MAX but accepts a variable number of arguments.
+ *
+ * @note Input arguments must be numeric variables.
+ *
+ * @param ... Variable argument list.
+ *
+ * @return Highest value from the input list.
+ */
+#define NRFX_MAX_N(...) \
+    NRFX_EVAL(NRFX_FOR_EACH(_NRFX_MAX_P1, (), __VA_ARGS__) 0 \
+              NRFX_FOR_EACH(_NRFX_MAX_P2, (), __VA_ARGS__))
+
+/** @} */
+
+#endif /* NRFX_UTILS_H__ */

--- a/nrfx/drivers/nrfx_utils_internal.h
+++ b/nrfx/drivers/nrfx_utils_internal.h
@@ -1,0 +1,1730 @@
+/*
+ * Copyright (c) 2022 - 2023, Nordic Semiconductor ASA
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef NRFX_UTILS_INTERNAL_H__
+#define NRFX_UTILS_INTERNAL_H__
+
+/* NRFX_IS_ENABLED() helpers */
+
+/* This is called from NRFX_IS_ENABLED(), and sticks on a "_XXXX" prefix,
+ * it will now be "_XXXX1" if config_macro is "1", or just "_XXXX" if it's
+ * undefined.
+ *   ENABLED:   NRFX_IS_ENABLED2(_XXXX1)
+ *   DISABLED   NRFX_IS_ENABLED2(_XXXX)
+ */
+#define _NRFX_IS_ENABLED1(config_macro) _NRFX_IS_ENABLED2(_XXXX##config_macro)
+
+/* Here's the core trick, we map "_XXXX1" to "_YYYY," (i.e. a string
+ * with a trailing comma), so it has the effect of making this a
+ * two-argument tuple to the preprocessor only in the case where the
+ * value is defined to "1"
+ *   ENABLED:    _YYYY,    <--- note comma!
+ *   DISABLED:   _XXXX
+ */
+#define _XXXX1 _YYYY,
+
+/* Then we append an extra argument to fool the gcc preprocessor into
+ * accepting it as a varargs macro.
+ *                         arg1   arg2  arg3
+ *   ENABLED:   NRFX_IS_ENABLED3(_YYYY,    1,    0)
+ *   DISABLED   NRFX_IS_ENABLED3(_XXXX 1,  0)
+ */
+#define _NRFX_IS_ENABLED2(one_or_two_args) _NRFX_IS_ENABLED3(one_or_two_args 1, 0)
+
+/* And our second argument is thus now cooked to be 1 in the case
+ * where the value is defined to 1, and 0 if not:
+ */
+#define _NRFX_IS_ENABLED3(ignore_this, val, ...) val
+
+/* Used internally by NRFX_COND_CODE_1 and NRFX_COND_CODE_0. */
+#define _NRFX_COND_CODE_1(_flag, _if_1_code, _else_code) \
+    _NRFX_COND_CODE1(_XXXX##_flag, _if_1_code, _else_code)
+
+#define _NRFX_COND_CODE_0(_flag, _if_0_code, _else_code) \
+    _NRFX_COND_CODE1(_ZZZZ##_flag, _if_0_code, _else_code)
+
+#define _ZZZZ0 _YYYY,
+
+#define _NRFX_COND_CODE1(one_or_two_args, _if_code, _else_code) \
+    NRFX_GET_ARG2_DEBRACKET(one_or_two_args _if_code, _else_code)
+
+#define NRFX_GET_ARG2_DEBRACKET(ignore_this, val, ...) NRFX_DEBRACKET val
+
+#define NRFX_DEBRACKET(...) __VA_ARGS__
+
+#define NRFX_EVAL(...) __VA_ARGS__
+
+#define NRFX_EMPTY()
+
+/* Helper macros used for @ref NRFX_MAX_N. */
+#define _NRFX_MAX_P1(x) NRFX_MAX NRFX_EMPTY() ((x),
+#define _NRFX_MAX_P2(x) )
+
+/* Implementation details for NRFX_NUM_VA_ARGS_LESS_1 */
+#define _NRFX_NUM_VA_ARGS_LESS_1_IMPL(\
+            _ignored,\
+            _0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10,\
+            _11, _12, _13, _14, _15, _16, _17, _18, _19, _20,\
+            _21, _22, _23, _24, _25, _26, _27, _28, _29, _30,\
+            _31, _32, _33, _34, _35, _36, _37, _38, _39, _40,\
+            _41, _42, _43, _44, _45, _46, _47, _48, _49, _50,\
+            _51, _52, _53, _54, _55, _56, _57, _58, _59, _60,\
+            _61, _62, N, ...) N
+
+/* Intermediate macros needed for @ref NRFX_FEATURE_PRESENT. */
+#define NRFX_INSTANCE_FEATURE_PRESENT(i, _instance_name, _feature_name) \
+        NRFX_COND_CODE_1(NRFX_CONCAT_3(_instance_name, i, _feature_name), (1), ())
+
+#define _NRFX_FEATURE_PRESENT(_instance_name, _feature_name, _rpt) \
+        NRFX_LISTIFY(_rpt, NRFX_INSTANCE_FEATURE_PRESENT, (), _instance_name, _feature_name)
+
+
+/** Used by @ref NRFX_FOREACH_ENABLED. Execute provided macro if driver instance is enabled.
+ *
+ * @param[in] i           Instance index.
+ * @param[in] off_code    Code which is pasted when given driver instance is disabled.
+ *                        Must be given in parentheses.
+ * @param[in] periph_name Peripheral name, e.g. SPIM.
+ * @param[in] prefix      Prefix added before instance index, e.g. some device has
+ *                        instances named like SPIM00. First 0 is passed here as prefix.
+ * @param[in] macro       Macro which is executed.
+ * @param[in] ...         Variable length arguments passed to the @p macro. Macro has following
+ *                        arguments: macro(periph_name, prefix, i, ...).
+ */
+#define _NRFX_EVAL_IF_ENABLED(i, off_code, periph_name, prefix, macro, ...) \
+        NRFX_COND_CODE_1(NRFX_CONCAT(NRFX_, periph_name, prefix, i, _ENABLED), \
+                    (macro(periph_name, prefix, i, __VA_ARGS__)), \
+                    off_code)
+
+/** Used by @ref NRFX_FOREACH_PRESENT. Execute provided macro if instance is present.
+ *
+ * Presence is determined by existing of token NRF_\<instance\> defined with wrapped
+ * in parenthesis value (see @ref NRFX_INSTANCE_PRESENT), where <instance\> is the concatenation
+ * of @p periph_name, @p prefix and @p i.
+ *
+ * @param[in] i           Instance index.
+ * @param[in] off_code    Code which is pasted when given driver instance is disabled.
+ *                        Must be given in parentheses.
+ * @param[in] periph_name Peripheral name, e.g. SPIM.
+ * @param[in] prefix      Prefix added before instance index, e.g. some device has
+ *                        instances named like SPIM00. First 0 is passed here as prefix.
+ * @param[in] macro       Macro which is executed.
+ * @param[in] ...         Variable length arguments passed to the @p macro. Macro has following
+ *                        arguments: macro(periph_name, prefix, i, ...).
+ */
+#define _NRFX_EVAL_IF_PRESENT(i, off_code, periph_name, prefix, macro, ...) \
+        NRFX_COND_CODE_1(NRFX_INSTANCE_PRESENT(NRFX_CONCAT(periph_name, prefix, i)), \
+                    (macro(periph_name, prefix, i, __VA_ARGS__)), \
+                    off_code)
+
+/* Macro used for enabled driver instances enum generation. */
+#define _NRFX_INST_ENUM(periph_name, prefix, i, _) \
+    NRFX_CONCAT(NRFX_, periph_name, prefix, i, _INST_IDX),
+
+/* Macro used for generation of irq handlers.
+ *
+ * Macro is using enum created by _NRFX_INSG_ENUM macro.
+ *
+ * @param[in] periph_name       Peripheral name, e.g. SPIM.
+ * @param[in] prefix            Prefix appended to the index.
+ * @param[in] i                 Index.
+ * @param[in] periph_name_small Peripheral name in small letters, e.g. spim.
+ */
+#define _NRFX_IRQ_HANDLER(periph_name, prefix, i, periph_name_small) \
+void NRFX_CONCAT(nrfx_, periph_name_small, _, prefix, i, _irq_handler)(void) \
+{ \
+    irq_handler(NRFX_CONCAT(NRF_, periph_name, prefix, i), \
+                &m_cb[NRFX_CONCAT(NRFX_, periph_name, prefix, i, _INST_IDX)]); \
+}
+
+/* Macro used for generation of irq handlers with addtional parameter.
+ *
+ * Additional parameter passed to the interrupt handler is a value returned by
+ * @p ext_macro. One of the use cases is a peripheral with variable number of
+ * channels (e.g. RTC or TIMER).
+ *
+ * Macro is using enum created by _NRFX_INSG_ENUM macro.
+ *
+ * @param[in] periph_name       Peripheral name, e.g. SPIM.
+ * @param[in] prefix            Prefix appended to the index.
+ * @param[in] i                 Index.
+ * @param[in] periph_name_small Peripheral name in small letters, e.g. spim.
+ * @param[in] ext_macro         Macro called as third parameter of the handler.
+ */
+#define _NRFX_IRQ_HANDLER_EXT(periph_name, prefix, i, periph_name_small, ext_macro) \
+void NRFX_CONCAT(nrfx_, periph_name_small, _, prefix, i, _irq_handler)(void) \
+{ \
+    irq_handler(NRFX_CONCAT(NRF_, periph_name, prefix, i), \
+                &m_cb[NRFX_CONCAT(NRFX_, periph_name, prefix, i, _INST_IDX)], \
+                ext_macro(NRFX_CONCAT(prefix, i))); \
+}
+
+#define _NRFX_IRQ_HANDLER_LIST(periph_name, prefix, i, periph_name_small) \
+    NRFX_CONCAT(nrfx_, periph_name_small, _, prefix, i, _irq_handler),
+
+#define _NRFX_IRQ_HANDLER_DECLARE(periph_name, prefix, i, periph_name_small) \
+    void NRFX_CONCAT(nrfx_, periph_name_small, _, prefix, i, _irq_handler)(void);
+
+/* Macro for getting third argument from the set of input arguments. */
+#define __NRFX_GET_ARG3(arg1, arg2, arg3, ...) arg3
+#define _NRFX_GET_ARG3(...) __NRFX_GET_ARG3(__VA_ARGS__)
+
+/* Macro for triggering argument evaluation. */
+#define _NRFX_EVAL(...) __VA_ARGS__
+
+/* Macro used for a trick which detects if input argument is wrapped in parenthesis.
+ *
+ * Macro that has parenthesis will expand to additional comma (additional argument)
+ * and that is used to return 0 or 1.
+ */
+#define _NRFX_ARG_HAS_PARENTHESIS(...) ,
+
+#define _NRFX_ARG16(_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, ...) _15
+
+/* Returns 1 if there is a comma in the arguments (if there is more than one argument) */
+#define _NRFX_HAS_COMMA(...) \
+    _NRFX_ARG16(__VA_ARGS__, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0)
+
+/* Internal macro used for @ref NRFX_IS_EMPTY */
+#define _NRFX_IS_EMPTY2(_0, _1, _2, _3) \
+    _NRFX_HAS_COMMA(NRFX_CONCAT(_NRFX_IS_EMPTY_CASE_, _0, _1, _2, _3))
+
+#define _NRFX_IS_EMPTY_CASE_0001 ,
+
+/* Internal macro used for @ref NRFX_IS_EMPTY */
+#define _NRFX_IS_EMPTY(...)                                                                 \
+    _NRFX_IS_EMPTY2(                                                                        \
+    /* test if there is just one argument, eventually an empty one */                       \
+    _NRFX_HAS_COMMA(__VA_ARGS__),                                                           \
+    /* test if _TRIGGER_PARENTHESIS_ together with the argument adds a comma */             \
+    _NRFX_HAS_COMMA(_NRFX_ARG_HAS_PARENTHESIS __VA_ARGS__),                                 \
+    /* test if the argument together with a parenthesis adds a comma */                     \
+    _NRFX_HAS_COMMA(__VA_ARGS__ (/*empty*/)),                                               \
+    /* test if placing it between _TRIGGER_PARENTHESIS_ and the parenthesis adds a comma */ \
+    _NRFX_HAS_COMMA(_NRFX_ARG_HAS_PARENTHESIS __VA_ARGS__ (/*empty*/))                      \
+    )
+
+/**
+ * @brief Macro for generating else if statement code blocks that assignes token \<periph_name\>\<prefix\>\<i\>\<suffix\>
+ *        to the variable \<var\> if \<p_reg\> points to the instance NRF_\<periph_name\>\<prefix\>\<i\>.
+ *
+ * @param[in] periph_name Peripheral name, e.g. SPIM.
+ * @param[in] prefix      Prefix appended to the index.
+ * @param[in] i           Index.
+ * @param[in] var         Variable.
+ * @param[in] suffix      Suffix following an instance name, e.g. _CH_NUM.
+ * @param[in] p_reg       Specific peripheral instance register pointer.
+ */
+#define NRF_INTERNAL_ELSE_IF_EXTRACT_1(periph_name, prefix, i, var, suffix, p_reg) \
+    else if (p_reg == NRFX_CONCAT(NRF_, periph_name, prefix, i))                   \
+    {                                                                              \
+        var = NRFX_CONCAT(periph_name, prefix, i, suffix);                         \
+    }
+
+/**
+ * Macro used with @p NRFX_FOREACH_PRESENT for generating comma separated
+ * \<periph_name\>\<prefix\>\<i\>_CH_NUM tokens.
+ */
+#define NRFX_INTERNAL_CHAN_NUM(periph_name, prefix, i, _) \
+    NRFX_CONCAT(periph_name, prefix, i, _CH_NUM),
+
+/* Internal macros for @ref NRFX_FOR_EACH_IDX_FIXED_ARG */
+#define _NRFX_FOR_EACH_IDX_FIXED_ARG_EXEC(idx, x, fixed_arg0, fixed_arg1) \
+    fixed_arg0(idx, x, fixed_arg1)
+
+#define _NRFX_FOR_EACH_IDX_FIXED_ARG(F, sep, fixed_arg, ...) \
+    _NRFX_FOR_EACH_ENGINE(_NRFX_FOR_EACH_IDX_FIXED_ARG_EXEC, sep, \
+                      F, fixed_arg, __VA_ARGS__)
+
+/* Internal macros for @ref NRFX_FOR_EACH_FIXED_ARG */
+#define _NRFX_FOR_EACH_FIXED_ARG_EXEC(idx, x, fixed_arg0, fixed_arg1) \
+    fixed_arg0(x, fixed_arg1)
+
+#define _NRFX_FOR_EACH_FIXED_ARG(F, sep, fixed_arg, ...) \
+    _NRFX_FOR_EACH_ENGINE(_NRFX_FOR_EACH_FIXED_ARG_EXEC, sep, \
+                      F, fixed_arg, __VA_ARGS__)
+
+/* Internal macros for @ref NRFX_FOR_EACH_IDX */
+#define _NRFX_FOR_EACH_IDX_EXEC(idx, x, fixed_arg0, fixed_arg1) \
+    fixed_arg0(idx, x)
+
+#define _NRFX_FOR_EACH_IDX(F, sep, ...) \
+    _NRFX_FOR_EACH_ENGINE(_NRFX_FOR_EACH_IDX_EXEC, sep, F, _, __VA_ARGS__)
+
+/* Internal macros for @ref NRFX_FOR_EACH */
+#define _NRFX_FOR_EACH(F, sep, ...) \
+    _NRFX_FOR_EACH_ENGINE(_NRFX_FOR_EACH_EXEC, sep, F, _, __VA_ARGS__)
+
+#define _NRFX_FOR_EACH_EXEC(idx, x, fixed_arg0, fixed_arg1) \
+    fixed_arg0(x)
+
+#define _NRFX_FOR_EACH_ENGINE(x, sep, fixed_arg0, fixed_arg1, ...) \
+    _NRFX_FOR_LOOP_GET_ARG(__VA_ARGS__, \
+        _NRFX_FOR_LOOP_64, \
+        _NRFX_FOR_LOOP_63, \
+        _NRFX_FOR_LOOP_62, \
+        _NRFX_FOR_LOOP_61, \
+        _NRFX_FOR_LOOP_60, \
+        _NRFX_FOR_LOOP_59, \
+        _NRFX_FOR_LOOP_58, \
+        _NRFX_FOR_LOOP_57, \
+        _NRFX_FOR_LOOP_56, \
+        _NRFX_FOR_LOOP_55, \
+        _NRFX_FOR_LOOP_54, \
+        _NRFX_FOR_LOOP_53, \
+        _NRFX_FOR_LOOP_52, \
+        _NRFX_FOR_LOOP_51, \
+        _NRFX_FOR_LOOP_50, \
+        _NRFX_FOR_LOOP_49, \
+        _NRFX_FOR_LOOP_48, \
+        _NRFX_FOR_LOOP_47, \
+        _NRFX_FOR_LOOP_46, \
+        _NRFX_FOR_LOOP_45, \
+        _NRFX_FOR_LOOP_44, \
+        _NRFX_FOR_LOOP_43, \
+        _NRFX_FOR_LOOP_42, \
+        _NRFX_FOR_LOOP_41, \
+        _NRFX_FOR_LOOP_40, \
+        _NRFX_FOR_LOOP_39, \
+        _NRFX_FOR_LOOP_38, \
+        _NRFX_FOR_LOOP_37, \
+        _NRFX_FOR_LOOP_36, \
+        _NRFX_FOR_LOOP_35, \
+        _NRFX_FOR_LOOP_34, \
+        _NRFX_FOR_LOOP_33, \
+        _NRFX_FOR_LOOP_32, \
+        _NRFX_FOR_LOOP_31, \
+        _NRFX_FOR_LOOP_30, \
+        _NRFX_FOR_LOOP_29, \
+        _NRFX_FOR_LOOP_28, \
+        _NRFX_FOR_LOOP_27, \
+        _NRFX_FOR_LOOP_26, \
+        _NRFX_FOR_LOOP_25, \
+        _NRFX_FOR_LOOP_24, \
+        _NRFX_FOR_LOOP_23, \
+        _NRFX_FOR_LOOP_22, \
+        _NRFX_FOR_LOOP_21, \
+        _NRFX_FOR_LOOP_20, \
+        _NRFX_FOR_LOOP_19, \
+        _NRFX_FOR_LOOP_18, \
+        _NRFX_FOR_LOOP_17, \
+        _NRFX_FOR_LOOP_16, \
+        _NRFX_FOR_LOOP_15, \
+        _NRFX_FOR_LOOP_14, \
+        _NRFX_FOR_LOOP_13, \
+        _NRFX_FOR_LOOP_12, \
+        _NRFX_FOR_LOOP_11, \
+        _NRFX_FOR_LOOP_10, \
+        _NRFX_FOR_LOOP_9, \
+        _NRFX_FOR_LOOP_8, \
+        _NRFX_FOR_LOOP_7, \
+        _NRFX_FOR_LOOP_6, \
+        _NRFX_FOR_LOOP_5, \
+        _NRFX_FOR_LOOP_4, \
+        _NRFX_FOR_LOOP_3, \
+        _NRFX_FOR_LOOP_2, \
+        _NRFX_FOR_LOOP_1, \
+        _NRFX_FOR_LOOP_0)(x, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__)
+
+/* Partial macros for @ref NRFX_CONCAT */
+#define _NRFX_CONCAT_0(arg, ...) arg
+
+#define _NRFX_CONCAT_1(arg, ...) NRFX_CONCAT_2(arg, _NRFX_CONCAT_0(__VA_ARGS__))
+
+#define _NRFX_CONCAT_2(arg, ...) NRFX_CONCAT_2(arg, _NRFX_CONCAT_1(__VA_ARGS__))
+
+#define _NRFX_CONCAT_3(arg, ...) NRFX_CONCAT_2(arg, _NRFX_CONCAT_2(__VA_ARGS__))
+
+#define _NRFX_CONCAT_4(arg, ...) NRFX_CONCAT_2(arg, _NRFX_CONCAT_3(__VA_ARGS__))
+
+#define _NRFX_CONCAT_5(arg, ...) NRFX_CONCAT_2(arg, _NRFX_CONCAT_4(__VA_ARGS__))
+
+#define _NRFX_CONCAT_6(arg, ...) NRFX_CONCAT_2(arg, _NRFX_CONCAT_5(__VA_ARGS__))
+
+#define _NRFX_CONCAT_7(arg, ...) NRFX_CONCAT_2(arg, _NRFX_CONCAT_6(__VA_ARGS__))
+
+/* Set of UTIL_LISTIFY particles */
+#define _NRFX_LISTIFY_0(F, sep, ...)
+
+#define _NRFX_LISTIFY_1(F, sep, ...) \
+    F(0, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_2(F, sep, ...) \
+    _NRFX_LISTIFY_1(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(1, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_3(F, sep, ...) \
+    _NRFX_LISTIFY_2(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(2, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_4(F, sep, ...) \
+    _NRFX_LISTIFY_3(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(3, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_5(F, sep, ...) \
+    _NRFX_LISTIFY_4(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(4, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_6(F, sep, ...) \
+    _NRFX_LISTIFY_5(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(5, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_7(F, sep, ...) \
+    _NRFX_LISTIFY_6(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(6, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_8(F, sep, ...) \
+    _NRFX_LISTIFY_7(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(7, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_9(F, sep, ...) \
+    _NRFX_LISTIFY_8(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(8, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_10(F, sep, ...) \
+    _NRFX_LISTIFY_9(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(9, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_11(F, sep, ...) \
+    _NRFX_LISTIFY_10(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(10, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_12(F, sep, ...) \
+    _NRFX_LISTIFY_11(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(11, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_13(F, sep, ...) \
+    _NRFX_LISTIFY_12(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(12, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_14(F, sep, ...) \
+    _NRFX_LISTIFY_13(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(13, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_15(F, sep, ...) \
+    _NRFX_LISTIFY_14(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(14, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_16(F, sep, ...) \
+    _NRFX_LISTIFY_15(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(15, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_17(F, sep, ...) \
+    _NRFX_LISTIFY_16(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(16, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_18(F, sep, ...) \
+    _NRFX_LISTIFY_17(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(17, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_19(F, sep, ...) \
+    _NRFX_LISTIFY_18(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(18, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_20(F, sep, ...) \
+    _NRFX_LISTIFY_19(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(19, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_21(F, sep, ...) \
+    _NRFX_LISTIFY_20(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(20, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_22(F, sep, ...) \
+    _NRFX_LISTIFY_21(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(21, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_23(F, sep, ...) \
+    _NRFX_LISTIFY_22(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(22, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_24(F, sep, ...) \
+    _NRFX_LISTIFY_23(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(23, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_25(F, sep, ...) \
+    _NRFX_LISTIFY_24(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(24, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_26(F, sep, ...) \
+    _NRFX_LISTIFY_25(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(25, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_27(F, sep, ...) \
+    _NRFX_LISTIFY_26(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(26, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_28(F, sep, ...) \
+    _NRFX_LISTIFY_27(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(27, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_29(F, sep, ...) \
+    _NRFX_LISTIFY_28(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(28, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_30(F, sep, ...) \
+    _NRFX_LISTIFY_29(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(29, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_31(F, sep, ...) \
+    _NRFX_LISTIFY_30(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(30, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_32(F, sep, ...) \
+    _NRFX_LISTIFY_31(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(31, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_33(F, sep, ...) \
+    _NRFX_LISTIFY_32(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(32, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_34(F, sep, ...) \
+    _NRFX_LISTIFY_33(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(33, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_35(F, sep, ...) \
+    _NRFX_LISTIFY_34(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(34, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_36(F, sep, ...) \
+    _NRFX_LISTIFY_35(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(35, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_37(F, sep, ...) \
+    _NRFX_LISTIFY_36(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(36, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_38(F, sep, ...) \
+    _NRFX_LISTIFY_37(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(37, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_39(F, sep, ...) \
+    _NRFX_LISTIFY_38(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(38, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_40(F, sep, ...) \
+    _NRFX_LISTIFY_39(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(39, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_41(F, sep, ...) \
+    _NRFX_LISTIFY_40(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(40, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_42(F, sep, ...) \
+    _NRFX_LISTIFY_41(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(41, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_43(F, sep, ...) \
+    _NRFX_LISTIFY_42(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(42, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_44(F, sep, ...) \
+    _NRFX_LISTIFY_43(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(43, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_45(F, sep, ...) \
+    _NRFX_LISTIFY_44(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(44, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_46(F, sep, ...) \
+    _NRFX_LISTIFY_45(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(45, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_47(F, sep, ...) \
+    _NRFX_LISTIFY_46(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(46, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_48(F, sep, ...) \
+    _NRFX_LISTIFY_47(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(47, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_49(F, sep, ...) \
+    _NRFX_LISTIFY_48(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(48, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_50(F, sep, ...) \
+    _NRFX_LISTIFY_49(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(49, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_51(F, sep, ...) \
+    _NRFX_LISTIFY_50(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(50, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_52(F, sep, ...) \
+    _NRFX_LISTIFY_51(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(51, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_53(F, sep, ...) \
+    _NRFX_LISTIFY_52(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(52, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_54(F, sep, ...) \
+    _NRFX_LISTIFY_53(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(53, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_55(F, sep, ...) \
+    _NRFX_LISTIFY_54(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(54, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_56(F, sep, ...) \
+    _NRFX_LISTIFY_55(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(55, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_57(F, sep, ...) \
+    _NRFX_LISTIFY_56(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(56, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_58(F, sep, ...) \
+    _NRFX_LISTIFY_57(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(57, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_59(F, sep, ...) \
+    _NRFX_LISTIFY_58(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(58, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_60(F, sep, ...) \
+    _NRFX_LISTIFY_59(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(59, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_61(F, sep, ...) \
+    _NRFX_LISTIFY_60(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(60, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_62(F, sep, ...) \
+    _NRFX_LISTIFY_61(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(61, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_63(F, sep, ...) \
+    _NRFX_LISTIFY_62(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(62, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_64(F, sep, ...) \
+    _NRFX_LISTIFY_63(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(63, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_65(F, sep, ...) \
+    _NRFX_LISTIFY_64(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(64, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_66(F, sep, ...) \
+    _NRFX_LISTIFY_65(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(65, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_67(F, sep, ...) \
+    _NRFX_LISTIFY_66(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(66, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_68(F, sep, ...) \
+    _NRFX_LISTIFY_67(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(67, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_69(F, sep, ...) \
+    _NRFX_LISTIFY_68(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(68, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_70(F, sep, ...) \
+    _NRFX_LISTIFY_69(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(69, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_71(F, sep, ...) \
+    _NRFX_LISTIFY_70(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(70, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_72(F, sep, ...) \
+    _NRFX_LISTIFY_71(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(71, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_73(F, sep, ...) \
+    _NRFX_LISTIFY_72(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(72, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_74(F, sep, ...) \
+    _NRFX_LISTIFY_73(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(73, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_75(F, sep, ...) \
+    _NRFX_LISTIFY_74(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(74, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_76(F, sep, ...) \
+    _NRFX_LISTIFY_75(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(75, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_77(F, sep, ...) \
+    _NRFX_LISTIFY_76(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(76, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_78(F, sep, ...) \
+    _NRFX_LISTIFY_77(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(77, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_79(F, sep, ...) \
+    _NRFX_LISTIFY_78(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(78, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_80(F, sep, ...) \
+    _NRFX_LISTIFY_79(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(79, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_81(F, sep, ...) \
+    _NRFX_LISTIFY_80(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(80, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_82(F, sep, ...) \
+    _NRFX_LISTIFY_81(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(81, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_83(F, sep, ...) \
+    _NRFX_LISTIFY_82(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(82, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_84(F, sep, ...) \
+    _NRFX_LISTIFY_83(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(83, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_85(F, sep, ...) \
+    _NRFX_LISTIFY_84(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(84, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_86(F, sep, ...) \
+    _NRFX_LISTIFY_85(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(85, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_87(F, sep, ...) \
+    _NRFX_LISTIFY_86(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(86, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_88(F, sep, ...) \
+    _NRFX_LISTIFY_87(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(87, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_89(F, sep, ...) \
+    _NRFX_LISTIFY_88(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(88, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_90(F, sep, ...) \
+    _NRFX_LISTIFY_89(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(89, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_91(F, sep, ...) \
+    _NRFX_LISTIFY_90(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(90, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_92(F, sep, ...) \
+    _NRFX_LISTIFY_91(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(91, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_93(F, sep, ...) \
+    _NRFX_LISTIFY_92(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(92, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_94(F, sep, ...) \
+    _NRFX_LISTIFY_93(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(93, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_95(F, sep, ...) \
+    _NRFX_LISTIFY_94(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(94, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_96(F, sep, ...) \
+    _NRFX_LISTIFY_95(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(95, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_97(F, sep, ...) \
+    _NRFX_LISTIFY_96(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(96, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_98(F, sep, ...) \
+    _NRFX_LISTIFY_97(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(97, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_99(F, sep, ...) \
+    _NRFX_LISTIFY_98(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(98, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_100(F, sep, ...) \
+    _NRFX_LISTIFY_99(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(99, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_101(F, sep, ...) \
+    _NRFX_LISTIFY_100(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(100, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_102(F, sep, ...) \
+    _NRFX_LISTIFY_101(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(101, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_103(F, sep, ...) \
+    _NRFX_LISTIFY_102(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(102, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_104(F, sep, ...) \
+    _NRFX_LISTIFY_103(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(103, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_105(F, sep, ...) \
+    _NRFX_LISTIFY_104(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(104, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_106(F, sep, ...) \
+    _NRFX_LISTIFY_105(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(105, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_107(F, sep, ...) \
+    _NRFX_LISTIFY_106(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(106, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_108(F, sep, ...) \
+    _NRFX_LISTIFY_107(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(107, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_109(F, sep, ...) \
+    _NRFX_LISTIFY_108(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(108, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_110(F, sep, ...) \
+    _NRFX_LISTIFY_109(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(109, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_111(F, sep, ...) \
+    _NRFX_LISTIFY_110(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(110, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_112(F, sep, ...) \
+    _NRFX_LISTIFY_111(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(111, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_113(F, sep, ...) \
+    _NRFX_LISTIFY_112(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(112, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_114(F, sep, ...) \
+    _NRFX_LISTIFY_113(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(113, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_115(F, sep, ...) \
+    _NRFX_LISTIFY_114(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(114, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_116(F, sep, ...) \
+    _NRFX_LISTIFY_115(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(115, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_117(F, sep, ...) \
+    _NRFX_LISTIFY_116(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(116, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_118(F, sep, ...) \
+    _NRFX_LISTIFY_117(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(117, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_119(F, sep, ...) \
+    _NRFX_LISTIFY_118(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(118, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_120(F, sep, ...) \
+    _NRFX_LISTIFY_119(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(119, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_121(F, sep, ...) \
+    _NRFX_LISTIFY_120(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(120, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_122(F, sep, ...) \
+    _NRFX_LISTIFY_121(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(121, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_123(F, sep, ...) \
+    _NRFX_LISTIFY_122(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(122, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_124(F, sep, ...) \
+    _NRFX_LISTIFY_123(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(123, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_125(F, sep, ...) \
+    _NRFX_LISTIFY_124(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(124, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_126(F, sep, ...) \
+    _NRFX_LISTIFY_125(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(125, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_127(F, sep, ...) \
+    _NRFX_LISTIFY_126(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(126, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_128(F, sep, ...) \
+    _NRFX_LISTIFY_127(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(127, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_129(F, sep, ...) \
+    _NRFX_LISTIFY_128(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(128, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_130(F, sep, ...) \
+    _NRFX_LISTIFY_129(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(129, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_131(F, sep, ...) \
+    _NRFX_LISTIFY_130(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(130, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_132(F, sep, ...) \
+    _NRFX_LISTIFY_131(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(131, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_133(F, sep, ...) \
+    _NRFX_LISTIFY_132(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(132, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_134(F, sep, ...) \
+    _NRFX_LISTIFY_133(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(133, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_135(F, sep, ...) \
+    _NRFX_LISTIFY_134(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(134, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_136(F, sep, ...) \
+    _NRFX_LISTIFY_135(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(135, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_137(F, sep, ...) \
+    _NRFX_LISTIFY_136(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(136, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_138(F, sep, ...) \
+    _NRFX_LISTIFY_137(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(137, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_139(F, sep, ...) \
+    _NRFX_LISTIFY_138(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(138, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_140(F, sep, ...) \
+    _NRFX_LISTIFY_139(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(139, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_141(F, sep, ...) \
+    _NRFX_LISTIFY_140(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(140, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_142(F, sep, ...) \
+    _NRFX_LISTIFY_141(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(141, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_143(F, sep, ...) \
+    _NRFX_LISTIFY_142(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(142, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_144(F, sep, ...) \
+    _NRFX_LISTIFY_143(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(143, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_145(F, sep, ...) \
+    _NRFX_LISTIFY_144(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(144, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_146(F, sep, ...) \
+    _NRFX_LISTIFY_145(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(145, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_147(F, sep, ...) \
+    _NRFX_LISTIFY_146(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(146, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_148(F, sep, ...) \
+    _NRFX_LISTIFY_147(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(147, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_149(F, sep, ...) \
+    _NRFX_LISTIFY_148(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(148, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_150(F, sep, ...) \
+    _NRFX_LISTIFY_149(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(149, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_151(F, sep, ...) \
+    _NRFX_LISTIFY_150(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(150, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_152(F, sep, ...) \
+    _NRFX_LISTIFY_151(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(151, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_153(F, sep, ...) \
+    _NRFX_LISTIFY_152(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(152, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_154(F, sep, ...) \
+    _NRFX_LISTIFY_153(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(153, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_155(F, sep, ...) \
+    _NRFX_LISTIFY_154(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(154, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_156(F, sep, ...) \
+    _NRFX_LISTIFY_155(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(155, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_157(F, sep, ...) \
+    _NRFX_LISTIFY_156(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(156, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_158(F, sep, ...) \
+    _NRFX_LISTIFY_157(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(157, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_159(F, sep, ...) \
+    _NRFX_LISTIFY_158(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(158, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_160(F, sep, ...) \
+    _NRFX_LISTIFY_159(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(159, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_161(F, sep, ...) \
+    _NRFX_LISTIFY_160(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(160, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_162(F, sep, ...) \
+    _NRFX_LISTIFY_161(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(161, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_163(F, sep, ...) \
+    _NRFX_LISTIFY_162(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(162, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_164(F, sep, ...) \
+    _NRFX_LISTIFY_163(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(163, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_165(F, sep, ...) \
+    _NRFX_LISTIFY_164(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(164, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_166(F, sep, ...) \
+    _NRFX_LISTIFY_165(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(165, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_167(F, sep, ...) \
+    _NRFX_LISTIFY_166(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(166, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_168(F, sep, ...) \
+    _NRFX_LISTIFY_167(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(167, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_169(F, sep, ...) \
+    _NRFX_LISTIFY_168(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(168, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_170(F, sep, ...) \
+    _NRFX_LISTIFY_169(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(169, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_171(F, sep, ...) \
+    _NRFX_LISTIFY_170(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(170, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_172(F, sep, ...) \
+    _NRFX_LISTIFY_171(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(171, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_173(F, sep, ...) \
+    _NRFX_LISTIFY_172(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(172, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_174(F, sep, ...) \
+    _NRFX_LISTIFY_173(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(173, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_175(F, sep, ...) \
+    _NRFX_LISTIFY_174(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(174, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_176(F, sep, ...) \
+    _NRFX_LISTIFY_175(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(175, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_177(F, sep, ...) \
+    _NRFX_LISTIFY_176(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(176, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_178(F, sep, ...) \
+    _NRFX_LISTIFY_177(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(177, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_179(F, sep, ...) \
+    _NRFX_LISTIFY_178(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(178, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_180(F, sep, ...) \
+    _NRFX_LISTIFY_179(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(179, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_181(F, sep, ...) \
+    _NRFX_LISTIFY_180(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(180, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_182(F, sep, ...) \
+    _NRFX_LISTIFY_181(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(181, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_183(F, sep, ...) \
+    _NRFX_LISTIFY_182(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(182, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_184(F, sep, ...) \
+    _NRFX_LISTIFY_183(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(183, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_185(F, sep, ...) \
+    _NRFX_LISTIFY_184(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(184, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_186(F, sep, ...) \
+    _NRFX_LISTIFY_185(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(185, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_187(F, sep, ...) \
+    _NRFX_LISTIFY_186(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(186, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_188(F, sep, ...) \
+    _NRFX_LISTIFY_187(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(187, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_189(F, sep, ...) \
+    _NRFX_LISTIFY_188(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(188, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_190(F, sep, ...) \
+    _NRFX_LISTIFY_189(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(189, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_191(F, sep, ...) \
+    _NRFX_LISTIFY_190(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(190, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_192(F, sep, ...) \
+    _NRFX_LISTIFY_191(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(191, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_193(F, sep, ...) \
+    _NRFX_LISTIFY_192(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(192, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_194(F, sep, ...) \
+    _NRFX_LISTIFY_193(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(193, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_195(F, sep, ...) \
+    _NRFX_LISTIFY_194(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(194, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_196(F, sep, ...) \
+    _NRFX_LISTIFY_195(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(195, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_197(F, sep, ...) \
+    _NRFX_LISTIFY_196(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(196, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_198(F, sep, ...) \
+    _NRFX_LISTIFY_197(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(197, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_199(F, sep, ...) \
+    _NRFX_LISTIFY_198(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(198, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_200(F, sep, ...) \
+    _NRFX_LISTIFY_199(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(199, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_201(F, sep, ...) \
+    _NRFX_LISTIFY_200(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(200, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_202(F, sep, ...) \
+    _NRFX_LISTIFY_201(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(201, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_203(F, sep, ...) \
+    _NRFX_LISTIFY_202(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(202, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_204(F, sep, ...) \
+    _NRFX_LISTIFY_203(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(203, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_205(F, sep, ...) \
+    _NRFX_LISTIFY_204(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(204, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_206(F, sep, ...) \
+    _NRFX_LISTIFY_205(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(205, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_207(F, sep, ...) \
+    _NRFX_LISTIFY_206(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(206, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_208(F, sep, ...) \
+    _NRFX_LISTIFY_207(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(207, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_209(F, sep, ...) \
+    _NRFX_LISTIFY_208(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(208, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_210(F, sep, ...) \
+    _NRFX_LISTIFY_209(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(209, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_211(F, sep, ...) \
+    _NRFX_LISTIFY_210(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(210, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_212(F, sep, ...) \
+    _NRFX_LISTIFY_211(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(211, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_213(F, sep, ...) \
+    _NRFX_LISTIFY_212(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(212, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_214(F, sep, ...) \
+    _NRFX_LISTIFY_213(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(213, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_215(F, sep, ...) \
+    _NRFX_LISTIFY_214(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(214, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_216(F, sep, ...) \
+    _NRFX_LISTIFY_215(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(215, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_217(F, sep, ...) \
+    _NRFX_LISTIFY_216(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(216, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_218(F, sep, ...) \
+    _NRFX_LISTIFY_217(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(217, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_219(F, sep, ...) \
+    _NRFX_LISTIFY_218(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(218, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_220(F, sep, ...) \
+    _NRFX_LISTIFY_219(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(219, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_221(F, sep, ...) \
+    _NRFX_LISTIFY_220(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(220, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_222(F, sep, ...) \
+    _NRFX_LISTIFY_221(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(221, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_223(F, sep, ...) \
+    _NRFX_LISTIFY_222(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(222, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_224(F, sep, ...) \
+    _NRFX_LISTIFY_223(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(223, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_225(F, sep, ...) \
+    _NRFX_LISTIFY_224(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(224, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_226(F, sep, ...) \
+    _NRFX_LISTIFY_225(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(225, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_227(F, sep, ...) \
+    _NRFX_LISTIFY_226(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(226, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_228(F, sep, ...) \
+    _NRFX_LISTIFY_227(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(227, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_229(F, sep, ...) \
+    _NRFX_LISTIFY_228(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(228, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_230(F, sep, ...) \
+    _NRFX_LISTIFY_229(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(229, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_231(F, sep, ...) \
+    _NRFX_LISTIFY_230(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(230, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_232(F, sep, ...) \
+    _NRFX_LISTIFY_231(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(231, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_233(F, sep, ...) \
+    _NRFX_LISTIFY_232(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(232, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_234(F, sep, ...) \
+    _NRFX_LISTIFY_233(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(233, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_235(F, sep, ...) \
+    _NRFX_LISTIFY_234(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(234, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_236(F, sep, ...) \
+    _NRFX_LISTIFY_235(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(235, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_237(F, sep, ...) \
+    _NRFX_LISTIFY_236(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(236, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_238(F, sep, ...) \
+    _NRFX_LISTIFY_237(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(237, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_239(F, sep, ...) \
+    _NRFX_LISTIFY_238(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(238, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_240(F, sep, ...) \
+    _NRFX_LISTIFY_239(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(239, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_241(F, sep, ...) \
+    _NRFX_LISTIFY_240(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(240, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_242(F, sep, ...) \
+    _NRFX_LISTIFY_241(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(241, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_243(F, sep, ...) \
+    _NRFX_LISTIFY_242(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(242, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_244(F, sep, ...) \
+    _NRFX_LISTIFY_243(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(243, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_245(F, sep, ...) \
+    _NRFX_LISTIFY_244(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(244, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_246(F, sep, ...) \
+    _NRFX_LISTIFY_245(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(245, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_247(F, sep, ...) \
+    _NRFX_LISTIFY_246(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(246, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_248(F, sep, ...) \
+    _NRFX_LISTIFY_247(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(247, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_249(F, sep, ...) \
+    _NRFX_LISTIFY_248(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(248, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_250(F, sep, ...) \
+    _NRFX_LISTIFY_249(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(249, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_251(F, sep, ...) \
+    _NRFX_LISTIFY_250(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(250, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_252(F, sep, ...) \
+    _NRFX_LISTIFY_251(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(251, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_253(F, sep, ...) \
+    _NRFX_LISTIFY_252(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(252, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_254(F, sep, ...) \
+    _NRFX_LISTIFY_253(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(253, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_255(F, sep, ...) \
+    _NRFX_LISTIFY_254(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(254, __VA_ARGS__)
+
+#define _NRFX_LISTIFY_256(F, sep, ...) \
+    _NRFX_LISTIFY_255(F, sep, __VA_ARGS__) NRFX_DEBRACKET sep \
+    F(255, __VA_ARGS__)
+
+#define _NRFX_FOR_LOOP_GET_ARG(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, \
+                _12, _13, _14, _15, _16, _17, _18, _19, _20, \
+                _21, _22, _23, _24, _25, _26, _27, _28, _29, \
+                _30, _31, _32, _33, _34, _35, _36, _37, _38, \
+                _39, _40, _41, _42, _43, _44, _45, _46, _47, \
+                _48, _49, _50, _51, _52, _53, _54, _55, _56, \
+                _57, _58, _59, _60, _61, _62, _63, _64, N, ...) N
+
+#define _NRFX_FOR_LOOP_0(call, sep, fixed_arg0, fixed_arg1, ...)
+
+#define _NRFX_FOR_LOOP_1(call, sep, fixed_arg0, fixed_arg1, x) \
+    call(0, x, fixed_arg0, fixed_arg1)
+
+#define _NRFX_FOR_LOOP_2(call, sep, fixed_arg0, fixed_arg1, x, ...) \
+    _NRFX_FOR_LOOP_1(call, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__) \
+    NRFX_DEBRACKET sep \
+    call(1, x, fixed_arg0, fixed_arg1)
+
+#define _NRFX_FOR_LOOP_3(call, sep, fixed_arg0, fixed_arg1, x, ...) \
+    _NRFX_FOR_LOOP_2(call, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__) \
+    NRFX_DEBRACKET sep \
+    call(2, x, fixed_arg0, fixed_arg1)
+
+#define _NRFX_FOR_LOOP_4(call, sep, fixed_arg0, fixed_arg1, x, ...) \
+    _NRFX_FOR_LOOP_3(call, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__) \
+    NRFX_DEBRACKET sep \
+    call(3, x, fixed_arg0, fixed_arg1)
+
+#define _NRFX_FOR_LOOP_5(call, sep, fixed_arg0, fixed_arg1, x, ...) \
+    _NRFX_FOR_LOOP_4(call, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__) \
+    NRFX_DEBRACKET sep \
+    call(4, x, fixed_arg0, fixed_arg1)
+
+#define _NRFX_FOR_LOOP_6(call, sep, fixed_arg0, fixed_arg1, x, ...) \
+    _NRFX_FOR_LOOP_5(call, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__) \
+    NRFX_DEBRACKET sep \
+    call(5, x, fixed_arg0, fixed_arg1)
+
+#define _NRFX_FOR_LOOP_7(call, sep, fixed_arg0, fixed_arg1, x, ...) \
+    _NRFX_FOR_LOOP_6(call, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__) \
+    NRFX_DEBRACKET sep \
+    call(6, x, fixed_arg0, fixed_arg1)
+
+#define _NRFX_FOR_LOOP_8(call, sep, fixed_arg0, fixed_arg1, x, ...) \
+    _NRFX_FOR_LOOP_7(call, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__) \
+    NRFX_DEBRACKET sep \
+    call(7, x, fixed_arg0, fixed_arg1)
+
+#define _NRFX_FOR_LOOP_9(call, sep, fixed_arg0, fixed_arg1, x, ...) \
+    _NRFX_FOR_LOOP_8(call, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__) \
+    NRFX_DEBRACKET sep \
+    call(8, x, fixed_arg0, fixed_arg1)
+
+#define _NRFX_FOR_LOOP_10(call, sep, fixed_arg0, fixed_arg1, x, ...) \
+    _NRFX_FOR_LOOP_9(call, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__) \
+    NRFX_DEBRACKET sep \
+    call(9, x, fixed_arg0, fixed_arg1)
+
+#define _NRFX_FOR_LOOP_11(call, sep, fixed_arg0, fixed_arg1, x, ...) \
+    _NRFX_FOR_LOOP_10(call, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__) \
+    NRFX_DEBRACKET sep \
+    call(10, x, fixed_arg0, fixed_arg1)
+
+#define _NRFX_FOR_LOOP_12(call, sep, fixed_arg0, fixed_arg1, x, ...) \
+    _NRFX_FOR_LOOP_11(call, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__) \
+    NRFX_DEBRACKET sep \
+    call(11, x, fixed_arg0, fixed_arg1)
+
+#define _NRFX_FOR_LOOP_13(call, sep, fixed_arg0, fixed_arg1, x, ...) \
+    _NRFX_FOR_LOOP_12(call, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__) \
+    NRFX_DEBRACKET sep \
+    call(12, x, fixed_arg0, fixed_arg1)
+
+#define _NRFX_FOR_LOOP_14(call, sep, fixed_arg0, fixed_arg1, x, ...) \
+    _NRFX_FOR_LOOP_13(call, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__) \
+    NRFX_DEBRACKET sep \
+    call(13, x, fixed_arg0, fixed_arg1)
+
+#define _NRFX_FOR_LOOP_15(call, sep, fixed_arg0, fixed_arg1, x, ...) \
+    _NRFX_FOR_LOOP_14(call, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__) \
+    NRFX_DEBRACKET sep \
+    call(14, x, fixed_arg0, fixed_arg1)
+
+#define _NRFX_FOR_LOOP_16(call, sep, fixed_arg0, fixed_arg1, x, ...) \
+    _NRFX_FOR_LOOP_15(call, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__) \
+    NRFX_DEBRACKET sep \
+    call(15, x, fixed_arg0, fixed_arg1)
+
+#define _NRFX_FOR_LOOP_17(call, sep, fixed_arg0, fixed_arg1, x, ...) \
+    _NRFX_FOR_LOOP_16(call, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__) \
+    NRFX_DEBRACKET sep \
+    call(16, x, fixed_arg0, fixed_arg1)
+
+#define _NRFX_FOR_LOOP_18(call, sep, fixed_arg0, fixed_arg1, x, ...) \
+    _NRFX_FOR_LOOP_17(call, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__) \
+    NRFX_DEBRACKET sep \
+    call(17, x, fixed_arg0, fixed_arg1)
+
+#define _NRFX_FOR_LOOP_19(call, sep, fixed_arg0, fixed_arg1, x, ...) \
+    _NRFX_FOR_LOOP_18(call, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__) \
+    NRFX_DEBRACKET sep \
+    call(18, x, fixed_arg0, fixed_arg1)
+
+#define _NRFX_FOR_LOOP_20(call, sep, fixed_arg0, fixed_arg1, x, ...) \
+    _NRFX_FOR_LOOP_19(call, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__) \
+    NRFX_DEBRACKET sep \
+    call(19, x, fixed_arg0, fixed_arg1)
+
+#define _NRFX_FOR_LOOP_21(call, sep, fixed_arg0, fixed_arg1, x, ...) \
+    _NRFX_FOR_LOOP_20(call, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__) \
+    NRFX_DEBRACKET sep \
+    call(20, x, fixed_arg0, fixed_arg1)
+
+#define _NRFX_FOR_LOOP_22(call, sep, fixed_arg0, fixed_arg1, x, ...) \
+    _NRFX_FOR_LOOP_21(call, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__) \
+    NRFX_DEBRACKET sep \
+    call(21, x, fixed_arg0, fixed_arg1)
+
+#define _NRFX_FOR_LOOP_23(call, sep, fixed_arg0, fixed_arg1, x, ...) \
+    _NRFX_FOR_LOOP_22(call, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__) \
+    NRFX_DEBRACKET sep \
+    call(22, x, fixed_arg0, fixed_arg1)
+
+#define _NRFX_FOR_LOOP_24(call, sep, fixed_arg0, fixed_arg1, x, ...) \
+    _NRFX_FOR_LOOP_23(call, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__) \
+    NRFX_DEBRACKET sep \
+    call(23, x, fixed_arg0, fixed_arg1)
+
+#define _NRFX_FOR_LOOP_25(call, sep, fixed_arg0, fixed_arg1, x, ...) \
+    _NRFX_FOR_LOOP_24(call, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__) \
+    NRFX_DEBRACKET sep \
+    call(24, x, fixed_arg0, fixed_arg1)
+
+#define _NRFX_FOR_LOOP_26(call, sep, fixed_arg0, fixed_arg1, x, ...) \
+    _NRFX_FOR_LOOP_25(call, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__) \
+    NRFX_DEBRACKET sep \
+    call(25, x, fixed_arg0, fixed_arg1)
+
+#define _NRFX_FOR_LOOP_27(call, sep, fixed_arg0, fixed_arg1, x, ...) \
+    _NRFX_FOR_LOOP_26(call, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__) \
+    NRFX_DEBRACKET sep \
+    call(26, x, fixed_arg0, fixed_arg1)
+
+#define _NRFX_FOR_LOOP_28(call, sep, fixed_arg0, fixed_arg1, x, ...) \
+    _NRFX_FOR_LOOP_27(call, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__) \
+    NRFX_DEBRACKET sep \
+    call(27, x, fixed_arg0, fixed_arg1)
+
+#define _NRFX_FOR_LOOP_29(call, sep, fixed_arg0, fixed_arg1, x, ...) \
+    _NRFX_FOR_LOOP_28(call, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__) \
+    NRFX_DEBRACKET sep \
+    call(28, x, fixed_arg0, fixed_arg1)
+
+#define _NRFX_FOR_LOOP_30(call, sep, fixed_arg0, fixed_arg1, x, ...) \
+    _NRFX_FOR_LOOP_29(call, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__) \
+    NRFX_DEBRACKET sep \
+    call(29, x, fixed_arg0, fixed_arg1)
+
+#define _NRFX_FOR_LOOP_31(call, sep, fixed_arg0, fixed_arg1, x, ...) \
+    _NRFX_FOR_LOOP_30(call, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__) \
+    NRFX_DEBRACKET sep \
+    call(30, x, fixed_arg0, fixed_arg1)
+
+#define _NRFX_FOR_LOOP_32(call, sep, fixed_arg0, fixed_arg1, x, ...) \
+    _NRFX_FOR_LOOP_31(call, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__) \
+    NRFX_DEBRACKET sep \
+    call(31, x, fixed_arg0, fixed_arg1)
+
+#define _NRFX_FOR_LOOP_33(call, sep, fixed_arg0, fixed_arg1, x, ...) \
+    _NRFX_FOR_LOOP_32(call, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__) \
+    NRFX_DEBRACKET sep \
+    call(32, x, fixed_arg0, fixed_arg1)
+
+#define _NRFX_FOR_LOOP_34(call, sep, fixed_arg0, fixed_arg1, x, ...) \
+    _NRFX_FOR_LOOP_33(call, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__) \
+    NRFX_DEBRACKET sep \
+    call(33, x, fixed_arg0, fixed_arg1)
+
+#define _NRFX_FOR_LOOP_35(call, sep, fixed_arg0, fixed_arg1, x, ...) \
+    _NRFX_FOR_LOOP_34(call, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__) \
+    NRFX_DEBRACKET sep \
+    call(34, x, fixed_arg0, fixed_arg1)
+
+#define _NRFX_FOR_LOOP_36(call, sep, fixed_arg0, fixed_arg1, x, ...) \
+    _NRFX_FOR_LOOP_35(call, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__) \
+    NRFX_DEBRACKET sep \
+    call(35, x, fixed_arg0, fixed_arg1)
+
+#define _NRFX_FOR_LOOP_37(call, sep, fixed_arg0, fixed_arg1, x, ...) \
+    _NRFX_FOR_LOOP_36(call, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__) \
+    NRFX_DEBRACKET sep \
+    call(36, x, fixed_arg0, fixed_arg1)
+
+#define _NRFX_FOR_LOOP_38(call, sep, fixed_arg0, fixed_arg1, x, ...) \
+    _NRFX_FOR_LOOP_37(call, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__) \
+    NRFX_DEBRACKET sep \
+    call(37, x, fixed_arg0, fixed_arg1)
+
+#define _NRFX_FOR_LOOP_39(call, sep, fixed_arg0, fixed_arg1, x, ...) \
+    _NRFX_FOR_LOOP_38(call, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__) \
+    NRFX_DEBRACKET sep \
+    call(38, x, fixed_arg0, fixed_arg1)
+
+#define _NRFX_FOR_LOOP_40(call, sep, fixed_arg0, fixed_arg1, x, ...) \
+    _NRFX_FOR_LOOP_39(call, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__) \
+    NRFX_DEBRACKET sep \
+    call(39, x, fixed_arg0, fixed_arg1)
+
+#define _NRFX_FOR_LOOP_41(call, sep, fixed_arg0, fixed_arg1, x, ...) \
+    _NRFX_FOR_LOOP_40(call, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__) \
+    NRFX_DEBRACKET sep \
+    call(40, x, fixed_arg0, fixed_arg1)
+
+#define _NRFX_FOR_LOOP_42(call, sep, fixed_arg0, fixed_arg1, x, ...) \
+    _NRFX_FOR_LOOP_41(call, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__) \
+    NRFX_DEBRACKET sep \
+    call(41, x, fixed_arg0, fixed_arg1)
+
+#define _NRFX_FOR_LOOP_43(call, sep, fixed_arg0, fixed_arg1, x, ...) \
+    _NRFX_FOR_LOOP_42(call, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__) \
+    NRFX_DEBRACKET sep \
+    call(42, x, fixed_arg0, fixed_arg1)
+
+#define _NRFX_FOR_LOOP_44(call, sep, fixed_arg0, fixed_arg1, x, ...) \
+    _NRFX_FOR_LOOP_43(call, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__) \
+    NRFX_DEBRACKET sep \
+    call(43, x, fixed_arg0, fixed_arg1)
+
+#define _NRFX_FOR_LOOP_45(call, sep, fixed_arg0, fixed_arg1, x, ...) \
+    _NRFX_FOR_LOOP_44(call, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__) \
+    NRFX_DEBRACKET sep \
+    call(44, x, fixed_arg0, fixed_arg1)
+
+#define _NRFX_FOR_LOOP_46(call, sep, fixed_arg0, fixed_arg1, x, ...) \
+    _NRFX_FOR_LOOP_45(call, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__) \
+    NRFX_DEBRACKET sep \
+    call(45, x, fixed_arg0, fixed_arg1)
+
+#define _NRFX_FOR_LOOP_47(call, sep, fixed_arg0, fixed_arg1, x, ...) \
+    _NRFX_FOR_LOOP_46(call, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__) \
+    NRFX_DEBRACKET sep \
+    call(46, x, fixed_arg0, fixed_arg1)
+
+#define _NRFX_FOR_LOOP_48(call, sep, fixed_arg0, fixed_arg1, x, ...) \
+    _NRFX_FOR_LOOP_47(call, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__) \
+    NRFX_DEBRACKET sep \
+    call(47, x, fixed_arg0, fixed_arg1)
+
+#define _NRFX_FOR_LOOP_49(call, sep, fixed_arg0, fixed_arg1, x, ...) \
+    _NRFX_FOR_LOOP_48(call, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__) \
+    NRFX_DEBRACKET sep \
+    call(48, x, fixed_arg0, fixed_arg1)
+
+#define _NRFX_FOR_LOOP_50(call, sep, fixed_arg0, fixed_arg1, x, ...) \
+    _NRFX_FOR_LOOP_49(call, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__) \
+    NRFX_DEBRACKET sep \
+    call(49, x, fixed_arg0, fixed_arg1)
+
+#define _NRFX_FOR_LOOP_51(call, sep, fixed_arg0, fixed_arg1, x, ...) \
+    _NRFX_FOR_LOOP_50(call, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__) \
+    NRFX_DEBRACKET sep \
+    call(50, x, fixed_arg0, fixed_arg1)
+
+#define _NRFX_FOR_LOOP_52(call, sep, fixed_arg0, fixed_arg1, x, ...) \
+    _NRFX_FOR_LOOP_51(call, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__) \
+    NRFX_DEBRACKET sep \
+    call(51, x, fixed_arg0, fixed_arg1)
+
+#define _NRFX_FOR_LOOP_53(call, sep, fixed_arg0, fixed_arg1, x, ...) \
+    _NRFX_FOR_LOOP_52(call, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__) \
+    NRFX_DEBRACKET sep \
+    call(52, x, fixed_arg0, fixed_arg1)
+
+#define _NRFX_FOR_LOOP_54(call, sep, fixed_arg0, fixed_arg1, x, ...) \
+    _NRFX_FOR_LOOP_53(call, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__) \
+    NRFX_DEBRACKET sep \
+    call(53, x, fixed_arg0, fixed_arg1)
+
+#define _NRFX_FOR_LOOP_55(call, sep, fixed_arg0, fixed_arg1, x, ...) \
+    _NRFX_FOR_LOOP_54(call, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__) \
+    NRFX_DEBRACKET sep \
+    call(54, x, fixed_arg0, fixed_arg1)
+
+#define _NRFX_FOR_LOOP_56(call, sep, fixed_arg0, fixed_arg1, x, ...) \
+    _NRFX_FOR_LOOP_55(call, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__) \
+    NRFX_DEBRACKET sep \
+    call(55, x, fixed_arg0, fixed_arg1)
+
+#define _NRFX_FOR_LOOP_57(call, sep, fixed_arg0, fixed_arg1, x, ...) \
+    _NRFX_FOR_LOOP_56(call, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__) \
+    NRFX_DEBRACKET sep \
+    call(56, x, fixed_arg0, fixed_arg1)
+
+#define _NRFX_FOR_LOOP_58(call, sep, fixed_arg0, fixed_arg1, x, ...) \
+    _NRFX_FOR_LOOP_57(call, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__) \
+    NRFX_DEBRACKET sep \
+    call(57, x, fixed_arg0, fixed_arg1)
+
+#define _NRFX_FOR_LOOP_59(call, sep, fixed_arg0, fixed_arg1, x, ...) \
+    _NRFX_FOR_LOOP_58(call, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__) \
+    NRFX_DEBRACKET sep \
+    call(58, x, fixed_arg0, fixed_arg1)
+
+#define _NRFX_FOR_LOOP_60(call, sep, fixed_arg0, fixed_arg1, x, ...) \
+    _NRFX_FOR_LOOP_59(call, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__) \
+    NRFX_DEBRACKET sep \
+    call(59, x, fixed_arg0, fixed_arg1)
+
+#define _NRFX_FOR_LOOP_61(call, sep, fixed_arg0, fixed_arg1, x, ...) \
+    _NRFX_FOR_LOOP_60(call, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__) \
+    NRFX_DEBRACKET sep \
+    call(60, x, fixed_arg0, fixed_arg1)
+
+#define _NRFX_FOR_LOOP_62(call, sep, fixed_arg0, fixed_arg1, x, ...) \
+    _NRFX_FOR_LOOP_61(call, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__) \
+    NRFX_DEBRACKET sep \
+    call(61, x, fixed_arg0, fixed_arg1)
+
+#define _NRFX_FOR_LOOP_63(call, sep, fixed_arg0, fixed_arg1, x, ...) \
+    _NRFX_FOR_LOOP_62(call, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__) \
+    NRFX_DEBRACKET sep \
+    call(62, x, fixed_arg0, fixed_arg1)
+
+#define _NRFX_FOR_LOOP_64(call, sep, fixed_arg0, fixed_arg1, x, ...) \
+    _NRFX_FOR_LOOP_63(call, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__) \
+    NRFX_DEBRACKET sep \
+    call(63, x, fixed_arg0, fixed_arg1)
+
+#endif /* NRFX_UTILS_INTERNAL_H__ */

--- a/nrfx/drivers/src/nrfx_dppi.c
+++ b/nrfx/drivers/src/nrfx_dppi.c
@@ -33,7 +33,8 @@
 
 #include <nrfx.h>
 
-#if NRFX_CHECK(NRFX_DPPI_ENABLED)
+// Driver for single instance DPPI
+#if NRFX_CHECK(NRFX_DPPI_ENABLED) && (!defined(DPPIC_COUNT) || (DPPIC_COUNT == 1))
 
 #include <nrfx_dppi.h>
 #include <helpers/nrfx_flag32_allocator.h>
@@ -51,11 +52,16 @@
 #define NRFX_DPPI_GROUPS_USED 0x00000000uL
 #endif
 
+#if defined(DPPI_CH_NUM)
 #define DPPI_AVAILABLE_CHANNELS_MASK \
-    ((uint32_t)(((1ULL << DPPI_CH_NUM) - 1) & (~NRFX_DPPI_CHANNELS_USED)))
+    ((uint32_t)(NRFX_BIT_MASK(DPPI_CH_NUM) & (~NRFX_DPPI_CHANNELS_USED)))
+#else
+#define DPPI_AVAILABLE_CHANNELS_MASK \
+    ((uint32_t)(NRFX_BIT_MASK(NRF_DPPI_CH_NUM_MAX) & (~NRFX_DPPI_CHANNELS_USED)))
+#endif
 
-#define DPPI_AVAILABLE_GROUPS_MASK   \
-    (((1UL << DPPI_GROUP_NUM) - 1)   & (~NRFX_DPPI_GROUPS_USED))
+#define DPPI_AVAILABLE_GROUPS_MASK \
+    (NRFX_BIT_MASK(DPPI_GROUP_NUM) & (~NRFX_DPPI_GROUPS_USED))
 
 /** @brief Set bit at given position. */
 #define DPPI_BIT_SET(pos) (1uL << (pos))
@@ -71,8 +77,7 @@ void nrfx_dppi_free(void)
     uint8_t group_idx = NRF_DPPI_CHANNEL_GROUP0;
 
     // Disable all channels
-    nrf_dppi_channels_disable(NRF_DPPIC,
-                              DPPI_AVAILABLE_CHANNELS_MASK & ~m_allocated_channels);
+    nrfy_dppi_channels_disable(NRF_DPPIC, DPPI_AVAILABLE_CHANNELS_MASK & ~m_allocated_channels);
 
     // Clear all groups configurations
     while (mask)
@@ -80,7 +85,7 @@ void nrfx_dppi_free(void)
         nrf_dppi_channel_group_t group = (nrf_dppi_channel_group_t)group_idx;
         if (mask & DPPI_BIT_SET(group))
         {
-            nrf_dppi_group_clear(NRF_DPPIC, group);
+            nrfy_dppi_group_clear(NRF_DPPIC, group);
             mask &= ~DPPI_BIT_SET(group);
         }
         group_idx++;
@@ -100,7 +105,7 @@ nrfx_err_t nrfx_dppi_channel_alloc(uint8_t * p_channel)
 
 nrfx_err_t nrfx_dppi_channel_free(uint8_t channel)
 {
-    nrf_dppi_channels_disable(NRF_DPPIC, NRFX_BIT(channel));
+    nrfy_dppi_channels_disable(NRF_DPPIC, NRFX_BIT(channel));
     return nrfx_flag32_free(&m_allocated_channels, channel);
 }
 
@@ -114,7 +119,7 @@ nrfx_err_t nrfx_dppi_channel_enable(uint8_t channel)
     }
     else
     {
-        nrf_dppi_channels_enable(NRF_DPPIC, DPPI_BIT_SET(channel));
+        nrfy_dppi_channels_enable(NRF_DPPIC, DPPI_BIT_SET(channel));
     }
     NRFX_LOG_INFO("Function: %s, error code: %s.", __func__, NRFX_LOG_ERROR_STRING_GET(err_code));
     return err_code;
@@ -130,7 +135,7 @@ nrfx_err_t nrfx_dppi_channel_disable(uint8_t channel)
     }
     else
     {
-        nrf_dppi_channels_disable(NRF_DPPIC, DPPI_BIT_SET(channel));
+        nrfy_dppi_channels_disable(NRF_DPPIC, DPPI_BIT_SET(channel));
         err_code = NRFX_SUCCESS;
     }
     NRFX_LOG_INFO("Function: %s, error code: %s.", __func__, NRFX_LOG_ERROR_STRING_GET(err_code));
@@ -144,7 +149,7 @@ nrfx_err_t nrfx_dppi_group_alloc(nrf_dppi_channel_group_t * p_group)
 
 nrfx_err_t nrfx_dppi_group_free(nrf_dppi_channel_group_t group)
 {
-    nrf_dppi_group_disable(NRF_DPPIC, group);
+    nrfy_dppi_group_disable(NRF_DPPIC, group);
     return nrfx_flag32_free(&m_allocated_groups, group);
 }
 
@@ -160,9 +165,9 @@ nrfx_err_t nrfx_dppi_channel_include_in_group(uint8_t                  channel,
     }
     else
     {
-        NRFX_CRITICAL_SECTION_ENTER();
-        nrf_dppi_channels_include_in_group(NRF_DPPIC, DPPI_BIT_SET(channel), group);
-        NRFX_CRITICAL_SECTION_EXIT();
+        NRFY_CRITICAL_SECTION_ENTER();
+        nrfy_dppi_channels_include_in_group(NRF_DPPIC, DPPI_BIT_SET(channel), group);
+        NRFY_CRITICAL_SECTION_EXIT();
     }
     NRFX_LOG_INFO("Function: %s, error code: %s.", __func__, NRFX_LOG_ERROR_STRING_GET(err_code));
     return err_code;
@@ -180,9 +185,9 @@ nrfx_err_t nrfx_dppi_channel_remove_from_group(uint8_t                  channel,
     }
     else
     {
-        NRFX_CRITICAL_SECTION_ENTER();
-        nrf_dppi_channels_remove_from_group(NRF_DPPIC, DPPI_BIT_SET(channel), group);
-        NRFX_CRITICAL_SECTION_EXIT();
+        NRFY_CRITICAL_SECTION_ENTER();
+        nrfy_dppi_channels_remove_from_group(NRF_DPPIC, DPPI_BIT_SET(channel), group);
+        NRFY_CRITICAL_SECTION_EXIT();
     }
     NRFX_LOG_INFO("Function: %s, error code: %s.", __func__, NRFX_LOG_ERROR_STRING_GET(err_code));
     return err_code;
@@ -198,7 +203,7 @@ nrfx_err_t nrfx_dppi_group_clear(nrf_dppi_channel_group_t group)
     }
     else
     {
-        nrf_dppi_channels_remove_from_group(NRF_DPPIC, DPPI_AVAILABLE_CHANNELS_MASK, group);
+        nrfy_dppi_channels_remove_from_group(NRF_DPPIC, DPPI_AVAILABLE_CHANNELS_MASK, group);
     }
     NRFX_LOG_INFO("Function: %s, error code: %s.", __func__, NRFX_LOG_ERROR_STRING_GET(err_code));
     return err_code;
@@ -214,7 +219,7 @@ nrfx_err_t nrfx_dppi_group_enable(nrf_dppi_channel_group_t group)
     }
     else
     {
-        nrf_dppi_group_enable(NRF_DPPIC, group);
+        nrfy_dppi_group_enable(NRF_DPPIC, group);
     }
     NRFX_LOG_INFO("Function: %s, error code: %s.", __func__, NRFX_LOG_ERROR_STRING_GET(err_code));
     return err_code;
@@ -230,10 +235,10 @@ nrfx_err_t nrfx_dppi_group_disable(nrf_dppi_channel_group_t group)
     }
     else
     {
-        nrf_dppi_group_disable(NRF_DPPIC, group);
+        nrfy_dppi_group_disable(NRF_DPPIC, group);
     }
     NRFX_LOG_INFO("Function: %s, error code: %s.", __func__, NRFX_LOG_ERROR_STRING_GET(err_code));
     return err_code;
 }
 
-#endif // NRFX_CHECK(NRFX_DPPI_ENABLED)
+#endif // defined(DPPI_PRESENT) && defined(DPPIC_COUNT == 1)

--- a/nrfx/drivers/src/nrfx_gpiote.c
+++ b/nrfx/drivers/src/nrfx_gpiote.c
@@ -46,6 +46,8 @@
 #define MAX_PIN_NUMBER 32
 #elif (GPIO_COUNT == 2)
 #define MAX_PIN_NUMBER (32 + P1_PIN_NUM)
+#elif (GPIO_COUNT > 2)
+#define MAX_PIN_NUMBER (32 * GPIO_COUNT)
 #else
 #error "Not supported."
 #endif
@@ -69,8 +71,8 @@ NRFX_STATIC_ASSERT(NRFX_GPIOTE_TRIGGER_TOGGLE == GPIOTE_CONFIG_POLARITY_Toggle);
  * +--------+-------+-----------------------+-----+--------+--------+---------+-------+
  * | 0      | 1     | 2-4                   | 5   | 6      | 7      | 8-12    | 13-15 |
  * +--------+-------+-----------------------+-----+--------+--------+---------+-------+
- * | in use | dir   | nrfx_gpiote_trigger_t | te  | skip   | legacy |8:       | TE    |
- * | 0: no  | 0:in  |                       | used| config | api    | present | index |
+ * | in use | dir   | nrfx_gpiote_trigger_t | te  | skip   | N/A    |8:       | TE    |
+ * | 0: no  | 0:in  |                       | used| config |        | present | index |
  * | 1: yes | 1:out |                       |     |        |        |9-12:    | (when |
  * |        |       |                       |     |        |        | handler |  used)|
  * |        |       |                       |     |        |        | index   |       |
@@ -108,7 +110,6 @@ NRFX_STATIC_ASSERT(NRFX_GPIOTE_TRIGGER_MAX <= NRFX_BIT(PIN_FLAG_TRIG_MODE_BITS))
 
 #define PIN_FLAG_TE_USED        NRFX_BIT(5)
 #define PIN_FLAG_SKIP_CONFIG    NRFX_BIT(6)
-#define PIN_FLAG_LEGACY_API_PIN NRFX_BIT(7)
 
 #define PIN_FLAG_HANDLER_PRESENT NRFX_BIT(8)
 
@@ -265,12 +266,11 @@ static uint8_t pin_te_get(nrfx_gpiote_pin_t pin)
 
 static bool is_level(nrfx_gpiote_trigger_t trigger)
 {
-        return trigger >= NRFX_GPIOTE_TRIGGER_LOW;
+    return trigger >= NRFX_GPIOTE_TRIGGER_LOW;
 }
 
 static bool handler_in_use(int32_t handler_id)
 {
-
     for (uint32_t i = 0; i < MAX_PIN_NUMBER; i++)
     {
         if (PIN_GET_HANDLER_ID(m_cb.pin_flags[i]) == handler_id)
@@ -278,7 +278,6 @@ static bool handler_in_use(int32_t handler_id)
             return true;
         }
     }
-
     return false;
 }
 
@@ -315,7 +314,7 @@ static void pin_handler_trigger_uninit(nrfx_gpiote_pin_t pin)
     if (pin_in_use_by_te(pin))
     {
         /* te to default */
-        nrf_gpiote_te_default(NRF_GPIOTE, pin_te_get(pin));
+        nrfy_gpiote_te_default(NRF_GPIOTE, pin_te_get(pin));
     }
     else
     {
@@ -337,7 +336,7 @@ nrfx_err_t nrfx_gpiote_pin_uninit(nrfx_gpiote_pin_t pin)
 
     nrfx_gpiote_trigger_disable(pin);
     pin_handler_trigger_uninit(pin);
-    nrf_gpio_cfg_default(pin);
+    nrfy_gpio_cfg_default(pin);
 
     return NRFX_SUCCESS;
 }
@@ -406,7 +405,7 @@ static inline nrf_gpio_pin_sense_t get_initial_sense(nrfx_gpiote_pin_t pin)
     else
     {
         /* If edge detection start with sensing opposite state. */
-        sense = nrf_gpio_pin_read(pin) ? NRF_GPIO_PIN_SENSE_LOW : NRF_GPIO_PIN_SENSE_HIGH;
+        sense = nrfy_gpio_pin_read(pin) ? NRF_GPIO_PIN_SENSE_LOW : NRF_GPIO_PIN_SENSE_HIGH;
     }
 
     return sense;
@@ -429,7 +428,7 @@ nrfx_err_t nrfx_gpiote_input_configure(nrfx_gpiote_pin_t                    pin,
         nrf_gpio_pin_dir_t dir = NRF_GPIO_PIN_DIR_INPUT;
         nrf_gpio_pin_input_t input_connect = NRF_GPIO_PIN_INPUT_CONNECT;
 
-        nrf_gpio_reconfigure(pin, &dir, &input_connect, &p_input_config->pull, NULL, NULL);
+        nrfy_gpio_reconfigure(pin, &dir, &input_connect, &p_input_config->pull, NULL, NULL);
 
         m_cb.pin_flags[pin] &= ~PIN_FLAG_OUTPUT;
         m_cb.pin_flags[pin] |= PIN_FLAG_IN_USE;
@@ -465,14 +464,14 @@ nrfx_err_t nrfx_gpiote_input_configure(nrfx_gpiote_pin_t                    pin,
 
                 if (trigger == NRFX_GPIOTE_TRIGGER_NONE)
                 {
-                    nrf_gpiote_te_default(NRF_GPIOTE, ch);
+                    nrfy_gpiote_te_default(NRF_GPIOTE, ch);
                 }
                 else
                 {
                     nrf_gpiote_polarity_t polarity = gpiote_trigger_to_polarity(trigger);
 
-                    nrf_gpiote_event_disable(NRF_GPIOTE, ch);
-                    nrf_gpiote_event_configure(NRF_GPIOTE, ch, pin, polarity);
+                    nrfy_gpiote_event_disable(NRF_GPIOTE, ch);
+                    nrfy_gpiote_event_configure(NRF_GPIOTE, ch, pin, polarity);
 
                     m_cb.pin_flags[pin] |= PIN_FLAG_TE_ID(ch);
                 }
@@ -525,8 +524,8 @@ nrfx_err_t nrfx_gpiote_output_configure(nrfx_gpiote_pin_t                   pin,
 
         nrf_gpio_pin_dir_t dir = NRF_GPIO_PIN_DIR_OUTPUT;
 
-        nrf_gpio_reconfigure(pin, &dir, &p_config->input_connect, &p_config->pull,
-                             &p_config->drive, NULL);
+        nrfy_gpio_reconfigure(pin, &dir, &p_config->input_connect, &p_config->pull,
+                              &p_config->drive, NULL);
 
         m_cb.pin_flags[pin] |= PIN_FLAG_IN_USE | PIN_FLAG_OUTPUT;
     }
@@ -540,13 +539,13 @@ nrfx_err_t nrfx_gpiote_output_configure(nrfx_gpiote_pin_t                   pin,
 
         uint32_t ch = p_task_config->task_ch;
 
-        nrf_gpiote_te_default(NRF_GPIOTE, ch);
+        nrfy_gpiote_te_default(NRF_GPIOTE, ch);
         m_cb.pin_flags[pin] &= ~(PIN_FLAG_TE_USED | PIN_TE_ID_MASK);
         if (p_task_config->polarity != NRF_GPIOTE_POLARITY_NONE)
         {
-            nrf_gpiote_task_configure(NRF_GPIOTE, ch, pin,
-                                      p_task_config->polarity,
-                                      p_task_config->init_val);
+            nrfy_gpiote_task_configure(NRF_GPIOTE, ch, pin,
+                                       p_task_config->polarity,
+                                       p_task_config->init_val);
             m_cb.pin_flags[pin] |= PIN_FLAG_TE_ID(ch);
         }
     }
@@ -603,11 +602,8 @@ nrfx_err_t nrfx_gpiote_init(uint8_t interrupt_priority)
 
     memset(m_cb.pin_flags, 0, sizeof(m_cb.pin_flags));
 
-    NRFX_IRQ_PRIORITY_SET(nrfx_get_irq_number(NRF_GPIOTE), interrupt_priority);
-    NRFX_IRQ_ENABLE(nrfx_get_irq_number(NRF_GPIOTE));
+    nrfy_gpiote_int_init(NRF_GPIOTE, (uint32_t)NRF_GPIOTE_INT_PORT_MASK, interrupt_priority, true);
 
-    nrf_gpiote_event_clear(NRF_GPIOTE, NRF_GPIOTE_EVENT_PORT);
-    nrf_gpiote_int_enable(NRF_GPIOTE, (uint32_t)NRF_GPIOTE_INT_PORT_MASK);
     m_cb.state = NRFX_DRV_STATE_INITIALIZED;
     m_cb.available_evt_handlers = NRFX_BIT_MASK(NRFX_GPIOTE_CONFIG_NUM_OF_EVT_HANDLERS);
 
@@ -631,24 +627,9 @@ void nrfx_gpiote_uninit(void)
 
     for (i = 0; i < MAX_PIN_NUMBER; i++)
     {
-        if (nrf_gpio_pin_present_check(i) && pin_in_use(i))
+        if (nrfy_gpio_pin_present_check(i) && pin_in_use(i))
         {
-            if (m_cb.pin_flags[i] & PIN_FLAG_LEGACY_API_PIN)
-            {
-                m_cb.pin_flags[i] &= ~PIN_FLAG_LEGACY_API_PIN;
-                if (pin_has_trigger(i))
-                {
-                    nrfx_gpiote_in_uninit(i);
-                }
-                else
-                {
-                    nrfx_gpiote_out_uninit(i);
-                }
-            }
-            else
-            {
-                nrfx_gpiote_pin_uninit(i);
-            }
+            nrfx_gpiote_pin_uninit(i);
         }
     }
     m_cb.state = NRFX_DRV_STATE_UNINITIALIZED;
@@ -665,165 +646,81 @@ nrfx_err_t nrfx_gpiote_channel_alloc(uint8_t * p_channel)
     return nrfx_flag32_alloc(&m_cb.available_channels_mask, p_channel);
 }
 
-nrfx_err_t nrfx_gpiote_out_init(nrfx_gpiote_pin_t                pin,
-                                nrfx_gpiote_out_config_t const * p_config)
-{
-    uint8_t ch;
-    nrfx_err_t err;
-
-    if (p_config->task_pin)
-    {
-        err = nrfx_gpiote_channel_alloc(&ch);
-        if (err != NRFX_SUCCESS)
-        {
-            return err;
-        }
-    }
-    else
-    {
-        /* Value will not be used. */
-        ch = 0xFF;
-    }
-
-    err = nrfx_gpiote_out_prealloc_init(pin, p_config, ch);
-    if (err == NRFX_ERROR_BUSY && p_config->task_pin)
-    {
-        nrfx_gpiote_channel_free(ch);
-    }
-
-    return err;
-}
-
-nrfx_err_t nrfx_gpiote_out_prealloc_init(nrfx_gpiote_pin_t                pin,
-                                         nrfx_gpiote_out_config_t const * p_config,
-                                         uint8_t                          channel)
-{
-    nrfx_gpiote_output_config_t config = NRFX_GPIOTE_DEFAULT_OUTPUT_CONFIG;
-    nrfx_gpiote_task_config_t task_config;
-    bool use_task = p_config->task_pin;
-    nrfx_err_t err;
-
-    if (pin_in_use(pin))
-    {
-        return NRFX_ERROR_BUSY;
-    }
-
-    if (p_config->init_state == NRF_GPIOTE_INITIAL_VALUE_HIGH)
-    {
-        nrf_gpio_pin_set(pin);
-    }
-
-    if (use_task)
-    {
-
-        task_config.task_ch = channel;
-        task_config.init_val = p_config->init_state;
-        task_config.polarity = p_config->action;
-    }
-
-    err = nrfx_gpiote_output_configure(pin, &config, use_task ? &task_config : NULL);
-    if (err == NRFX_SUCCESS)
-    {
-        m_cb.pin_flags[pin] |= PIN_FLAG_LEGACY_API_PIN;
-    }
-
-    return err;
-}
-
-void nrfx_gpiote_out_uninit(nrfx_gpiote_pin_t pin)
-{
-    NRFX_ASSERT(nrf_gpio_pin_present_check(pin));
-    NRFX_ASSERT(pin_in_use(pin));
-
-    uint8_t ch = pin_in_use_by_te(pin) ? pin_te_get(pin) : 0xFF;
-
-    nrfx_err_t err = nrfx_gpiote_pin_uninit(pin);
-    NRFX_ASSERT(err == NRFX_SUCCESS);
-
-    if (ch != 0xFF)
-    {
-        nrfx_gpiote_channel_free(ch);
-    }
-
-    (void)err;
-}
-
-
 void nrfx_gpiote_out_set(nrfx_gpiote_pin_t pin)
 {
-    NRFX_ASSERT(nrf_gpio_pin_present_check(pin));
+    NRFX_ASSERT(nrfy_gpio_pin_present_check(pin));
     NRFX_ASSERT(pin_is_output(pin) && !pin_in_use_by_te(pin));
 
-    nrf_gpio_pin_set(pin);
+    nrfy_gpio_pin_set(pin);
 }
 
 
 void nrfx_gpiote_out_clear(nrfx_gpiote_pin_t pin)
 {
-    NRFX_ASSERT(nrf_gpio_pin_present_check(pin));
+    NRFX_ASSERT(nrfy_gpio_pin_present_check(pin));
     NRFX_ASSERT(pin_is_output(pin) && !pin_in_use_by_te(pin));
 
-    nrf_gpio_pin_clear(pin);
+    nrfy_gpio_pin_clear(pin);
 }
 
 
 void nrfx_gpiote_out_toggle(nrfx_gpiote_pin_t pin)
 {
-    NRFX_ASSERT(nrf_gpio_pin_present_check(pin));
+    NRFX_ASSERT(nrfy_gpio_pin_present_check(pin));
     NRFX_ASSERT(pin_is_output(pin) && !pin_in_use_by_te(pin));
 
-    nrf_gpio_pin_toggle(pin);
+    nrfy_gpio_pin_toggle(pin);
 }
 
 void nrfx_gpiote_out_task_enable(nrfx_gpiote_pin_t pin)
 {
     (void)pin_is_task_output; /* Add to avoid compiler warnings when asserts disabled.*/
-    NRFX_ASSERT(nrf_gpio_pin_present_check(pin));
+    NRFX_ASSERT(nrfy_gpio_pin_present_check(pin));
     NRFX_ASSERT(pin_is_task_output(pin));
 
-    nrf_gpiote_task_enable(NRF_GPIOTE, (uint32_t)pin_te_get(pin));
+    nrfy_gpiote_task_enable(NRF_GPIOTE, (uint32_t)pin_te_get(pin));
 }
 
 
 void nrfx_gpiote_out_task_disable(nrfx_gpiote_pin_t pin)
 {
-    NRFX_ASSERT(nrf_gpio_pin_present_check(pin));
+    NRFX_ASSERT(nrfy_gpio_pin_present_check(pin));
     NRFX_ASSERT(pin_is_task_output(pin));
 
-    nrf_gpiote_task_disable(NRF_GPIOTE, (uint32_t)pin_te_get(pin));
+    nrfy_gpiote_task_disable(NRF_GPIOTE, (uint32_t)pin_te_get(pin));
 }
 
 
 nrf_gpiote_task_t nrfx_gpiote_out_task_get(nrfx_gpiote_pin_t pin)
 {
-    NRFX_ASSERT(nrf_gpio_pin_present_check(pin));
+    NRFX_ASSERT(nrfy_gpio_pin_present_check(pin));
     NRFX_ASSERT(pin_is_task_output(pin));
 
-    return nrf_gpiote_out_task_get((uint8_t)pin_te_get(pin));
+    return nrfy_gpiote_out_task_get((uint8_t)pin_te_get(pin));
 }
 
 
-uint32_t nrfx_gpiote_out_task_addr_get(nrfx_gpiote_pin_t pin)
+uint32_t nrfx_gpiote_out_task_address_get(nrfx_gpiote_pin_t pin)
 {
     nrf_gpiote_task_t task = nrfx_gpiote_out_task_get(pin);
-    return nrf_gpiote_task_address_get(NRF_GPIOTE, task);
+    return nrfy_gpiote_task_address_get(NRF_GPIOTE, task);
 }
 
 
 #if defined(GPIOTE_FEATURE_SET_PRESENT)
 nrf_gpiote_task_t nrfx_gpiote_set_task_get(nrfx_gpiote_pin_t pin)
 {
-    NRFX_ASSERT(nrf_gpio_pin_present_check(pin));
+    NRFX_ASSERT(nrfy_gpio_pin_present_check(pin));
     NRFX_ASSERT(pin_is_task_output(pin));
 
-    return nrf_gpiote_set_task_get((uint8_t)pin_te_get(pin));
+    return nrfy_gpiote_set_task_get((uint8_t)pin_te_get(pin));
 }
 
 
-uint32_t nrfx_gpiote_set_task_addr_get(nrfx_gpiote_pin_t pin)
+uint32_t nrfx_gpiote_set_task_address_get(nrfx_gpiote_pin_t pin)
 {
     nrf_gpiote_task_t task = nrfx_gpiote_set_task_get(pin);
-    return nrf_gpiote_task_address_get(NRF_GPIOTE, task);
+    return nrfy_gpiote_task_address_get(NRF_GPIOTE, task);
 }
 #endif // defined(GPIOTE_FEATURE_SET_PRESENT)
 
@@ -831,51 +728,51 @@ uint32_t nrfx_gpiote_set_task_addr_get(nrfx_gpiote_pin_t pin)
 #if defined(GPIOTE_FEATURE_CLR_PRESENT)
 nrf_gpiote_task_t nrfx_gpiote_clr_task_get(nrfx_gpiote_pin_t pin)
 {
-    NRFX_ASSERT(nrf_gpio_pin_present_check(pin));
+    NRFX_ASSERT(nrfy_gpio_pin_present_check(pin));
     NRFX_ASSERT(pin_is_task_output(pin));
 
-    return nrf_gpiote_clr_task_get((uint8_t)pin_te_get(pin));
+    return nrfy_gpiote_clr_task_get((uint8_t)pin_te_get(pin));
 }
 
 
-uint32_t nrfx_gpiote_clr_task_addr_get(nrfx_gpiote_pin_t pin)
+uint32_t nrfx_gpiote_clr_task_address_get(nrfx_gpiote_pin_t pin)
 {
     nrf_gpiote_task_t task = nrfx_gpiote_clr_task_get(pin);
-    return nrf_gpiote_task_address_get(NRF_GPIOTE, task);
+    return nrfy_gpiote_task_address_get(NRF_GPIOTE, task);
 }
 #endif // defined(GPIOTE_FEATURE_CLR_PRESENT)
 
 
 void nrfx_gpiote_out_task_force(nrfx_gpiote_pin_t pin, uint8_t state)
 {
-    NRFX_ASSERT(nrf_gpio_pin_present_check(pin));
+    NRFX_ASSERT(nrfy_gpio_pin_present_check(pin));
     NRFX_ASSERT(pin_is_task_output(pin));
 
     nrf_gpiote_outinit_t init_val =
         state ? NRF_GPIOTE_INITIAL_VALUE_HIGH : NRF_GPIOTE_INITIAL_VALUE_LOW;
-    nrf_gpiote_task_force(NRF_GPIOTE, (uint32_t)pin_te_get(pin), init_val);
+    nrfy_gpiote_task_force(NRF_GPIOTE, (uint32_t)pin_te_get(pin), init_val);
 }
 
 
 void nrfx_gpiote_out_task_trigger(nrfx_gpiote_pin_t pin)
 {
-    NRFX_ASSERT(nrf_gpio_pin_present_check(pin));
+    NRFX_ASSERT(nrfy_gpio_pin_present_check(pin));
     NRFX_ASSERT(pin_is_task_output(pin));
 
-    nrf_gpiote_task_t task = nrf_gpiote_out_task_get((uint8_t)pin_te_get(pin));
-    nrf_gpiote_task_trigger(NRF_GPIOTE, task);
+    nrf_gpiote_task_t task = nrfy_gpiote_out_task_get((uint8_t)pin_te_get(pin));
+    nrfy_gpiote_task_trigger(NRF_GPIOTE, task);
 }
 
 
 #if defined(GPIOTE_FEATURE_SET_PRESENT)
 void nrfx_gpiote_set_task_trigger(nrfx_gpiote_pin_t pin)
 {
-    NRFX_ASSERT(nrf_gpio_pin_present_check(pin));
+    NRFX_ASSERT(nrfy_gpio_pin_present_check(pin));
     NRFX_ASSERT(pin_in_use(pin));
     NRFX_ASSERT(pin_in_use_by_te(pin));
 
-    nrf_gpiote_task_t task = nrf_gpiote_set_task_get((uint8_t)pin_te_get(pin));
-    nrf_gpiote_task_trigger(NRF_GPIOTE, task);
+    nrf_gpiote_task_t task = nrfy_gpiote_set_task_get((uint8_t)pin_te_get(pin));
+    nrfy_gpiote_task_trigger(NRF_GPIOTE, task);
 }
 
 
@@ -884,107 +781,16 @@ void nrfx_gpiote_set_task_trigger(nrfx_gpiote_pin_t pin)
 #if  defined(GPIOTE_FEATURE_CLR_PRESENT)
 void nrfx_gpiote_clr_task_trigger(nrfx_gpiote_pin_t pin)
 {
-    NRFX_ASSERT(nrf_gpio_pin_present_check(pin));
+    NRFX_ASSERT(nrfy_gpio_pin_present_check(pin));
     NRFX_ASSERT(pin_in_use(pin));
     NRFX_ASSERT(pin_in_use_by_te(pin));
 
-    nrf_gpiote_task_t task = nrf_gpiote_clr_task_get((uint8_t)pin_te_get(pin));
-    nrf_gpiote_task_trigger(NRF_GPIOTE, task);
+    nrf_gpiote_task_t task = nrfy_gpiote_clr_task_get((uint8_t)pin_te_get(pin));
+    nrfy_gpiote_task_trigger(NRF_GPIOTE, task);
 }
 
 
 #endif // defined(GPIOTE_FEATURE_CLR_PRESENT)
-
-
-nrfx_err_t nrfx_gpiote_in_init(nrfx_gpiote_pin_t               pin,
-                               nrfx_gpiote_in_config_t const * p_config,
-                               nrfx_gpiote_evt_handler_t       evt_handler)
-{
-    uint8_t ch;
-    nrfx_err_t err;
-
-    if (p_config->hi_accuracy)
-    {
-        err = nrfx_gpiote_channel_alloc(&ch);
-        if (err != NRFX_SUCCESS)
-        {
-            return err;
-        }
-    }
-    else
-    {
-        /* Value will not be used. */
-        ch = 0xFF;
-    }
-
-    err = nrfx_gpiote_in_prealloc_init(pin, p_config, ch, evt_handler);
-    if ((err == NRFX_ERROR_NO_MEM) && p_config->hi_accuracy)
-    {
-        nrfx_gpiote_channel_free(ch);
-    }
-
-    return err;
-}
-
-static void legacy_handler(nrfx_gpiote_pin_t pin, nrfx_gpiote_trigger_t trigger, void * p_context)
-{
-    NRFX_ASSERT(trigger <= NRFX_GPIOTE_TRIGGER_TOGGLE);
-
-    ((nrfx_gpiote_evt_handler_t)p_context)(pin, gpiote_trigger_to_polarity(trigger));
-}
-
-nrfx_err_t nrfx_gpiote_in_prealloc_init(nrfx_gpiote_pin_t               pin,
-                                        nrfx_gpiote_in_config_t const * p_config,
-                                        uint8_t                         channel,
-                                        nrfx_gpiote_evt_handler_t       evt_handler)
-{
-    nrfx_err_t err;
-    bool skip_in_config = false;
-    nrfx_gpiote_input_config_t input_config;
-    nrfx_gpiote_trigger_config_t trigger_config = {
-        .trigger = gpiote_polarity_to_trigger(p_config->sense),
-        .p_in_channel = p_config->hi_accuracy ? &channel : NULL
-    };
-    nrfx_gpiote_handler_config_t handler_config = {
-        .handler = legacy_handler,
-        .p_context = (void *)evt_handler
-    };
-
-    if (p_config->is_watcher)
-    {
-        nrfx_gpiote_output_config_t output_config = {
-            .input_connect = NRF_GPIO_PIN_INPUT_CONNECT
-        };
-
-        skip_in_config = true;
-        err = nrfx_gpiote_output_configure(pin, &output_config, NULL);
-        if (err != NRFX_SUCCESS)
-        {
-            return err;
-        }
-    }
-    else
-    {
-        input_config.pull = p_config->pull;
-    }
-
-    if (p_config->skip_gpio_setup)
-    {
-        m_cb.pin_flags[pin] |= PIN_FLAG_SKIP_CONFIG;
-        skip_in_config = true;
-    }
-
-    err = nrfx_gpiote_input_configure(pin,
-                                      skip_in_config ? NULL : &input_config,
-                                      &trigger_config,
-                                      &handler_config);
-    if (err == NRFX_SUCCESS)
-    {
-        m_cb.pin_flags[pin] |= PIN_FLAG_LEGACY_API_PIN;
-    }
-
-    return err;
-}
 
 void nrfx_gpiote_trigger_enable(nrfx_gpiote_pin_t pin, bool int_enable)
 {
@@ -994,17 +800,17 @@ void nrfx_gpiote_trigger_enable(nrfx_gpiote_pin_t pin, bool int_enable)
     {
         uint8_t ch = pin_te_get(pin);
 
-        nrf_gpiote_event_clear(NRF_GPIOTE, nrf_gpiote_in_event_get(ch));
-        nrf_gpiote_event_enable(NRF_GPIOTE, ch);
+        nrfy_gpiote_event_clear(NRF_GPIOTE, nrf_gpiote_in_event_get(ch));
+        nrfy_gpiote_event_enable(NRF_GPIOTE, ch);
         if (int_enable)
         {
-            nrf_gpiote_int_enable(NRF_GPIOTE, NRFX_BIT(ch));
+            nrfy_gpiote_int_enable(NRF_GPIOTE, NRFX_BIT(ch));
         }
     }
     else
     {
         NRFX_ASSERT(int_enable);
-        nrf_gpio_cfg_sense_set(pin, get_initial_sense(pin));
+        nrfy_gpio_cfg_sense_set(pin, get_initial_sense(pin));
     }
 }
 
@@ -1014,75 +820,41 @@ void nrfx_gpiote_trigger_disable(nrfx_gpiote_pin_t pin)
     {
         uint8_t ch = pin_te_get(pin);
 
-        nrf_gpiote_int_disable(NRF_GPIOTE, NRFX_BIT(ch));
-        nrf_gpiote_event_disable(NRF_GPIOTE, ch);
+        nrfy_gpiote_int_disable(NRF_GPIOTE, NRFX_BIT(ch));
+        nrfy_gpiote_event_disable(NRF_GPIOTE, ch);
     }
     else
     {
-        nrf_gpio_cfg_sense_set(pin, NRF_GPIO_PIN_NOSENSE);
+        nrfy_gpio_cfg_sense_set(pin, NRF_GPIO_PIN_NOSENSE);
     }
 }
-
-void nrfx_gpiote_in_uninit(nrfx_gpiote_pin_t pin)
-{
-    NRFX_ASSERT(pin_in_use(pin));
-    NRFX_ASSERT(pin_is_input(pin) || pin_has_trigger(pin));
-    nrfx_err_t err;
-    uint8_t ch;
-
-    if (!pin_in_use(pin))
-    {
-        return;
-    }
-
-    ch = pin_in_use_by_te(pin) ? pin_te_get(pin) : 0xFF;
-
-    if (m_cb.pin_flags[pin] & PIN_FLAG_SKIP_CONFIG)
-    {
-        pin_handler_trigger_uninit(pin);
-        m_cb.pin_flags[pin] &= ~PIN_FLAG_SKIP_CONFIG;
-    }
-    else
-    {
-        err = nrfx_gpiote_pin_uninit(pin);
-        NRFX_ASSERT(err == NRFX_SUCCESS);
-    }
-
-    if (ch != 0xFF)
-    {
-        nrfx_gpiote_channel_free(ch);
-    }
-
-    (void)err;
-}
-
 
 bool nrfx_gpiote_in_is_set(nrfx_gpiote_pin_t pin)
 {
-    NRFX_ASSERT(nrf_gpio_pin_present_check(pin));
-    return nrf_gpio_pin_read(pin) ? true : false;
+    NRFX_ASSERT(nrfy_gpio_pin_present_check(pin));
+    return nrfy_gpio_pin_read(pin) ? true : false;
 }
 
 
 nrf_gpiote_event_t nrfx_gpiote_in_event_get(nrfx_gpiote_pin_t pin)
 {
-    NRFX_ASSERT(nrf_gpio_pin_present_check(pin));
+    NRFX_ASSERT(nrfy_gpio_pin_present_check(pin));
     NRFX_ASSERT(pin_is_input(pin));
     NRFX_ASSERT(pin_has_trigger(pin));
 
     if (pin_in_use_by_te(pin))
     {
-        return nrf_gpiote_in_event_get((uint8_t)pin_te_get(pin));
+        return nrfy_gpiote_in_event_get((uint8_t)pin_te_get(pin));
     }
 
     return NRF_GPIOTE_EVENT_PORT;
 }
 
 
-uint32_t nrfx_gpiote_in_event_addr_get(nrfx_gpiote_pin_t pin)
+uint32_t nrfx_gpiote_in_event_address_get(nrfx_gpiote_pin_t pin)
 {
     nrf_gpiote_event_t event = nrfx_gpiote_in_event_get(pin);
-    return nrf_gpiote_event_address_get(NRF_GPIOTE, event);
+    return nrfy_gpiote_event_address_get(NRF_GPIOTE, event);
 }
 
 static void call_handler(nrfx_gpiote_pin_t pin, nrfx_gpiote_trigger_t trigger)
@@ -1106,12 +878,12 @@ static void next_sense_cond_call_handler(nrfx_gpiote_pin_t     pin,
     if (is_level(trigger))
     {
         call_handler(pin, trigger);
-        if (nrf_gpio_pin_sense_get(pin) == sense)
+        if (nrfy_gpio_pin_sense_get(pin) == sense)
         {
             /* The sensing mechanism needs to be reenabled here so that the PORT event
              * is generated again for the pin if it stays at the sensed level. */
-            nrf_gpio_cfg_sense_set(pin, NRF_GPIO_PIN_NOSENSE);
-            nrf_gpio_cfg_sense_set(pin, sense);
+            nrfy_gpio_cfg_sense_set(pin, NRF_GPIO_PIN_NOSENSE);
+            nrfy_gpio_cfg_sense_set(pin, sense);
         }
     }
     else
@@ -1122,7 +894,7 @@ static void next_sense_cond_call_handler(nrfx_gpiote_pin_t     pin,
         nrf_gpio_pin_sense_t next_sense = (sense == NRF_GPIO_PIN_SENSE_HIGH) ?
                 NRF_GPIO_PIN_SENSE_LOW : NRF_GPIO_PIN_SENSE_HIGH;
 
-        nrf_gpio_cfg_sense_set(pin, next_sense);
+        nrfy_gpio_cfg_sense_set(pin, next_sense);
 
         /* Invoke user handler only if the sensed pin level matches its polarity
          * configuration. Call handler unconditionally in case of toggle trigger or
@@ -1139,7 +911,7 @@ static void next_sense_cond_call_handler(nrfx_gpiote_pin_t     pin,
 #if defined(NRF_GPIO_LATCH_PRESENT)
 static bool latch_pending_read_and_check(uint32_t * latch)
 {
-    nrf_gpio_latches_read_and_clear(0, GPIO_COUNT, latch);
+    nrfy_gpio_latches_read_and_clear(0, GPIO_COUNT, latch);
 
     for (uint32_t port_idx = 0; port_idx < GPIO_COUNT; port_idx++)
     {
@@ -1158,7 +930,7 @@ static void port_event_handle(void)
 {
     uint32_t latch[GPIO_COUNT];
 
-    nrf_gpio_latches_read_and_clear(0, GPIO_COUNT, latch);
+    nrfy_gpio_latches_read_and_clear(0, GPIO_COUNT, latch);
 
     do {
         for (uint32_t i = 0; i < GPIO_COUNT; i++)
@@ -1173,20 +945,20 @@ static void port_event_handle(void)
                 nrfx_gpiote_trigger_t trigger = PIN_FLAG_TRIG_MODE_GET(m_cb.pin_flags[pin]);
 
                 nrf_bitmask_bit_clear(pin, latch);
-                sense = nrf_gpio_pin_sense_get(pin);
+                sense = nrfy_gpio_pin_sense_get(pin);
 
                 next_sense_cond_call_handler(pin, trigger, sense);
                 /* Try to clear LATCH bit corresponding to currently processed pin.
                  * This may not succeed if the pin's state changed during the interrupt processing
                  * and now it matches the new sense configuration. In such case,
                  * the pin will be processed again in another iteration of the outer loop. */
-                nrf_gpio_pin_latch_clear(pin);
+                nrfy_gpio_pin_latch_clear(pin);
            }
         }
 
         /* All pins have been handled, clear PORT, check latch again in case
          * something came between deciding to exit and clearing PORT event. */
-        nrf_gpiote_event_clear(NRF_GPIOTE, NRF_GPIOTE_EVENT_PORT);
+        (void)nrfy_gpiote_events_process(NRF_GPIOTE, (uint32_t)NRF_GPIOTE_INT_PORT_MASK);
     } while (latch_pending_read_and_check(latch));
 }
 
@@ -1197,7 +969,7 @@ static bool input_read_and_check(uint32_t * input, uint32_t * pins_to_check)
     bool process_inputs_again;
     uint32_t new_input[GPIO_COUNT];
 
-    nrf_gpio_ports_read(0, GPIO_COUNT, new_input);
+    nrfy_gpio_ports_read(0, GPIO_COUNT, new_input);
 
     process_inputs_again = false;
     for (uint32_t port_idx = 0; port_idx < GPIO_COUNT; port_idx++)
@@ -1228,7 +1000,7 @@ static void port_event_handle(void)
     uint8_t pin;
     nrfx_gpiote_trigger_t trigger;
 
-    nrf_gpio_ports_read(0, GPIO_COUNT, input);
+    nrfy_gpio_ports_read(0, GPIO_COUNT, input);
 
     for (uint32_t port_idx = 0; port_idx < GPIO_COUNT; port_idx++)
     {
@@ -1249,7 +1021,7 @@ static void port_event_handle(void)
                 pin = rel_pin + 32 * i;
 
                 trigger = PIN_FLAG_TRIG_MODE_GET(m_cb.pin_flags[pin]);
-                sense = nrf_gpio_pin_sense_get(pin);
+                sense = nrfy_gpio_pin_sense_get(pin);
                 pin_state = nrf_bitmask_bit_is_set(pin, input);
 
                 /* Process pin further only if its state matches its sense level. */
@@ -1280,7 +1052,7 @@ static void port_event_handle(void)
                 rel_pin = NRF_CTZ(pin_mask);
                 pin_mask &= ~NRFX_BIT(rel_pin);
                 pin = rel_pin + 32 * i;
-                if (nrf_gpio_pin_sense_get(pin) != NRF_GPIO_PIN_NOSENSE)
+                if (nrfy_gpio_pin_sense_get(pin) != NRF_GPIO_PIN_NOSENSE)
                 {
                     trigger = PIN_FLAG_TRIG_MODE_GET(m_cb.pin_flags[pin]);
                     if (trigger == NRFX_GPIOTE_TRIGGER_HIGH)
@@ -1295,7 +1067,7 @@ static void port_event_handle(void)
             }
         }
 
-        nrf_gpiote_event_clear(NRF_GPIOTE, NRF_GPIOTE_EVENT_PORT);
+        (void)nrfy_gpiote_events_process(NRF_GPIOTE, (uint32_t)NRF_GPIOTE_INT_PORT_MASK);
     } while (input_read_and_check(input, pins_to_check));
 }
 #endif // defined(NRF_GPIO_LATCH_PRESENT)
@@ -1306,8 +1078,8 @@ static void gpiote_evt_handle(uint32_t mask)
     {
         uint32_t ch = NRF_CTZ(mask);
         mask &= ~NRFX_BIT(ch);
-        nrfx_gpiote_pin_t pin = nrf_gpiote_event_pin_get(NRF_GPIOTE, ch);
-        nrf_gpiote_polarity_t polarity = nrf_gpiote_event_polarity_get(NRF_GPIOTE, ch);
+        nrfx_gpiote_pin_t pin = nrfy_gpiote_event_pin_get(NRF_GPIOTE, ch);
+        nrf_gpiote_polarity_t polarity = nrfy_gpiote_event_polarity_get(NRF_GPIOTE, ch);
 
         call_handler(pin, gpiote_polarity_to_trigger(polarity));
     }
@@ -1315,34 +1087,21 @@ static void gpiote_evt_handle(uint32_t mask)
 
 void nrfx_gpiote_irq_handler(void)
 {
-    uint32_t status = 0;
-    uint32_t i;
-    nrf_gpiote_event_t event = NRF_GPIOTE_EVENT_IN_0;
-    uint32_t mask = (uint32_t)NRF_GPIOTE_INT_IN0_MASK;
+    /* Collect status of all GPIOTE pin events. Processing is done once all are collected and cleared.*/
+    uint32_t enabled_in_events = nrf_gpiote_int_enable_check(NRF_GPIOTE, NRF_GPIOTE_INT_IN_MASK);
+    uint32_t evt_mask = nrfy_gpiote_events_process(NRF_GPIOTE,
+                                                   enabled_in_events |
+                                                   (uint32_t)NRF_GPIOTE_INT_PORT_MASK);
 
-    /* collect status of all GPIOTE pin events. Processing is done once all are collected and cleared.*/
-    for (i = 0; i < GPIOTE_CH_NUM; i++)
-    {
-        if (nrf_gpiote_event_check(NRF_GPIOTE, event) &&
-            nrf_gpiote_int_enable_check(NRF_GPIOTE, mask))
-        {
-            nrf_gpiote_event_clear(NRF_GPIOTE, event);
-            status |= mask;
-        }
-        mask <<= 1;
-        /* Incrementing to next event, utilizing the fact that events are grouped together
-         * in ascending order. */
-        event = (nrf_gpiote_event_t)((uint32_t)event + sizeof(uint32_t));
-    }
-
-    /* handle PORT event */
-    if (nrf_gpiote_event_check(NRF_GPIOTE, NRF_GPIOTE_EVENT_PORT))
+    /* Handle PORT event. */
+    if (evt_mask & (uint32_t)NRF_GPIOTE_INT_PORT_MASK)
     {
         port_event_handle();
+        evt_mask &= ~(uint32_t)NRF_GPIOTE_INT_PORT_MASK;
     }
 
     /* Process pin events. */
-    gpiote_evt_handle(status);
+    gpiote_evt_handle(evt_mask);
 }
 
 #endif // NRFX_CHECK(NRFX_GPIOTE_ENABLED)

--- a/nrfx/drivers/src/nrfx_i2s.c
+++ b/nrfx/drivers/src/nrfx_i2s.c
@@ -36,7 +36,7 @@
 #if NRFX_CHECK(NRFX_I2S_ENABLED)
 
 #include <nrfx_i2s.h>
-#include <hal/nrf_gpio.h>
+#include <haly/nrfy_gpio.h>
 
 #define NRFX_LOG_MODULE I2S
 #include <nrfx_log.h>
@@ -85,9 +85,9 @@ typedef struct
     uint16_t            buffer_size;
     nrfx_i2s_buffers_t  next_buffers;
     nrfx_i2s_buffers_t  current_buffers;
-} i2s_control_block_t;
-static i2s_control_block_t m_cb;
+} nrfx_i2s_cb_t;
 
+static nrfx_i2s_cb_t m_cb[NRFX_I2S_ENABLED_COUNT];
 
 static void configure_pins(nrfx_i2s_config_t const * p_config)
 {
@@ -100,64 +100,42 @@ static void configure_pins(nrfx_i2s_config_t const * p_config)
         //   mode).
         if (p_config->mode == NRF_I2S_MODE_MASTER)
         {
-            nrf_gpio_cfg_output(p_config->sck_pin);
-            nrf_gpio_cfg_output(p_config->lrck_pin);
+            nrfy_gpio_cfg_output(p_config->sck_pin);
+            nrfy_gpio_cfg_output(p_config->lrck_pin);
         }
         else
         {
-            nrf_gpio_cfg_input(p_config->sck_pin,  NRF_GPIO_PIN_NOPULL);
-            nrf_gpio_cfg_input(p_config->lrck_pin, NRF_GPIO_PIN_NOPULL);
+            nrfy_gpio_cfg_input(p_config->sck_pin,  NRF_GPIO_PIN_NOPULL);
+            nrfy_gpio_cfg_input(p_config->lrck_pin, NRF_GPIO_PIN_NOPULL);
         }
         // - MCK (optional) - always output,
-        if (p_config->mck_pin != NRFX_I2S_PIN_NOT_USED)
+        if (p_config->mck_pin != NRF_I2S_PIN_NOT_CONNECTED)
         {
-            nrf_gpio_cfg_output(p_config->mck_pin);
+            nrfy_gpio_cfg_output(p_config->mck_pin);
         }
         // - SDOUT (optional) - always output,
-        if (p_config->sdout_pin != NRFX_I2S_PIN_NOT_USED)
+        if (p_config->sdout_pin != NRF_I2S_PIN_NOT_CONNECTED)
         {
-            nrf_gpio_cfg_output(p_config->sdout_pin);
+            nrfy_gpio_cfg_output(p_config->sdout_pin);
         }
         // - SDIN (optional) - always input.
-        if (p_config->sdin_pin != NRFX_I2S_PIN_NOT_USED)
+        if (p_config->sdin_pin != NRF_I2S_PIN_NOT_CONNECTED)
         {
-            nrf_gpio_cfg_input(p_config->sdin_pin, NRF_GPIO_PIN_NOPULL);
+            nrfy_gpio_cfg_input(p_config->sdin_pin, NRF_GPIO_PIN_NOPULL);
         }
-    }
-
-    if (!p_config->skip_psel_cfg)
-    {
-        uint32_t mck_pin = (p_config->mck_pin != NRFX_I2S_PIN_NOT_USED)
-                           ? p_config->mck_pin
-                           : NRF_I2S_PIN_NOT_CONNECTED;
-        uint32_t sdout_pin = (p_config->sdout_pin != NRFX_I2S_PIN_NOT_USED)
-                             ? p_config->sdout_pin
-                             : NRF_I2S_PIN_NOT_CONNECTED;
-        uint32_t sdin_pin = (p_config->sdin_pin != NRFX_I2S_PIN_NOT_USED)
-                            ? p_config->sdin_pin
-                            : NRF_I2S_PIN_NOT_CONNECTED;
-
-        nrf_i2s_pins_set(NRF_I2S0,
-                         p_config->sck_pin,
-                         p_config->lrck_pin,
-                         mck_pin,
-                         sdout_pin,
-                         sdin_pin);
     }
 }
 
-static void deconfigure_pins(void)
+static void deconfigure_pins(nrfx_i2s_t const * p_instance)
 {
-    uint32_t sck_pin   = nrf_i2s_sck_pin_get(NRF_I2S0);
-    uint32_t lrck_pin  = nrf_i2s_lrck_pin_get(NRF_I2S0);
-    uint32_t mck_pin   = nrf_i2s_mck_pin_get(NRF_I2S0);
-    uint32_t sdout_pin = nrf_i2s_sdout_pin_get(NRF_I2S0);
-    uint32_t sdin_pin  = nrf_i2s_sdin_pin_get(NRF_I2S0);
+    nrf_i2s_pins_t pins;
+
+    nrfy_i2s_pins_get(p_instance->p_reg, &pins);
 
 #if USE_WORKAROUND_FOR_ANOMALY_170
     // Create bitmask for extracting pin number from PSEL register.
     uint32_t pin_mask = I2S_PSEL_SCK_PIN_Msk;
-#if defined(I2S_PSEL_SCK_PORT_Msk)
+#if NRF_I2S_HAS_GPIO_PORT_SELECTION
     // If device supports more than one GPIO port, take port number into account as well.
     pin_mask |= I2S_PSEL_SCK_PORT_Msk;
 #endif
@@ -165,34 +143,80 @@ static void deconfigure_pins(void)
     uint32_t pin_mask = 0xFFFFFFFF;
 #endif // USE_WORKAROUND_FOR_ANOMALY_170
 
-    nrf_gpio_cfg_default(sck_pin & pin_mask);
-    nrf_gpio_cfg_default(lrck_pin & pin_mask);
+    nrfy_gpio_cfg_default(pins.sck_pin & pin_mask);
+    nrfy_gpio_cfg_default(pins.lrck_pin & pin_mask);
 
-    if (mck_pin != NRF_I2S_PIN_NOT_CONNECTED)
+    if (pins.mck_pin != NRF_I2S_PIN_NOT_CONNECTED)
     {
-        nrf_gpio_cfg_default(mck_pin & pin_mask);
+        nrfy_gpio_cfg_default(pins.mck_pin & pin_mask);
     }
 
-    if (sdout_pin != NRF_I2S_PIN_NOT_CONNECTED)
+    if (pins.sdout_pin != NRF_I2S_PIN_NOT_CONNECTED)
     {
-        nrf_gpio_cfg_default(sdout_pin & pin_mask);
+        nrfy_gpio_cfg_default(pins.sdout_pin & pin_mask);
     }
 
-    if (sdin_pin != NRF_I2S_PIN_NOT_CONNECTED)
+    if (pins.sdin_pin != NRF_I2S_PIN_NOT_CONNECTED)
     {
-        nrf_gpio_cfg_default(sdin_pin & pin_mask);
+        nrfy_gpio_cfg_default(pins.sdin_pin & pin_mask);
     }
 }
 
-nrfx_err_t nrfx_i2s_init(nrfx_i2s_config_t const * p_config,
+static inline bool validate_config(nrf_i2s_mode_t   mode,
+                                   nrf_i2s_ratio_t  ratio,
+                                   nrf_i2s_swidth_t swidth)
+{
+    // The MCK/LRCK ratio has to be a multiple of 2 * sample width.
+    if (mode == NRF_I2S_MODE_MASTER)
+    {
+        if (swidth == NRF_I2S_SWIDTH_16BIT)
+        {
+            if (ratio == NRF_I2S_RATIO_48X)
+            {
+                return false;
+            }
+        }
+
+        if (swidth == NRF_I2S_SWIDTH_24BIT)
+        {
+            if ((ratio == NRF_I2S_RATIO_32X)  ||
+                (ratio == NRF_I2S_RATIO_64X)  ||
+                (ratio == NRF_I2S_RATIO_128X) ||
+                (ratio == NRF_I2S_RATIO_256X) ||
+                (ratio == NRF_I2S_RATIO_512X))
+            {
+                return false;
+            }
+        }
+
+#if NRF_I2S_HAS_SWIDTH_32BIT
+        if (swidth == NRF_I2S_SWIDTH_32BIT)
+        {
+            if ((ratio == NRF_I2S_RATIO_32X) ||
+                (ratio == NRF_I2S_RATIO_48X) ||
+                (ratio == NRF_I2S_RATIO_96X))
+            {
+                return false;
+            }
+        }
+#endif
+
+    }
+
+    return true;
+}
+
+nrfx_err_t nrfx_i2s_init(nrfx_i2s_t const *        p_instance,
+                         nrfx_i2s_config_t const * p_config,
                          nrfx_i2s_data_handler_t   handler)
 {
     NRFX_ASSERT(p_config);
     NRFX_ASSERT(handler);
 
     nrfx_err_t err_code;
+    nrfx_i2s_cb_t * p_cb = &m_cb[p_instance->drv_inst_idx];
 
-    if (m_cb.state != NRFX_DRV_STATE_UNINITIALIZED)
+    if (p_cb->state != NRFX_DRV_STATE_UNINITIALIZED)
     {
         err_code = NRFX_ERROR_INVALID_STATE;
         NRFX_LOG_WARNING("Function: %s, error code: %s.",
@@ -201,14 +225,10 @@ nrfx_err_t nrfx_i2s_init(nrfx_i2s_config_t const * p_config,
         return err_code;
     }
 
-    if (!nrf_i2s_configure(NRF_I2S0,
-                           p_config->mode,
-                           p_config->format,
-                           p_config->alignment,
-                           p_config->sample_width,
-                           p_config->channels,
-                           p_config->mck_setup,
-                           p_config->ratio))
+
+    if (!validate_config(p_config->mode,
+                         p_config->ratio,
+                         p_config->sample_width))
     {
         err_code = NRFX_ERROR_INVALID_PARAM;
         NRFX_LOG_WARNING("Function: %s, error code: %s.",
@@ -217,61 +237,90 @@ nrfx_err_t nrfx_i2s_init(nrfx_i2s_config_t const * p_config,
         return err_code;
     }
 
-#if NRF_I2S_HAS_CLKCONFIG
-    nrf_i2s_clk_configure(NRF_I2S0, p_config->clksrc, p_config->enable_bypass);
-#endif
-
     configure_pins(p_config);
 
-    m_cb.skip_gpio_cfg = p_config->skip_gpio_cfg;
-    m_cb.skip_psel_cfg = p_config->skip_psel_cfg;
-    m_cb.handler = handler;
+    nrfy_i2s_config_t nrfy_config =
+    {
+        .config = {
+            .mode         = p_config->mode,
+            .format       = p_config->format,
+            .alignment    = p_config->alignment,
+            .sample_width = p_config->sample_width,
+            .channels     = p_config->channels,
+            .mck_setup    = p_config->mck_setup,
+            .ratio        = p_config->ratio,
+        },
+        .pins = {
+            .sck_pin      = p_config->sck_pin,
+            .lrck_pin     = p_config->lrck_pin,
+            .mck_pin      = p_config->mck_pin,
+            .sdout_pin    = p_config->sdout_pin,
+            .sdin_pin     = p_config->sdin_pin,
+        },
+#if NRF_I2S_HAS_CLKCONFIG
+        .clksrc        = p_config->clksrc,
+        .enable_bypass = p_config->enable_bypass,
+#endif
+        .skip_psel_cfg = p_config->skip_psel_cfg
+    };
 
-    NRFX_IRQ_PRIORITY_SET(nrfx_get_irq_number(NRF_I2S0), p_config->irq_priority);
-    NRFX_IRQ_ENABLE(nrfx_get_irq_number(NRF_I2S0));
+    nrfy_i2s_periph_configure(p_instance->p_reg, &nrfy_config);
 
-    m_cb.state = NRFX_DRV_STATE_INITIALIZED;
+    p_cb->handler = handler;
+    p_cb->skip_gpio_cfg = p_config->skip_gpio_cfg;
+    p_cb->skip_psel_cfg = p_config->skip_psel_cfg;
+
+    nrfy_i2s_int_init(p_instance->p_reg,
+                      NRF_I2S_INT_RXPTRUPD_MASK |
+                      NRF_I2S_INT_TXPTRUPD_MASK |
+                      NRF_I2S_INT_STOPPED_MASK,
+                      p_config->irq_priority,
+                      false);
+
+    p_cb->state = NRFX_DRV_STATE_INITIALIZED;
 
     NRFX_LOG_INFO("Initialized.");
     return NRFX_SUCCESS;
 }
 
-
-void nrfx_i2s_uninit(void)
+void nrfx_i2s_uninit(nrfx_i2s_t const * p_instance)
 {
-    NRFX_ASSERT(m_cb.state != NRFX_DRV_STATE_UNINITIALIZED);
+    nrfx_i2s_cb_t * p_cb = &m_cb[p_instance->drv_inst_idx];
 
-    nrfx_i2s_stop();
+    NRFX_ASSERT(p_cb->state != NRFX_DRV_STATE_UNINITIALIZED);
 
-    NRFX_IRQ_DISABLE(nrfx_get_irq_number(NRF_I2S0));
+    nrfx_i2s_stop(p_instance);
 
-    nrf_i2s_disable(NRF_I2S0);
+    nrfy_i2s_int_uninit(p_instance->p_reg);
+    nrfy_i2s_disable(p_instance->p_reg);
 
-    if (!m_cb.skip_gpio_cfg)
+    if (!p_cb->skip_gpio_cfg)
     {
-        deconfigure_pins();
+        deconfigure_pins(p_instance);
     }
 
 #if USE_WORKAROUND_FOR_ANOMALY_196
-    if (!m_cb.skip_psel_cfg)
+    if (!p_cb->skip_psel_cfg)
     {
-        // Disabling I2S is insufficient to release pins acquired
-        // by the peripheral. Explicit disconnect is needed.
-        nrf_i2s_pins_set(NRF_I2S0,
-                         NRF_I2S_PIN_NOT_CONNECTED,
-                         NRF_I2S_PIN_NOT_CONNECTED,
-                         NRF_I2S_PIN_NOT_CONNECTED,
-                         NRF_I2S_PIN_NOT_CONNECTED,
-                         NRF_I2S_PIN_NOT_CONNECTED);
+        // Disabling I2S is insufficient to release pins acquired by the peripheral.
+        // Explicit disconnect is needed.
+        nrf_i2s_pins_t pins = {
+            .sck_pin   = NRF_I2S_PIN_NOT_CONNECTED,
+            .lrck_pin  = NRF_I2S_PIN_NOT_CONNECTED,
+            .mck_pin   = NRF_I2S_PIN_NOT_CONNECTED,
+            .sdout_pin = NRF_I2S_PIN_NOT_CONNECTED,
+            .sdin_pin  = NRF_I2S_PIN_NOT_CONNECTED,
+        };
+        nrfy_i2s_pins_set(p_instance->p_reg, &pins);
     }
 #endif
 
-    m_cb.state = NRFX_DRV_STATE_UNINITIALIZED;
+    p_cb->state = NRFX_DRV_STATE_UNINITIALIZED;
     NRFX_LOG_INFO("Uninitialized.");
 }
 
-
-nrfx_err_t nrfx_i2s_start(nrfx_i2s_buffers_t const * p_initial_buffers,
+nrfx_err_t nrfx_i2s_start(nrfx_i2s_t const *         p_instance,
+                          nrfx_i2s_buffers_t const * p_initial_buffers,
                           uint16_t                   buffer_size,
                           uint8_t                    flags)
 {
@@ -288,8 +337,9 @@ nrfx_err_t nrfx_i2s_start(nrfx_i2s_buffers_t const * p_initial_buffers,
     (void)(flags);
 
     nrfx_err_t err_code;
+    nrfx_i2s_cb_t * p_cb = &m_cb[p_instance->drv_inst_idx];
 
-    if (m_cb.state != NRFX_DRV_STATE_INITIALIZED)
+    if (p_cb->state != NRFX_DRV_STATE_INITIALIZED)
     {
         err_code = NRFX_ERROR_INVALID_STATE;
         NRFX_LOG_WARNING("Function: %s, error code: %s.",
@@ -311,45 +361,49 @@ nrfx_err_t nrfx_i2s_start(nrfx_i2s_buffers_t const * p_initial_buffers,
         return err_code;
     }
 
-    m_cb.use_rx         = (p_initial_buffers->p_rx_buffer != NULL);
-    m_cb.use_tx         = (p_initial_buffers->p_tx_buffer != NULL);
-    m_cb.rx_ready       = false;
-    m_cb.tx_ready       = false;
-    m_cb.buffers_needed = false;
-    m_cb.buffer_size    = buffer_size;
+    p_cb->use_rx         = (p_initial_buffers->p_rx_buffer != NULL);
+    p_cb->use_tx         = (p_initial_buffers->p_tx_buffer != NULL);
+    p_cb->rx_ready       = false;
+    p_cb->tx_ready       = false;
+    p_cb->buffers_needed = false;
+    p_cb->buffer_size    = buffer_size;
 
     // Set the provided initial buffers as next, they will become the current
     // ones after the IRQ handler is called for the first time, what will occur
     // right after the START task is triggered.
-    m_cb.next_buffers = *p_initial_buffers;
-    m_cb.current_buffers.p_rx_buffer = NULL;
-    m_cb.current_buffers.p_tx_buffer = NULL;
+    p_cb->next_buffers = *p_initial_buffers;
+    p_cb->current_buffers.p_rx_buffer = NULL;
+    p_cb->current_buffers.p_tx_buffer = NULL;
 
-    nrf_i2s_transfer_set(NRF_I2S0,
-                         m_cb.buffer_size,
-                         m_cb.next_buffers.p_rx_buffer,
-                         m_cb.next_buffers.p_tx_buffer);
 
-    nrf_i2s_enable(NRF_I2S0);
+    nrfy_i2s_enable(p_instance->p_reg);
 
-    m_cb.state = NRFX_DRV_STATE_POWERED_ON;
+    p_cb->state = NRFX_DRV_STATE_POWERED_ON;
 
-    nrf_i2s_event_clear(NRF_I2S0, NRF_I2S_EVENT_RXPTRUPD);
-    nrf_i2s_event_clear(NRF_I2S0, NRF_I2S_EVENT_TXPTRUPD);
-    nrf_i2s_event_clear(NRF_I2S0, NRF_I2S_EVENT_STOPPED);
-    nrf_i2s_int_enable(NRF_I2S0, (m_cb.use_rx ? NRF_I2S_INT_RXPTRUPD_MASK : 0) |
-                                 (m_cb.use_tx ? NRF_I2S_INT_TXPTRUPD_MASK : 0) |
-                                 NRF_I2S_INT_STOPPED_MASK);
-    nrf_i2s_task_trigger(NRF_I2S0, NRF_I2S_TASK_START);
+    nrfy_i2s_int_enable(p_instance->p_reg,
+                        (p_cb->use_rx ? NRF_I2S_INT_RXPTRUPD_MASK : 0) |
+                        (p_cb->use_tx ? NRF_I2S_INT_TXPTRUPD_MASK : 0) |
+                        NRF_I2S_INT_STOPPED_MASK);
+
+    const nrfy_i2s_xfer_desc_t xfer = {
+        .p_buffers   = &p_cb->next_buffers,
+        .buffer_size = p_cb->buffer_size,
+    };
+
+    nrfy_i2s_buffers_set(p_instance->p_reg, &xfer);
+    nrfy_i2s_xfer_start(p_instance->p_reg, NULL);
 
     NRFX_LOG_INFO("Started.");
     return NRFX_SUCCESS;
 }
 
-
-nrfx_err_t nrfx_i2s_next_buffers_set(nrfx_i2s_buffers_t const * p_buffers)
+nrfx_err_t nrfx_i2s_next_buffers_set(nrfx_i2s_t const *         p_instance,
+                                     nrfx_i2s_buffers_t const * p_buffers)
 {
-    NRFX_ASSERT(m_cb.state == NRFX_DRV_STATE_POWERED_ON);
+    nrfx_err_t err_code;
+    nrfx_i2s_cb_t * p_cb = &m_cb[p_instance->drv_inst_idx];
+
+    NRFX_ASSERT(p_cb->state == NRFX_DRV_STATE_POWERED_ON);
     NRFX_ASSERT(p_buffers);
     NRFX_ASSERT((p_buffers->p_rx_buffer == NULL) ||
                 (nrfx_is_in_ram(p_buffers->p_rx_buffer) &&
@@ -358,9 +412,7 @@ nrfx_err_t nrfx_i2s_next_buffers_set(nrfx_i2s_buffers_t const * p_buffers)
                 (nrfx_is_in_ram(p_buffers->p_tx_buffer) &&
                  nrfx_is_word_aligned(p_buffers->p_tx_buffer)));
 
-    nrfx_err_t err_code;
-
-    if (!m_cb.buffers_needed)
+    if (!p_cb->buffers_needed)
     {
         err_code = NRFX_ERROR_INVALID_STATE;
         NRFX_LOG_WARNING("Function: %s, error code: %s.",
@@ -382,113 +434,128 @@ nrfx_err_t nrfx_i2s_next_buffers_set(nrfx_i2s_buffers_t const * p_buffers)
         return err_code;
     }
 
-    if (m_cb.use_tx)
+    if (p_cb->use_tx)
     {
         NRFX_ASSERT(p_buffers->p_tx_buffer != NULL);
-        nrf_i2s_tx_buffer_set(NRF_I2S0, p_buffers->p_tx_buffer);
     }
-    if (m_cb.use_rx)
+    if (p_cb->use_rx)
     {
         NRFX_ASSERT(p_buffers->p_rx_buffer != NULL);
-        nrf_i2s_rx_buffer_set(NRF_I2S0, p_buffers->p_rx_buffer);
     }
 
-    m_cb.next_buffers   = *p_buffers;
-    m_cb.buffers_needed = false;
+    nrfy_i2s_xfer_desc_t xfer = {
+        .p_buffers   = p_buffers,
+        .buffer_size = p_cb->buffer_size,
+    };
+
+    nrfy_i2s_buffers_set(p_instance->p_reg, &xfer);
+
+    p_cb->next_buffers   = *p_buffers;
+    p_cb->buffers_needed = false;
 
     return NRFX_SUCCESS;
 }
 
-
-void nrfx_i2s_stop(void)
+void nrfx_i2s_stop(nrfx_i2s_t const * p_instance)
 {
-    NRFX_ASSERT(m_cb.state != NRFX_DRV_STATE_UNINITIALIZED);
+    nrfx_i2s_cb_t * p_cb = &m_cb[p_instance->drv_inst_idx];
 
-    m_cb.buffers_needed = false;
+    NRFX_ASSERT(p_cb->state != NRFX_DRV_STATE_UNINITIALIZED);
+
+    p_cb->buffers_needed = false;
 
     // First disable interrupts, then trigger the STOP task, so no spurious
     // RXPTRUPD and TXPTRUPD events (see nRF52 anomaly 55) are processed.
-    nrf_i2s_int_disable(NRF_I2S0, NRF_I2S_INT_RXPTRUPD_MASK |
-                                  NRF_I2S_INT_TXPTRUPD_MASK);
-    nrf_i2s_task_trigger(NRF_I2S0, NRF_I2S_TASK_STOP);
+    nrfy_i2s_int_disable(p_instance->p_reg, NRF_I2S_INT_RXPTRUPD_MASK |
+                                            NRF_I2S_INT_TXPTRUPD_MASK);
+
+    nrfy_i2s_abort(p_instance->p_reg, NULL);
 
 #if NRFX_CHECK(USE_WORKAROUND_FOR_I2S_STOP_ANOMALY)
-    *((volatile uint32_t *)(((uint32_t)NRF_I2S0) + 0x38)) = 1;
-    *((volatile uint32_t *)(((uint32_t)NRF_I2S0) + 0x3C)) = 1;
+    *((volatile uint32_t *)(((uint32_t)p_instance->p_reg) + 0x38)) = 1;
+    *((volatile uint32_t *)(((uint32_t)p_instance->p_reg) + 0x3C)) = 1;
 #endif
 }
 
-
-void nrfx_i2s_irq_handler(void)
+static void irq_handler(NRF_I2S_Type * p_reg, nrfx_i2s_cb_t * p_cb)
 {
-    if (nrf_i2s_event_check(NRF_I2S0, NRF_I2S_EVENT_TXPTRUPD))
+    uint32_t event_mask;
+    nrfy_i2s_xfer_desc_t xfer = {
+        .p_buffers   = &p_cb->current_buffers,
+        .buffer_size = p_cb->buffer_size,
+    };
+
+    event_mask = nrfy_i2s_events_process(p_reg,
+                                         NRFY_EVENT_TO_INT_BITMASK(NRF_I2S_EVENT_TXPTRUPD) |
+                                         NRFY_EVENT_TO_INT_BITMASK(NRF_I2S_EVENT_RXPTRUPD) |
+                                         NRFY_EVENT_TO_INT_BITMASK(NRF_I2S_EVENT_STOPPED),
+                                         &xfer);
+
+    if (event_mask & NRFY_EVENT_TO_INT_BITMASK(NRF_I2S_EVENT_TXPTRUPD))
     {
-        nrf_i2s_event_clear(NRF_I2S0, NRF_I2S_EVENT_TXPTRUPD);
-        m_cb.tx_ready = true;
-        if (m_cb.use_tx && m_cb.buffers_needed)
+        p_cb->tx_ready = true;
+        if (p_cb->use_tx && p_cb->buffers_needed)
         {
-            m_cb.buffers_reused = true;
+            p_cb->buffers_reused = true;
         }
     }
-    if (nrf_i2s_event_check(NRF_I2S0, NRF_I2S_EVENT_RXPTRUPD))
+    if (event_mask & NRFY_EVENT_TO_INT_BITMASK(NRF_I2S_EVENT_RXPTRUPD))
     {
-        nrf_i2s_event_clear(NRF_I2S0, NRF_I2S_EVENT_RXPTRUPD);
-        m_cb.rx_ready = true;
-        if (m_cb.use_rx && m_cb.buffers_needed)
+        p_cb->rx_ready = true;
+        if (p_cb->use_rx && p_cb->buffers_needed)
         {
-            m_cb.buffers_reused = true;
+            p_cb->buffers_reused = true;
         }
     }
 
-    if (nrf_i2s_event_check(NRF_I2S0, NRF_I2S_EVENT_STOPPED))
+    if (event_mask & NRFY_EVENT_TO_INT_BITMASK(NRF_I2S_EVENT_STOPPED))
     {
-        nrf_i2s_event_clear(NRF_I2S0, NRF_I2S_EVENT_STOPPED);
-        nrf_i2s_int_disable(NRF_I2S0, NRF_I2S_INT_STOPPED_MASK);
-        nrf_i2s_disable(NRF_I2S0);
+        nrfy_i2s_int_disable(p_reg, NRF_I2S_INT_STOPPED_MASK);
+        nrfy_i2s_disable(p_reg);
 
         // When stopped, release all buffers, including these scheduled for
         // the next part of the transfer, and signal that the transfer has
         // finished.
 
-        m_cb.handler(&m_cb.current_buffers, 0);
+        p_cb->handler(&p_cb->current_buffers, 0);
 
         // Change the state of the driver before calling the handler with
         // the flag signaling that the transfer has finished, so that it is
         // possible to start a new transfer directly from the handler function.
-        m_cb.state = NRFX_DRV_STATE_INITIALIZED;
+        p_cb->state = NRFX_DRV_STATE_INITIALIZED;
         NRFX_LOG_INFO("Stopped.");
 
-        m_cb.handler(&m_cb.next_buffers, NRFX_I2S_STATUS_TRANSFER_STOPPED);
+        p_cb->handler(&p_cb->next_buffers, NRFX_I2S_STATUS_TRANSFER_STOPPED);
     }
     else
     {
         // Check if the requested transfer has been completed:
         // - full-duplex mode
-        if ((m_cb.use_tx && m_cb.use_rx && m_cb.tx_ready && m_cb.rx_ready) ||
+        if ((p_cb->use_tx && p_cb->use_rx &&
+             p_cb->tx_ready && p_cb->rx_ready) ||
             // - TX only mode
-            (!m_cb.use_rx && m_cb.tx_ready) ||
+            (!p_cb->use_rx && p_cb->tx_ready) ||
             // - RX only mode
-            (!m_cb.use_tx && m_cb.rx_ready))
+            (!p_cb->use_tx && p_cb->rx_ready))
         {
-            m_cb.tx_ready = false;
-            m_cb.rx_ready = false;
+            p_cb->tx_ready = false;
+            p_cb->rx_ready = false;
 
             // If the application did not supply the buffers for the next
             // part of the transfer until this moment, the current buffers
             // cannot be released, since the I2S peripheral already started
             // using them. Signal this situation to the application by
             // passing NULL instead of the structure with released buffers.
-            if (m_cb.buffers_reused)
+            if (p_cb->buffers_reused)
             {
-                m_cb.buffers_reused = false;
+                p_cb->buffers_reused = false;
                 // This will most likely be set at this point. However, there is
                 // a small time window between TXPTRUPD and RXPTRUPD events,
                 // and it is theoretically possible that next buffers will be
                 // set in this window, so to be sure this flag is set to true,
                 // set it explicitly.
-                m_cb.buffers_needed = true;
-                m_cb.handler(NULL,
-                             NRFX_I2S_STATUS_NEXT_BUFFERS_NEEDED);
+                p_cb->buffers_needed = true;
+                p_cb->handler(NULL, NRFX_I2S_STATUS_NEXT_BUFFERS_NEEDED);
             }
             else
             {
@@ -496,17 +563,18 @@ void nrfx_i2s_irq_handler(void)
                 // are now released and will be returned to the application,
                 // and the ones scheduled to be used as next become the current
                 // ones.
-                nrfx_i2s_buffers_t released_buffers = m_cb.current_buffers;
-                m_cb.current_buffers = m_cb.next_buffers;
-                m_cb.next_buffers.p_rx_buffer = NULL;
-                m_cb.next_buffers.p_tx_buffer = NULL;
-                m_cb.buffers_needed = true;
-                m_cb.handler(&released_buffers,
-                             NRFX_I2S_STATUS_NEXT_BUFFERS_NEEDED);
+                nrfx_i2s_buffers_t released_buffers = p_cb->current_buffers;
+                p_cb->current_buffers = p_cb->next_buffers;
+                p_cb->next_buffers.p_rx_buffer = NULL;
+                p_cb->next_buffers.p_tx_buffer = NULL;
+                p_cb->buffers_needed = true;
+                p_cb->handler(&released_buffers, NRFX_I2S_STATUS_NEXT_BUFFERS_NEEDED);
             }
 
         }
     }
 }
+
+NRFX_INSTANCE_IRQ_HANDLERS(I2S, i2s)
 
 #endif // NRFX_CHECK(NRFX_I2S_ENABLED)

--- a/nrfx/drivers/src/nrfx_nfct.c
+++ b/nrfx/drivers/src/nrfx_nfct.c
@@ -40,6 +40,8 @@
 #define NRFX_LOG_MODULE NFCT
 #include <nrfx_log.h>
 
+#define FIELD_TIMER_FREQUENCY_HZ NRFX_MHZ_TO_HZ(1)
+
 #if !defined(USE_WORKAROUND_FOR_ANOMALY_79) &&          \
     (defined(NRF52832_XXAA) || defined(NRF52832_XXAB))
 #define USE_WORKAROUND_FOR_ANOMALY_79 1
@@ -369,14 +371,9 @@ static void nrfx_nfct_field_timer_handler(nrf_timer_event_t event_type, void * p
 
 static inline nrfx_err_t nrfx_nfct_field_timer_config(void)
 {
-    nrfx_err_t          err_code;
-    nrfx_timer_config_t timer_cfg =
-    {
-        .frequency          = NRF_TIMER_FREQ_1MHz,
-        .mode               = NRF_TIMER_MODE_TIMER,
-        .bit_width          = NRF_TIMER_BIT_WIDTH_16,
-        .interrupt_priority = NRFX_NFCT_DEFAULT_CONFIG_IRQ_PRIORITY
-    };
+    nrfx_err_t err_code;
+    nrfx_timer_config_t timer_cfg = NRFX_TIMER_DEFAULT_CONFIG(FIELD_TIMER_FREQUENCY_HZ);
+    timer_cfg.interrupt_priority = NRFX_NFCT_DEFAULT_CONFIG_IRQ_PRIORITY;
 
     err_code = nrfx_timer_init(&m_timer_workaround.timer,
                                &timer_cfg,

--- a/nrfx/drivers/src/nrfx_qdec.c
+++ b/nrfx/drivers/src/nrfx_qdec.c
@@ -36,7 +36,12 @@
 #if NRFX_CHECK(NRFX_QDEC_ENABLED)
 
 #include <nrfx_qdec.h>
-#include <hal/nrf_gpio.h>
+
+#if !NRFX_FEATURE_PRESENT(NRFX_QDEC, _ENABLED)
+#error "No enabled QDEC instances. Check <nrfx_config.h>."
+#endif
+
+#include <haly/nrfy_gpio.h>
 
 #define NRFX_LOG_MODULE QDEC
 #include <nrfx_log.h>
@@ -47,58 +52,75 @@
     (event == NRF_QDEC_EVENT_ACCOF     ? "NRF_QDEC_EVENT_ACCOF"     : \
                                          "UNKNOWN EVENT")))
 
-
-static nrfx_qdec_event_handler_t m_qdec_event_handler = NULL;
-static nrfx_drv_state_t m_state = NRFX_DRV_STATE_UNINITIALIZED;
-static bool m_skip_gpio_cfg;
-
-void nrfx_qdec_irq_handler(void)
+// Control block - driver instance local data.
+typedef struct
 {
-    nrfx_qdec_event_t event;
-    if ( nrf_qdec_event_check(NRF_QDEC, NRF_QDEC_EVENT_SAMPLERDY) &&
-         nrf_qdec_int_enable_check(NRF_QDEC, NRF_QDEC_INT_SAMPLERDY_MASK) )
-    {
-        nrf_qdec_event_clear(NRF_QDEC, NRF_QDEC_EVENT_SAMPLERDY);
-        NRFX_LOG_DEBUG("Event: %s.", EVT_TO_STR(NRF_QDEC_EVENT_SAMPLERDY));
+    nrfx_drv_state_t          state;
+    bool                      skip_gpio_cfg;
+    nrfx_qdec_event_handler_t handler;
+    void *                    p_context;
+} qdec_control_block_t;
 
-        event.type = NRF_QDEC_EVENT_SAMPLERDY;
-        event.data.sample.value = (int8_t)nrf_qdec_sample_get(NRF_QDEC);
-        m_qdec_event_handler(event);
+static qdec_control_block_t m_cb[NRFX_QDEC_ENABLED_COUNT];
+
+static void qdec_configure(nrfx_qdec_t const *        p_instance,
+                           nrfx_qdec_config_t const * p_config)
+{
+    if (!p_config->skip_gpio_cfg)
+    {
+        nrfy_gpio_cfg_input(p_config->psela, NRF_GPIO_PIN_NOPULL);
+        nrfy_gpio_cfg_input(p_config->pselb, NRF_GPIO_PIN_NOPULL);
+        if (p_config->pselled != NRF_QDEC_PIN_NOT_CONNECTED)
+        {
+            nrfy_gpio_cfg_input(p_config->pselled, NRF_GPIO_PIN_NOPULL);
+        }
     }
 
-    if ( nrf_qdec_event_check(NRF_QDEC, NRF_QDEC_EVENT_REPORTRDY) &&
-         nrf_qdec_int_enable_check(NRF_QDEC, NRF_QDEC_INT_REPORTRDY_MASK) )
+    nrfy_qdec_config_t nrfy_config =
     {
-        nrf_qdec_event_clear(NRF_QDEC, NRF_QDEC_EVENT_REPORTRDY);
-        NRFX_LOG_DEBUG("Event: %s.", EVT_TO_STR(NRF_QDEC_EVENT_REPORTRDY));
+        .reportper = p_config->reportper,
+        .sampleper = p_config->sampleper,
+        .pins = {
+            .a_pin   = p_config->psela,
+            .b_pin   = p_config->pselb,
+            .led_pin = p_config->pselled
+        },
+        .ledpre    = p_config->ledpre,
+        .ledpol    = p_config->ledpol,
+        .dbfen     = p_config->dbfen,
+        .skip_psel_cfg = p_config->skip_psel_cfg
+    };
 
-        event.type = NRF_QDEC_EVENT_REPORTRDY;
+    nrfy_qdec_periph_configure(p_instance->p_reg, &nrfy_config);
+    nrfy_qdec_shorts_enable(p_instance->p_reg, NRF_QDEC_SHORT_REPORTRDY_READCLRACC_MASK);
 
-        event.data.report.acc    = (int16_t)nrf_qdec_accread_get(NRF_QDEC);
-        event.data.report.accdbl = (uint16_t)nrf_qdec_accdblread_get(NRF_QDEC);
-        m_qdec_event_handler(event);
-    }
+    uint32_t int_mask = NRF_QDEC_INT_ACCOF_MASK;
 
-    if ( nrf_qdec_event_check(NRF_QDEC, NRF_QDEC_EVENT_ACCOF) &&
-         nrf_qdec_int_enable_check(NRF_QDEC, NRF_QDEC_INT_ACCOF_MASK) )
+    if (p_config->reportper_inten)
     {
-        nrf_qdec_event_clear(NRF_QDEC, NRF_QDEC_EVENT_ACCOF);
-        NRFX_LOG_DEBUG("Event: %s.", EVT_TO_STR(NRF_QDEC_EVENT_ACCOF));
-
-        event.type = NRF_QDEC_EVENT_ACCOF;
-        m_qdec_event_handler(event);
+        int_mask |= NRF_QDEC_INT_REPORTRDY_MASK;
     }
+    if (p_config->sample_inten)
+    {
+        int_mask |= NRF_QDEC_INT_SAMPLERDY_MASK;
+    }
+    nrfy_qdec_int_init(p_instance->p_reg, int_mask, p_config->interrupt_priority, true);
 }
 
-
-nrfx_err_t nrfx_qdec_init(nrfx_qdec_config_t const * p_config,
-                          nrfx_qdec_event_handler_t  event_handler)
+nrfx_err_t nrfx_qdec_init(nrfx_qdec_t const *        p_instance,
+                          nrfx_qdec_config_t const * p_config,
+                          nrfx_qdec_event_handler_t  handler,
+                          void *                     p_context)
 {
+    NRFX_ASSERT(p_instance);
     NRFX_ASSERT(p_config);
-    NRFX_ASSERT(event_handler);
+    NRFX_ASSERT(handler);
+
+    qdec_control_block_t * const p_cb = &m_cb[p_instance->drv_inst_idx];
+
     nrfx_err_t err_code;
 
-    if (m_state != NRFX_DRV_STATE_UNINITIALIZED)
+    if (p_cb->state != NRFX_DRV_STATE_UNINITIALIZED)
     {
         err_code = NRFX_ERROR_INVALID_STATE;
         NRFX_LOG_WARNING("Function: %s, error code: %s.",
@@ -107,120 +129,154 @@ nrfx_err_t nrfx_qdec_init(nrfx_qdec_config_t const * p_config,
         return err_code;
     }
 
-    m_qdec_event_handler = event_handler;
-    m_skip_gpio_cfg = p_config->skip_gpio_cfg;
+    p_cb->handler = handler;
+    p_cb->p_context = p_context;
 
-    if (!p_config->skip_gpio_cfg)
+    if (p_config)
     {
-        nrf_gpio_cfg_input(p_config->psela, NRF_GPIO_PIN_NOPULL);
-        nrf_gpio_cfg_input(p_config->pselb, NRF_GPIO_PIN_NOPULL);
-        if (p_config->pselled != NRF_QDEC_LED_NOT_CONNECTED)
-        {
-            nrf_gpio_cfg_input(p_config->pselled, NRF_GPIO_PIN_NOPULL);
-        }
-    }
-    if (!p_config->skip_psel_cfg)
-    {
-        nrf_qdec_pins_set(NRF_QDEC, p_config->psela, p_config->pselb, p_config->pselled);
+        p_cb->skip_gpio_cfg = p_config->skip_gpio_cfg;
+        qdec_configure(p_instance, p_config);
     }
 
-    nrf_qdec_sampleper_set(NRF_QDEC, p_config->sampleper);
-    // Change the period and polarity of the LED only when it is used,
-    // otherwise the ledpre field might have an invalid value.
-    if (nrf_qdec_led_pin_get(NRF_QDEC) != NRF_QDEC_LED_NOT_CONNECTED)
-    {
-        nrf_qdec_ledpre_set(NRF_QDEC, p_config->ledpre);
-        nrf_qdec_ledpol_set(NRF_QDEC, p_config->ledpol);
-    }
-
-    if (p_config->dbfen)
-    {
-        nrf_qdec_dbfen_enable(NRF_QDEC);
-    }
-    else
-    {
-        nrf_qdec_dbfen_disable(NRF_QDEC);
-    }
-
-    uint32_t int_mask = NRF_QDEC_INT_ACCOF_MASK;
-
-    if (p_config->reportper != NRF_QDEC_REPORTPER_DISABLED)
-    {
-        nrf_qdec_shorts_enable(NRF_QDEC, NRF_QDEC_SHORT_REPORTRDY_READCLRACC_MASK);
-        nrf_qdec_reportper_set(NRF_QDEC, p_config->reportper);
-        int_mask |= NRF_QDEC_INT_REPORTRDY_MASK;
-    }
-
-    if (p_config->sample_inten)
-    {
-        int_mask |= NRF_QDEC_INT_SAMPLERDY_MASK;
-    }
-
-    nrf_qdec_int_enable(NRF_QDEC, int_mask);
-    NRFX_IRQ_PRIORITY_SET(nrfx_get_irq_number(NRF_QDEC), p_config->interrupt_priority);
-    NRFX_IRQ_ENABLE(nrfx_get_irq_number(NRF_QDEC));
-
-    m_state = NRFX_DRV_STATE_INITIALIZED;
+    p_cb->state = NRFX_DRV_STATE_INITIALIZED;
 
     err_code = NRFX_SUCCESS;
     NRFX_LOG_INFO("Function: %s, error code: %s.", __func__, NRFX_LOG_ERROR_STRING_GET(err_code));
     return err_code;
 }
 
-void nrfx_qdec_uninit(void)
+nrfx_err_t nrfx_qdec_reconfigure(nrfx_qdec_t const *        p_instance,
+                                 nrfx_qdec_config_t const * p_config)
 {
-    NRFX_ASSERT(m_state != NRFX_DRV_STATE_UNINITIALIZED);
-    nrfx_qdec_disable();
-    NRFX_IRQ_DISABLE(nrfx_get_irq_number(NRF_QDEC));
+    NRFX_ASSERT(p_config);
+    qdec_control_block_t * p_cb = &m_cb[p_instance->drv_inst_idx];
 
-    nrf_qdec_shorts_disable(NRF_QDEC, NRF_QDEC_SHORT_REPORTRDY_READCLRACC_MASK);
-
-    if (!m_skip_gpio_cfg)
+    if (p_cb->state == NRFX_DRV_STATE_UNINITIALIZED)
     {
-        nrf_gpio_cfg_default(nrf_qdec_phase_a_pin_get(NRF_QDEC));
-        nrf_gpio_cfg_default(nrf_qdec_phase_b_pin_get(NRF_QDEC));
+        return NRFX_ERROR_INVALID_STATE;
+    }
+    if (p_cb->state == NRFX_DRV_STATE_POWERED_ON)
+    {
+        return NRFX_ERROR_BUSY;
+    }
+    qdec_configure(p_instance, p_config);
+    nrfy_qdec_enable(p_instance->p_reg);
+    return NRFX_SUCCESS;
+}
 
-        uint32_t led_pin = nrf_qdec_led_pin_get(NRF_QDEC);
-        if (led_pin != NRF_QDEC_LED_NOT_CONNECTED)
+void nrfx_qdec_uninit(nrfx_qdec_t const * p_instance)
+{
+    NRFX_ASSERT(p_instance);
+    qdec_control_block_t * const p_cb = &m_cb[p_instance->drv_inst_idx];
+    nrfy_qdec_pins_t pins;
+
+    NRFX_ASSERT(p_cb->state != NRFX_DRV_STATE_UNINITIALIZED);
+
+    nrfy_qdec_disable(p_instance->p_reg);
+    nrfy_qdec_int_uninit(p_instance->p_reg);
+
+    nrfy_qdec_shorts_disable(p_instance->p_reg, NRF_QDEC_SHORT_REPORTRDY_READCLRACC_MASK);
+    if (!p_cb->skip_gpio_cfg)
+    {
+        nrfy_qdec_pins_get(p_instance->p_reg, &pins);
+        nrfy_gpio_cfg_default(pins.a_pin);
+        nrfy_gpio_cfg_default(pins.b_pin);
+
+        uint32_t led_pin = nrfy_qdec_led_pin_get(p_instance->p_reg);
+        if (led_pin != NRF_QDEC_PIN_NOT_CONNECTED)
         {
-            nrf_gpio_cfg_default(led_pin);
+            nrfy_gpio_cfg_default(led_pin);
         }
     }
 
-    m_state = NRFX_DRV_STATE_UNINITIALIZED;
+    p_cb->state = NRFX_DRV_STATE_UNINITIALIZED;
     NRFX_LOG_INFO("Uninitialized.");
 }
 
-void nrfx_qdec_enable(void)
+void nrfx_qdec_enable(nrfx_qdec_t const * p_instance)
 {
-    NRFX_ASSERT(m_state == NRFX_DRV_STATE_INITIALIZED);
-    nrf_qdec_enable(NRF_QDEC);
-    nrf_qdec_task_trigger(NRF_QDEC, NRF_QDEC_TASK_START);
-    m_state = NRFX_DRV_STATE_POWERED_ON;
+    NRFX_ASSERT(p_instance);
+
+    qdec_control_block_t * const p_cb = &m_cb[p_instance->drv_inst_idx];
+
+    NRFX_ASSERT(p_cb->state == NRFX_DRV_STATE_INITIALIZED);
+
+    nrfy_qdec_enable(p_instance->p_reg);
+    nrfy_qdec_task_trigger(p_instance->p_reg, NRF_QDEC_TASK_START);
+    p_cb->state = NRFX_DRV_STATE_POWERED_ON;
     NRFX_LOG_INFO("Enabled.");
 }
 
-void nrfx_qdec_disable(void)
+void nrfx_qdec_disable(nrfx_qdec_t const * p_instance)
 {
-    NRFX_ASSERT(m_state == NRFX_DRV_STATE_POWERED_ON);
-    nrf_qdec_task_trigger(NRF_QDEC, NRF_QDEC_TASK_STOP);
-    nrf_qdec_disable(NRF_QDEC);
-    m_state = NRFX_DRV_STATE_INITIALIZED;
+    NRFX_ASSERT(p_instance);
+
+    qdec_control_block_t * const p_cb = &m_cb[p_instance->drv_inst_idx];
+
+    NRFX_ASSERT(p_cb->state == NRFX_DRV_STATE_POWERED_ON);
+    nrfy_qdec_task_trigger(p_instance->p_reg, NRF_QDEC_TASK_STOP);
+    nrfy_qdec_disable(p_instance->p_reg);
+    p_cb->state = NRFX_DRV_STATE_INITIALIZED;
     NRFX_LOG_INFO("Disabled.");
 }
 
-void nrfx_qdec_accumulators_read(int16_t * p_acc, int16_t * p_accdbl)
+void nrfx_qdec_accumulators_read(nrfx_qdec_t const * p_instance,
+                                 int32_t *           p_acc,
+                                 uint32_t *          p_accdbl)
 {
-    NRFX_ASSERT(m_state == NRFX_DRV_STATE_POWERED_ON);
-    nrf_qdec_task_trigger(NRF_QDEC, NRF_QDEC_TASK_READCLRACC);
+    NRFX_ASSERT(p_instance);
+    NRFX_ASSERT(p_accdbl);
+    NRFX_ASSERT(p_acc);
+    NRFX_ASSERT(m_cb[p_instance->drv_inst_idx].state == NRFX_DRV_STATE_POWERED_ON);
 
-    *p_acc    = (int16_t)nrf_qdec_accread_get(NRF_QDEC);
-    *p_accdbl = (int16_t)nrf_qdec_accdblread_get(NRF_QDEC);
+    nrfy_qdec_task_trigger(p_instance->p_reg, NRF_QDEC_TASK_READCLRACC);
+    nrfy_qdec_accumulators_read(p_instance->p_reg, p_acc, p_accdbl);
 
     NRFX_LOG_DEBUG("Accumulators data, ACC register:");
     NRFX_LOG_HEXDUMP_DEBUG((uint8_t *)p_acc, sizeof(p_acc[0]));
     NRFX_LOG_DEBUG("Accumulators data, ACCDBL register:");
     NRFX_LOG_HEXDUMP_DEBUG((uint8_t *)p_accdbl, sizeof(p_accdbl[0]));
 }
+
+static void irq_handler(NRF_QDEC_Type * p_qdec, qdec_control_block_t * p_cb)
+{
+    uint32_t evt_to_process;
+    nrfx_qdec_event_t event;
+    uint32_t evt_mask;
+
+    evt_to_process = NRFY_EVENT_TO_INT_BITMASK(NRF_QDEC_EVENT_SAMPLERDY) |
+                     NRFY_EVENT_TO_INT_BITMASK(NRF_QDEC_EVENT_REPORTRDY) |
+                     NRFY_EVENT_TO_INT_BITMASK(NRF_QDEC_EVENT_ACCOF);
+
+    evt_mask = nrfy_qdec_events_process(p_qdec, evt_to_process);
+
+    if (evt_mask & NRFY_EVENT_TO_INT_BITMASK(NRF_QDEC_EVENT_SAMPLERDY))
+    {
+        NRFX_LOG_DEBUG("Event: %s.", EVT_TO_STR(NRF_QDEC_EVENT_SAMPLERDY));
+
+        event.type = NRF_QDEC_EVENT_SAMPLERDY;
+        event.data.sample.value = (int8_t)nrfy_qdec_sample_get(p_qdec);
+        p_cb->handler(event, p_cb->p_context);
+    }
+
+    if (evt_mask & NRFY_EVENT_TO_INT_BITMASK(NRF_QDEC_EVENT_REPORTRDY))
+    {
+        NRFX_LOG_DEBUG("Event: %s.", EVT_TO_STR(NRF_QDEC_EVENT_REPORTRDY));
+
+        event.type = NRF_QDEC_EVENT_REPORTRDY;
+        nrfy_qdec_accumulators_read(p_qdec, &event.data.report.acc, &event.data.report.accdbl);
+        p_cb->handler(event, p_cb->p_context);
+    }
+
+    if (evt_mask & NRFY_EVENT_TO_INT_BITMASK(NRF_QDEC_EVENT_ACCOF))
+    {
+        NRFX_LOG_DEBUG("Event: %s.", EVT_TO_STR(NRF_QDEC_EVENT_ACCOF));
+
+        event.type = NRF_QDEC_EVENT_ACCOF;
+        p_cb->handler(event, p_cb->p_context);
+    }
+}
+
+NRFX_INSTANCE_IRQ_HANDLERS(QDEC, qdec)
 
 #endif // NRFX_CHECK(NRFX_QDEC_ENABLED)

--- a/nrfx/drivers/src/nrfx_rtc.c
+++ b/nrfx/drivers/src/nrfx_rtc.c
@@ -35,8 +35,7 @@
 
 #if NRFX_CHECK(NRFX_RTC_ENABLED)
 
-#if !(NRFX_CHECK(NRFX_RTC0_ENABLED) || NRFX_CHECK(NRFX_RTC1_ENABLED) || \
-      NRFX_CHECK(NRFX_RTC2_ENABLED))
+#if !NRFX_FEATURE_PRESENT(NRFX_RTC, _ENABLED)
 #error "No enabled RTC instances. Check <nrfx_config.h>."
 #endif
 
@@ -58,13 +57,13 @@
 /** @brief RTC driver instance control block structure. */
 typedef struct
 {
-    nrfx_drv_state_t state;        /**< Instance state. */
-    bool             reliable;     /**< Reliable mode flag. */
-    uint8_t          tick_latency; /**< Maximum length of interrupt handler in ticks (max 7.7 ms). */
+    nrfx_rtc_handler_t handler;      /**< Instance event handler. */
+    nrfx_drv_state_t   state;        /**< Instance state. */
+    bool               reliable;     /**< Reliable mode flag. */
+    uint8_t            tick_latency; /**< Maximum length of interrupt handler in ticks (max 7.7 ms). */
 } nrfx_rtc_cb_t;
 
 // User callbacks local storage.
-static nrfx_rtc_handler_t m_handlers[NRFX_RTC_ENABLED_COUNT];
 static nrfx_rtc_cb_t      m_cb[NRFX_RTC_ENABLED_COUNT];
 
 nrfx_err_t nrfx_rtc_init(nrfx_rtc_t const *        p_instance,
@@ -75,7 +74,7 @@ nrfx_err_t nrfx_rtc_init(nrfx_rtc_t const *        p_instance,
     NRFX_ASSERT(handler);
     nrfx_err_t err_code;
 
-    m_handlers[p_instance->instance_id] = handler;
+    m_cb[p_instance->instance_id].handler = handler;
 
     if (m_cb[p_instance->instance_id].state != NRFX_DRV_STATE_UNINITIALIZED)
     {
@@ -86,9 +85,14 @@ nrfx_err_t nrfx_rtc_init(nrfx_rtc_t const *        p_instance,
         return err_code;
     }
 
-    NRFX_IRQ_PRIORITY_SET(p_instance->irq, p_config->interrupt_priority);
-    NRFX_IRQ_ENABLE(p_instance->irq);
-    nrf_rtc_prescaler_set(p_instance->p_reg, p_config->prescaler);
+    nrfy_rtc_int_init(p_instance->p_reg, 0, p_config->interrupt_priority, false);
+
+    nrfy_rtc_config_t config =
+    {
+        .prescaler = p_config->prescaler
+    };
+
+    nrfy_rtc_periph_configure(p_instance->p_reg, &config);
     m_cb[p_instance->instance_id].reliable     = p_config->reliable;
     m_cb[p_instance->instance_id].tick_latency = p_config->tick_latency;
     m_cb[p_instance->instance_id].state        = NRFX_DRV_STATE_INITIALIZED;
@@ -102,17 +106,11 @@ void nrfx_rtc_uninit(nrfx_rtc_t const * p_instance)
 {
     uint32_t mask = NRF_RTC_INT_TICK_MASK     |
                     NRF_RTC_INT_OVERFLOW_MASK |
-                    NRF_RTC_INT_COMPARE0_MASK |
-                    NRF_RTC_INT_COMPARE1_MASK |
-                    NRF_RTC_INT_COMPARE2_MASK |
-                    NRF_RTC_INT_COMPARE3_MASK;
+                    NRF_RTC_ALL_CHANNELS_INT_MASK;
     NRFX_ASSERT(m_cb[p_instance->instance_id].state != NRFX_DRV_STATE_UNINITIALIZED);
 
-    NRFX_IRQ_DISABLE(p_instance->irq);
-
-    nrf_rtc_task_trigger(p_instance->p_reg, NRF_RTC_TASK_STOP);
-    nrf_rtc_event_disable(p_instance->p_reg, mask);
-    nrf_rtc_int_disable(p_instance->p_reg, mask);
+    nrfy_rtc_int_uninit(p_instance->p_reg);
+    nrfy_rtc_stop(p_instance->p_reg, mask);
 
     m_cb[p_instance->instance_id].state = NRFX_DRV_STATE_UNINITIALIZED;
     NRFX_LOG_INFO("Uninitialized.");
@@ -122,7 +120,7 @@ void nrfx_rtc_enable(nrfx_rtc_t const * p_instance)
 {
     NRFX_ASSERT(m_cb[p_instance->instance_id].state == NRFX_DRV_STATE_INITIALIZED);
 
-    nrf_rtc_task_trigger(p_instance->p_reg, NRF_RTC_TASK_START);
+    nrfy_rtc_task_trigger(p_instance->p_reg, NRF_RTC_TASK_START);
     m_cb[p_instance->instance_id].state = NRFX_DRV_STATE_POWERED_ON;
     NRFX_LOG_INFO("Enabled.");
 }
@@ -131,7 +129,7 @@ void nrfx_rtc_disable(nrfx_rtc_t const * p_instance)
 {
     NRFX_ASSERT(m_cb[p_instance->instance_id].state != NRFX_DRV_STATE_UNINITIALIZED);
 
-    nrf_rtc_task_trigger(p_instance->p_reg, NRF_RTC_TASK_STOP);
+    nrfy_rtc_task_trigger(p_instance->p_reg, NRF_RTC_TASK_STOP);
     m_cb[p_instance->instance_id].state = NRFX_DRV_STATE_INITIALIZED;
     NRFX_LOG_INFO("Disabled.");
 }
@@ -142,16 +140,16 @@ nrfx_err_t nrfx_rtc_cc_disable(nrfx_rtc_t const * p_instance, uint32_t channel)
     NRFX_ASSERT(channel < p_instance->cc_channel_count);
 
     nrfx_err_t err_code;
-    uint32_t int_mask = RTC_CHANNEL_INT_MASK(channel);
-    nrf_rtc_event_t event = RTC_CHANNEL_EVENT_ADDR(channel);
+    uint32_t int_mask = NRF_RTC_CHANNEL_INT_MASK(channel);
+    nrf_rtc_event_t event = NRF_RTC_CHANNEL_EVENT_ADDR(channel);
 
-    nrf_rtc_event_disable(p_instance->p_reg, int_mask);
-    if (nrf_rtc_int_enable_check(p_instance->p_reg, int_mask))
+    nrfy_rtc_event_disable(p_instance->p_reg, int_mask);
+    if (nrfy_rtc_int_enable_check(p_instance->p_reg, int_mask))
     {
-        nrf_rtc_int_disable(p_instance->p_reg, int_mask);
-        if (nrf_rtc_event_check(p_instance->p_reg, event))
+        nrfy_rtc_int_disable(p_instance->p_reg, int_mask);
+        if (nrfy_rtc_event_check(p_instance->p_reg, event))
         {
-            nrf_rtc_event_clear(p_instance->p_reg, event);
+            nrfy_rtc_event_clear(p_instance->p_reg, event);
             err_code = NRFX_ERROR_TIMEOUT;
             NRFX_LOG_WARNING("Function: %s, error code: %s.",
                              __func__,
@@ -176,17 +174,16 @@ nrfx_err_t nrfx_rtc_cc_set(nrfx_rtc_t const * p_instance,
     NRFX_ASSERT(channel < p_instance->cc_channel_count);
 
     nrfx_err_t err_code;
-    uint32_t int_mask = RTC_CHANNEL_INT_MASK(channel);
-    nrf_rtc_event_t event = RTC_CHANNEL_EVENT_ADDR(channel);
+    uint32_t int_mask = NRF_RTC_CHANNEL_INT_MASK(channel);
+    nrf_rtc_event_t event = NRF_RTC_CHANNEL_EVENT_ADDR(channel);
 
-    nrf_rtc_event_disable(p_instance->p_reg, int_mask);
-    nrf_rtc_int_disable(p_instance->p_reg, int_mask);
+    nrfy_rtc_event_int_disable(p_instance->p_reg, int_mask);
 
-    val = RTC_WRAP(val);
+    val = NRF_RTC_WRAP(val);
     if (m_cb[p_instance->instance_id].reliable)
     {
-        nrf_rtc_cc_set(p_instance->p_reg,channel, val);
-        uint32_t cnt = nrf_rtc_counter_get(p_instance->p_reg);
+        nrfy_rtc_cc_set(p_instance->p_reg, channel, val);
+        uint32_t cnt = nrfy_rtc_counter_get(p_instance->p_reg);
         int32_t diff = cnt - val;
         if (cnt < val)
         {
@@ -203,15 +200,10 @@ nrfx_err_t nrfx_rtc_cc_set(nrfx_rtc_t const * p_instance,
     }
     else
     {
-        nrf_rtc_cc_set(p_instance->p_reg,channel,val);
+        nrfy_rtc_cc_set(p_instance->p_reg, channel, val);
     }
 
-    if (enable_irq)
-    {
-        nrf_rtc_event_clear(p_instance->p_reg, event);
-        nrf_rtc_int_enable(p_instance->p_reg, int_mask);
-    }
-    nrf_rtc_event_enable(p_instance->p_reg,int_mask);
+    nrfy_rtc_event_int_clear_enable(p_instance->p_reg, event, enable_irq);
 
     NRFX_LOG_INFO("RTC id: %d, channel enabled: %lu, compare value: %lu.",
                   p_instance->instance_id,
@@ -224,45 +216,30 @@ nrfx_err_t nrfx_rtc_cc_set(nrfx_rtc_t const * p_instance,
 
 void nrfx_rtc_tick_enable(nrfx_rtc_t const * p_instance, bool enable_irq)
 {
-    nrf_rtc_event_t event = NRF_RTC_EVENT_TICK;
-    uint32_t mask = NRF_RTC_INT_TICK_MASK;
-
-    nrf_rtc_event_clear(p_instance->p_reg, event);
-    nrf_rtc_event_enable(p_instance->p_reg, mask);
-    if (enable_irq)
-    {
-        nrf_rtc_int_enable(p_instance->p_reg, mask);
-    }
+    nrfy_rtc_event_int_clear_enable(p_instance->p_reg,
+                                    NRF_RTC_EVENT_TICK,
+                                    enable_irq);
     NRFX_LOG_INFO("Tick events enabled.");
 }
 
 void nrfx_rtc_tick_disable(nrfx_rtc_t const * p_instance)
 {
-    uint32_t mask = NRF_RTC_INT_TICK_MASK;
-
-    nrf_rtc_event_disable(p_instance->p_reg, mask);
-    nrf_rtc_int_disable(p_instance->p_reg, mask);
+    nrfy_rtc_event_int_disable(p_instance->p_reg,
+                               NRF_RTC_INT_TICK_MASK);
     NRFX_LOG_INFO("Tick events disabled.");
 }
 
 void nrfx_rtc_overflow_enable(nrfx_rtc_t const * p_instance, bool enable_irq)
 {
-    nrf_rtc_event_t event = NRF_RTC_EVENT_OVERFLOW;
-    uint32_t mask = NRF_RTC_INT_OVERFLOW_MASK;
-
-    nrf_rtc_event_clear(p_instance->p_reg, event);
-    nrf_rtc_event_enable(p_instance->p_reg, mask);
-    if (enable_irq)
-    {
-        nrf_rtc_int_enable(p_instance->p_reg, mask);
-    }
+    nrfy_rtc_event_int_clear_enable(p_instance->p_reg,
+                                    NRF_RTC_EVENT_OVERFLOW,
+                                    enable_irq);
 }
 
 void nrfx_rtc_overflow_disable(nrfx_rtc_t const * p_instance)
 {
-    uint32_t mask = NRF_RTC_INT_OVERFLOW_MASK;
-    nrf_rtc_event_disable(p_instance->p_reg, mask);
-    nrf_rtc_int_disable(p_instance->p_reg, mask);
+    nrfy_rtc_event_int_disable(p_instance->p_reg,
+                               NRF_RTC_INT_OVERFLOW_MASK);
 }
 
 uint32_t nrfx_rtc_max_ticks_get(nrfx_rtc_t const * p_instance)
@@ -279,71 +256,44 @@ uint32_t nrfx_rtc_max_ticks_get(nrfx_rtc_t const * p_instance)
     return ticks;
 }
 
-static void irq_handler(NRF_RTC_Type * p_reg,
-                        uint32_t       instance_id,
-                        uint32_t       channel_count)
+static void irq_handler(NRF_RTC_Type  * p_reg,
+                        nrfx_rtc_cb_t * p_cb,
+                        uint32_t        channel_count)
 {
-    uint32_t i;
-    uint32_t int_mask = (uint32_t)NRF_RTC_INT_COMPARE0_MASK;
-    nrf_rtc_event_t event = NRF_RTC_EVENT_COMPARE_0;
+    uint32_t evt_to_process = NRFY_EVENT_TO_INT_BITMASK(NRF_RTC_EVENT_TICK)     |
+                              NRFY_EVENT_TO_INT_BITMASK(NRF_RTC_EVENT_OVERFLOW) |
+                              NRF_RTC_ALL_CHANNELS_INT_MASK;
 
-    for (i = 0; i < channel_count; i++)
+    uint32_t event_mask = nrfy_rtc_events_process(p_reg, evt_to_process);
+
+    nrf_rtc_event_t event;
+    uint32_t active_cc_mask = nrfy_rtc_int_enable_check(p_reg, NRF_RTC_ALL_CHANNELS_INT_MASK);
+
+    for (uint32_t i = 0; i < channel_count; i++)
     {
-        if (nrf_rtc_int_enable_check(p_reg, int_mask) && nrf_rtc_event_check(p_reg, event))
+        event = nrf_rtc_compare_event_get(i);
+        if ((active_cc_mask & NRFY_EVENT_TO_INT_BITMASK(event)) &&
+            (event_mask & NRFY_EVENT_TO_INT_BITMASK(event)))
         {
-            nrf_rtc_event_disable(p_reg, int_mask);
-            nrf_rtc_int_disable(p_reg, int_mask);
-            nrf_rtc_event_clear(p_reg, event);
-            NRFX_LOG_DEBUG("Event: %s, instance id: %lu.",
-                           EVT_TO_STR(event),
-                           (unsigned long)instance_id);
-            m_handlers[instance_id]((nrfx_rtc_int_type_t)i);
+            nrfy_rtc_event_disable(p_reg, NRFY_EVENT_TO_INT_BITMASK(event));
+            NRFX_LOG_DEBUG("Event: %s, reg: %p.", EVT_TO_STR(event), p_reg);
+            p_cb->handler((nrfx_rtc_int_type_t)i);
         }
-        int_mask <<= 1;
-        event = (nrf_rtc_event_t)((uint32_t)event + sizeof(uint32_t));
     }
 
-    event = NRF_RTC_EVENT_TICK;
-    if (nrf_rtc_int_enable_check(p_reg, NRF_RTC_INT_TICK_MASK) && nrf_rtc_event_check(p_reg, event))
+    if (event_mask & NRFY_EVENT_TO_INT_BITMASK(NRF_RTC_EVENT_TICK))
     {
-        nrf_rtc_event_clear(p_reg, event);
-        NRFX_LOG_DEBUG("Event: %s, instance id: %lu.",
-                       EVT_TO_STR(event),
-                       (unsigned long)instance_id);
-        m_handlers[instance_id](NRFX_RTC_INT_TICK);
+        NRFX_LOG_DEBUG("Event: %s, reg: %p.", EVT_TO_STR(event), p_reg);
+        p_cb->handler(NRFX_RTC_INT_TICK);
     }
 
-    event = NRF_RTC_EVENT_OVERFLOW;
-    if (nrf_rtc_int_enable_check(p_reg, NRF_RTC_INT_OVERFLOW_MASK) &&
-        nrf_rtc_event_check(p_reg, event))
+    if (event_mask & NRFY_EVENT_TO_INT_BITMASK(NRF_RTC_EVENT_OVERFLOW))
     {
-        nrf_rtc_event_clear(p_reg, event);
-        NRFX_LOG_DEBUG("Event: %s, instance id: %lu.",
-                       EVT_TO_STR(event),
-                       (unsigned long)instance_id);
-        m_handlers[instance_id](NRFX_RTC_INT_OVERFLOW);
+        NRFX_LOG_DEBUG("Event: %s, reg: %p.", EVT_TO_STR(event), p_reg);
+        p_cb->handler(NRFX_RTC_INT_OVERFLOW);
     }
 }
 
-#if NRFX_CHECK(NRFX_RTC0_ENABLED)
-void nrfx_rtc_0_irq_handler(void)
-{
-    irq_handler(NRF_RTC0, NRFX_RTC0_INST_IDX, NRF_RTC_CC_CHANNEL_COUNT(0));
-}
-#endif
-
-#if NRFX_CHECK(NRFX_RTC1_ENABLED)
-void nrfx_rtc_1_irq_handler(void)
-{
-    irq_handler(NRF_RTC1, NRFX_RTC1_INST_IDX, NRF_RTC_CC_CHANNEL_COUNT(1));
-}
-#endif
-
-#if NRFX_CHECK(NRFX_RTC2_ENABLED)
-void nrfx_rtc_2_irq_handler(void)
-{
-    irq_handler(NRF_RTC2, NRFX_RTC2_INST_IDX, NRF_RTC_CC_CHANNEL_COUNT(2));
-}
-#endif
+NRFX_INSTANCE_IRQ_HANDLERS_EXT(RTC, rtc, NRF_RTC_CC_CHANNEL_COUNT)
 
 #endif // NRFX_CHECK(NRFX_RTC_ENABLED)

--- a/nrfx/drivers/src/nrfx_saadc.c
+++ b/nrfx/drivers/src/nrfx_saadc.c
@@ -70,14 +70,11 @@ typedef struct
 {
     nrfx_saadc_event_handler_t event_handler;                ///< Event handler function pointer.
     nrfx_saadc_event_handler_t calib_event_handler;          ///< Event handler function pointer for calibration event.
-    nrf_saadc_value_t *        p_buffer_primary;             ///< Pointer to the primary result buffer.
-    nrf_saadc_value_t *        p_buffer_secondary;           ///< Pointer to the secondary result buffer.
+    nrfy_saadc_buffer_t        buffer_primary;               ///< Primary buffer description structure.
+    nrfy_saadc_buffer_t        buffer_secondary;             ///< Secondary buffer description structure.
     nrf_saadc_value_t          calib_samples[2];             ///< Scratch buffer for post-calibration samples.
-    uint16_t                   size_primary;                 ///< Size of the primary result buffer.
-    uint16_t                   size_secondary;               ///< Size of the secondary result buffer.
     uint16_t                   samples_converted;            ///< Number of samples present in result buffer when in the blocking mode.
-    nrf_saadc_input_t          channels_pselp[SAADC_CH_NUM]; ///< Array holding each channel positive input.
-    nrf_saadc_input_t          channels_pseln[SAADC_CH_NUM]; ///< Array holding each channel negative input.
+    nrfy_saadc_channel_input_t channels_input[SAADC_CH_NUM]; ///< Array holding input of each of the channels.
     nrf_saadc_state_t          saadc_state;                  ///< State of the SAADC driver.
     nrf_saadc_state_t          saadc_state_prev;             ///< Previous state of the SAADC driver.
     uint8_t                    channels_configured;          ///< Bitmask of the configured channels.
@@ -102,7 +99,7 @@ static void saadc_anomaly_212_workaround_apply(void)
         c[i] = NRF_SAADC->CH[i].CONFIG;
         l[i] = NRF_SAADC->CH[i].LIMIT;
     }
-    nrf_saadc_resolution_t resolution = nrf_saadc_resolution_get(NRF_SAADC);
+    nrf_saadc_resolution_t resolution = nrfy_saadc_resolution_get(NRF_SAADC);
     uint32_t u640 = *(volatile uint32_t *)0x40007640;
     uint32_t u644 = *(volatile uint32_t *)0x40007644;
     uint32_t u648 = *(volatile uint32_t *)0x40007648;
@@ -118,7 +115,7 @@ static void saadc_anomaly_212_workaround_apply(void)
     *(volatile uint32_t *)0x40007640 = u640;
     *(volatile uint32_t *)0x40007644 = u644;
     *(volatile uint32_t *)0x40007648 = u648;
-    nrf_saadc_resolution_set(NRF_SAADC, resolution);
+    nrfy_saadc_resolution_set(NRF_SAADC, resolution);
 }
 #endif // NRFX_CHECK(USE_WORKAROUND_FOR_ANOMALY_212)
 
@@ -150,10 +147,11 @@ static void saadc_channel_config(nrfx_saadc_channel_t const * p_channel)
 {
     NRFX_ASSERT(p_channel->pin_p != NRF_SAADC_INPUT_DISABLED);
 
-    nrf_saadc_channel_init(NRF_SAADC, p_channel->channel_index, &p_channel->channel_config);
-    m_cb.channels_pselp[p_channel->channel_index] = p_channel->pin_p;
-    m_cb.channels_pseln[p_channel->channel_index] = p_channel->pin_n;
-    m_cb.channels_configured |= 1U << p_channel->channel_index;
+    uint8_t channel_index = p_channel->channel_index;
+    nrfy_saadc_channel_configure(NRF_SAADC, channel_index, &p_channel->channel_config, NULL);
+    m_cb.channels_input[channel_index].input_p = p_channel->pin_p;
+    m_cb.channels_input[channel_index].input_n = p_channel->pin_n;
+    m_cb.channels_configured |= 1U << channel_index;
 }
 
 static void saadc_channels_deconfig(uint32_t channel_mask)
@@ -165,8 +163,8 @@ static void saadc_channels_deconfig(uint32_t channel_mask)
         channel_mask             &= ~(1 << channel);
         m_cb.channels_configured &= ~(1 << channel);
 
-        m_cb.channels_pselp[channel] = NRF_SAADC_INPUT_DISABLED;
-        m_cb.channels_pseln[channel] = NRF_SAADC_INPUT_DISABLED;
+        m_cb.channels_input[channel].input_p = NRF_SAADC_INPUT_DISABLED;
+        m_cb.channels_input[channel].input_n = NRF_SAADC_INPUT_DISABLED;
     }
 }
 
@@ -176,8 +174,8 @@ static void saadc_channels_disable(uint32_t channel_mask)
     {
         uint8_t channel = NRF_CTZ(channel_mask);
         channel_mask &= ~(1 << channel);
-        nrf_saadc_channel_input_set(NRF_SAADC, channel,
-                                    NRF_SAADC_INPUT_DISABLED, NRF_SAADC_INPUT_DISABLED);
+        nrfy_saadc_channel_input_set(NRF_SAADC, channel,
+                                     NRF_SAADC_INPUT_DISABLED, NRF_SAADC_INPUT_DISABLED);
     }
 }
 
@@ -206,55 +204,45 @@ static void saadc_generic_mode_set(uint32_t                   ch_to_activate_mas
 #endif
 
 #if NRFX_CHECK(STOP_SAADC_ON_CHANNEL_CONFIG)
-    nrf_saadc_int_disable(NRF_SAADC, NRF_SAADC_INT_STOPPED);
-    nrf_saadc_task_trigger(NRF_SAADC, NRF_SAADC_TASK_STOP);
-    while (!nrf_saadc_event_check(NRF_SAADC, NRF_SAADC_EVENT_STOPPED))
-    {}
-    nrf_saadc_event_clear(NRF_SAADC, NRF_SAADC_EVENT_STOPPED);
+    nrfy_saadc_int_disable(NRF_SAADC, NRF_SAADC_INT_STOPPED);
+    nrfy_saadc_stop(NRF_SAADC, true);
 #endif
 
     m_cb.limits_low_activated = 0;
     m_cb.limits_high_activated = 0;
 
-    m_cb.p_buffer_primary = NULL;
-    m_cb.p_buffer_secondary = NULL;
+    m_cb.buffer_primary.p_buffer = NULL;
+    m_cb.buffer_secondary.p_buffer = NULL;
     m_cb.event_handler = event_handler;
     m_cb.channels_activated = ch_to_activate_mask;
     m_cb.samples_converted = 0;
 
-    nrf_saadc_resolution_set(NRF_SAADC, resolution);
-    nrf_saadc_oversample_set(NRF_SAADC, oversampling);
+    nrfy_saadc_config_t config = {.resolution = resolution, .oversampling = oversampling};
+    nrfy_saadc_periph_configure(NRF_SAADC, &config);
     if (event_handler)
     {
-        nrf_saadc_int_set(NRF_SAADC,
-                          NRF_SAADC_INT_STARTED |
-                          NRF_SAADC_INT_STOPPED |
-                          NRF_SAADC_INT_END);
+        nrfy_saadc_int_set(NRF_SAADC,
+                           NRF_SAADC_INT_STARTED |
+                           NRF_SAADC_INT_STOPPED |
+                           NRF_SAADC_INT_END);
     }
     else
     {
-        nrf_saadc_int_set(NRF_SAADC, 0);
+        nrfy_saadc_int_set(NRF_SAADC, 0);
     }
 
     for (uint32_t ch_pos = 0; ch_pos < SAADC_CH_NUM; ch_pos++)
     {
-        nrf_saadc_burst_t burst_to_set;
-        nrf_saadc_input_t pselp;
-        nrf_saadc_input_t pseln;
+        nrf_saadc_burst_t burst_to_set = NRF_SAADC_BURST_DISABLED;
+        nrfy_saadc_channel_input_t input = {.input_p = NRF_SAADC_INPUT_DISABLED,
+                                            .input_n = NRF_SAADC_INPUT_DISABLED};
         if (ch_to_activate_mask & (1 << ch_pos))
         {
-            pselp = m_cb.channels_pselp[ch_pos];
-            pseln = m_cb.channels_pseln[ch_pos];
+            input = m_cb.channels_input[ch_pos];
             burst_to_set = burst;
         }
-        else
-        {
-            pselp = NRF_SAADC_INPUT_DISABLED;
-            pseln = NRF_SAADC_INPUT_DISABLED;
-            burst_to_set = NRF_SAADC_BURST_DISABLED;
-        }
-        nrf_saadc_burst_set(NRF_SAADC, ch_pos, burst_to_set);
-        nrf_saadc_channel_input_set(NRF_SAADC, ch_pos, pselp, pseln);
+        nrfy_saadc_burst_set(NRF_SAADC, ch_pos, burst_to_set);
+        nrfy_saadc_channel_configure(NRF_SAADC, ch_pos, NULL, &input);
     }
 }
 
@@ -271,14 +259,13 @@ nrfx_err_t nrfx_saadc_init(uint8_t interrupt_priority)
     }
     m_cb.saadc_state = NRF_SAADC_STATE_IDLE;
 
-    nrf_saadc_event_clear(NRF_SAADC, NRF_SAADC_EVENT_STARTED);
-    nrf_saadc_event_clear(NRF_SAADC, NRF_SAADC_EVENT_STOPPED);
-    nrf_saadc_event_clear(NRF_SAADC, NRF_SAADC_EVENT_END);
-    nrf_saadc_event_clear(NRF_SAADC, NRF_SAADC_EVENT_CALIBRATEDONE);
-    nrf_saadc_int_set(NRF_SAADC, 0);
     saadc_channels_deconfig(SAADC_ALL_CHANNELS_MASK);
-    NRFX_IRQ_ENABLE(SAADC_IRQn);
-    NRFX_IRQ_PRIORITY_SET(SAADC_IRQn, interrupt_priority);
+    uint32_t mask = NRFY_EVENT_TO_INT_BITMASK(NRF_SAADC_EVENT_STARTED) |
+                    NRFY_EVENT_TO_INT_BITMASK(NRF_SAADC_EVENT_STOPPED) |
+                    NRFY_EVENT_TO_INT_BITMASK(NRF_SAADC_EVENT_END) |
+                    NRFY_EVENT_TO_INT_BITMASK(NRF_SAADC_EVENT_CALIBRATEDONE);
+
+    nrfy_saadc_int_init(NRF_SAADC, mask, interrupt_priority, false);
     m_cb.event_handler = NULL;
 
     err_code = NRFX_SUCCESS;
@@ -290,8 +277,9 @@ nrfx_err_t nrfx_saadc_init(uint8_t interrupt_priority)
 void nrfx_saadc_uninit(void)
 {
     nrfx_saadc_abort();
-    NRFX_IRQ_DISABLE(SAADC_IRQn);
-    nrf_saadc_disable(NRF_SAADC);
+
+    nrfy_saadc_int_uninit(NRF_SAADC);
+    nrfy_saadc_disable(NRF_SAADC);
     saadc_channels_disable(m_cb.channels_configured | m_cb.channels_activated);
     m_cb.saadc_state = NRF_SAADC_STATE_UNINITIALIZED;
 }
@@ -449,11 +437,11 @@ nrfx_err_t nrfx_saadc_advanced_mode_set(uint32_t                        channel_
 
     if (p_config->internal_timer_cc)
     {
-        nrf_saadc_continuous_mode_enable(NRF_SAADC, p_config->internal_timer_cc);
+        nrfy_saadc_continuous_mode_enable(NRF_SAADC, p_config->internal_timer_cc);
     }
     else
     {
-        nrf_saadc_continuous_mode_disable(NRF_SAADC);
+        nrfy_saadc_continuous_mode_disable(NRF_SAADC);
     }
 
     m_cb.channels_activated_count = active_ch_count;
@@ -469,7 +457,7 @@ nrfx_err_t nrfx_saadc_buffer_set(nrf_saadc_value_t * p_buffer, uint16_t size)
 {
     NRFX_ASSERT(m_cb.saadc_state != NRF_SAADC_STATE_UNINITIALIZED);
 
-    if (m_cb.p_buffer_secondary)
+    if (m_cb.buffer_secondary.p_buffer)
     {
         return NRFX_ERROR_ALREADY_INITIALIZED;
     }
@@ -486,6 +474,7 @@ nrfx_err_t nrfx_saadc_buffer_set(nrf_saadc_value_t * p_buffer, uint16_t size)
         return NRFX_ERROR_INVALID_LENGTH;
     }
 
+    nrfy_saadc_buffer_t buffer = {.p_buffer = p_buffer, .length = size};
     switch (m_cb.saadc_state)
     {
         case NRF_SAADC_STATE_SIMPLE_MODE:
@@ -493,27 +482,24 @@ nrfx_err_t nrfx_saadc_buffer_set(nrf_saadc_value_t * p_buffer, uint16_t size)
             {
                 return NRFX_ERROR_INVALID_LENGTH;
             }
-            m_cb.size_primary     = size;
-            m_cb.p_buffer_primary = p_buffer;
+            m_cb.buffer_primary = buffer;
             break;
 
         case NRF_SAADC_STATE_ADV_MODE_SAMPLE_STARTED:
-            nrf_saadc_buffer_init(NRF_SAADC, p_buffer, size);
+            nrfy_saadc_buffer_set(NRF_SAADC, &buffer, false, false);
             /* FALLTHROUGH */
 
         case NRF_SAADC_STATE_ADV_MODE:
             /* FALLTHROUGH */
 
         case NRF_SAADC_STATE_ADV_MODE_SAMPLE:
-            if (m_cb.p_buffer_primary)
+            if (m_cb.buffer_primary.p_buffer)
             {
-                m_cb.size_secondary     = size;
-                m_cb.p_buffer_secondary = p_buffer;
+                m_cb.buffer_secondary = buffer;
             }
             else
             {
-                m_cb.size_primary     = size;
-                m_cb.p_buffer_primary = p_buffer;
+                m_cb.buffer_primary = buffer;
             }
             break;
 
@@ -529,7 +515,7 @@ nrfx_err_t nrfx_saadc_mode_trigger(void)
     NRFX_ASSERT(m_cb.saadc_state != NRF_SAADC_STATE_UNINITIALIZED);
     NRFX_ASSERT(m_cb.saadc_state != NRF_SAADC_STATE_IDLE);
 
-    if (!m_cb.p_buffer_primary)
+    if (!m_cb.buffer_primary.p_buffer)
     {
         return NRFX_ERROR_NO_MEM;
     }
@@ -538,94 +524,78 @@ nrfx_err_t nrfx_saadc_mode_trigger(void)
     switch (m_cb.saadc_state)
     {
         case NRF_SAADC_STATE_SIMPLE_MODE:
-            nrf_saadc_enable(NRF_SAADC);
+        {
+            nrfy_saadc_enable(NRF_SAADC);
             // When in simple blocking or non-blocking mode, buffer size is equal to activated channel count.
             // Single SAMPLE task is enough to obtain one sample on each activated channel.
             // This will result in buffer being filled with samples and therefore END event will appear.
-            nrf_saadc_buffer_init(NRF_SAADC, m_cb.p_buffer_primary, m_cb.size_primary);
+
             if (m_cb.event_handler)
             {
                 m_cb.saadc_state = NRF_SAADC_STATE_SIMPLE_MODE_SAMPLE;
-                nrf_saadc_task_trigger(NRF_SAADC, NRF_SAADC_TASK_START);
+                nrfy_saadc_buffer_set(NRF_SAADC, &m_cb.buffer_primary, true, false);
             }
             else
             {
-                nrf_saadc_task_trigger(NRF_SAADC, NRF_SAADC_TASK_START);
-                while (!nrf_saadc_event_check(NRF_SAADC, NRF_SAADC_EVENT_STARTED))
-                {}
-                nrf_saadc_event_clear(NRF_SAADC, NRF_SAADC_EVENT_STARTED);
-
-                nrf_saadc_task_trigger(NRF_SAADC, NRF_SAADC_TASK_SAMPLE);
-                while (!nrf_saadc_event_check(NRF_SAADC, NRF_SAADC_EVENT_END))
-                {}
-                nrf_saadc_event_clear(NRF_SAADC, NRF_SAADC_EVENT_END);
-                nrf_saadc_disable(NRF_SAADC);
+                nrfy_saadc_buffer_set(NRF_SAADC, &m_cb.buffer_primary, true, true);
+                nrfy_saadc_sample_start(NRF_SAADC, &m_cb.buffer_primary);
+                nrfy_saadc_disable(NRF_SAADC);
             }
             break;
+        }
 
         case NRF_SAADC_STATE_ADV_MODE:
-            nrf_saadc_enable(NRF_SAADC);
+        {
+            nrfy_saadc_enable(NRF_SAADC);
             if (m_cb.event_handler)
             {
                 // When in advanced non-blocking mode, latch whole buffer in EasyDMA.
                 // END event will arrive when whole buffer is filled with samples.
+
                 m_cb.saadc_state = NRF_SAADC_STATE_ADV_MODE_SAMPLE;
-                nrf_saadc_buffer_init(NRF_SAADC, m_cb.p_buffer_primary, m_cb.size_primary);
-                nrf_saadc_task_trigger(NRF_SAADC, NRF_SAADC_TASK_START);
+                nrfy_saadc_buffer_set(NRF_SAADC, &m_cb.buffer_primary, true, false);
                 break;
             }
-
             // When in advanced blocking mode, latch single chunk of buffer in EasyDMA.
             // Each chunk consists of single sample from each activated channels.
             // END event will arrive when single chunk is filled with samples.
-            nrf_saadc_buffer_init(NRF_SAADC,
-                                  &m_cb.p_buffer_primary[m_cb.samples_converted],
-                                  m_cb.channels_activated_count);
-
-            nrf_saadc_task_trigger(NRF_SAADC, NRF_SAADC_TASK_START);
-            while (!nrf_saadc_event_check(NRF_SAADC, NRF_SAADC_EVENT_STARTED))
-            {}
-            nrf_saadc_event_clear(NRF_SAADC, NRF_SAADC_EVENT_STARTED);
-
+            nrfy_saadc_buffer_t chunk =
+                {.p_buffer = &m_cb.buffer_primary.p_buffer[m_cb.samples_converted],
+                 .length   = m_cb.channels_activated_count};
+            nrfy_saadc_buffer_set(NRF_SAADC, &chunk, true, true);
             if (m_cb.oversampling_without_burst)
             {
                 // Oversampling without burst is possible only on single channel.
                 // In this configuration more than one SAMPLE task is needed to obtain single sample.
                 uint32_t samples_to_take =
-                    nrf_saadc_oversample_sample_count_get(nrf_saadc_oversample_get(NRF_SAADC));
+                    nrfy_saadc_oversample_sample_count_get(nrfy_saadc_oversample_get(NRF_SAADC));
 
-                for (uint32_t sample_idx = 0; sample_idx < samples_to_take; sample_idx++)
+                for (uint32_t sample_idx = 0; sample_idx < samples_to_take - 1; sample_idx++)
                 {
-                    nrf_saadc_event_clear(NRF_SAADC, NRF_SAADC_EVENT_DONE);
-                    nrf_saadc_task_trigger(NRF_SAADC, NRF_SAADC_TASK_SAMPLE);
-                    while (!nrf_saadc_event_check(NRF_SAADC, NRF_SAADC_EVENT_DONE))
+                    nrfy_saadc_sample_start(NRF_SAADC, NULL);
+                    uint32_t evt_mask = NRFY_EVENT_TO_INT_BITMASK(NRF_SAADC_EVENT_DONE);
+                    while (!nrfy_saadc_events_process(NRF_SAADC, evt_mask, NULL))
                     {}
                 }
             }
-            else
-            {
-                // Single SAMPLE task is enough to obtain one sample on each activated channel.
-                // This will result in chunk being filled with samples and therefore END event will appear.
-                nrf_saadc_task_trigger(NRF_SAADC, NRF_SAADC_TASK_SAMPLE);
-            }
-            while (!nrf_saadc_event_check(NRF_SAADC, NRF_SAADC_EVENT_END))
-            {}
-            nrf_saadc_event_clear(NRF_SAADC, NRF_SAADC_EVENT_END);
+            // Single SAMPLE task is enough to obtain one sample on each activated channel.
+            // This will result in chunk being filled with samples and therefore END event will appear.
+            nrfy_saadc_sample_start(NRF_SAADC, &chunk);
 
             m_cb.samples_converted += m_cb.channels_activated_count;
-            if (m_cb.samples_converted < m_cb.size_primary)
+            if (m_cb.samples_converted < m_cb.buffer_primary.length)
             {
                 result = NRFX_ERROR_BUSY;
             }
             else
             {
-                m_cb.samples_converted  = 0;
-                m_cb.p_buffer_primary   = m_cb.p_buffer_secondary;
-                m_cb.size_primary       = m_cb.size_secondary;
-                m_cb.p_buffer_secondary = NULL;
+                m_cb.samples_converted         = 0;
+                m_cb.buffer_primary            = m_cb.buffer_secondary;
+                m_cb.buffer_secondary.p_buffer = NULL;
             }
-            nrf_saadc_disable(NRF_SAADC);
+            nrfy_saadc_disable(NRF_SAADC);
             break;
+        }
 
         default:
             result = NRFX_ERROR_INVALID_STATE;
@@ -642,13 +612,13 @@ void nrfx_saadc_abort(void)
     if (m_cb.saadc_state == NRF_SAADC_STATE_CALIBRATION ? m_cb.calib_event_handler :
                                                           m_cb.event_handler)
     {
-        nrf_saadc_task_trigger(NRF_SAADC, NRF_SAADC_TASK_STOP);
+        nrfy_saadc_abort(NRF_SAADC, NULL);
     }
     else
     {
-        m_cb.p_buffer_primary = NULL;
-        m_cb.p_buffer_secondary = NULL;
-        m_cb.samples_converted = 0;
+        m_cb.buffer_primary.p_buffer   = NULL;
+        m_cb.buffer_secondary.p_buffer = NULL;
+        m_cb.samples_converted         = 0;
     }
 }
 
@@ -673,30 +643,30 @@ nrfx_err_t nrfx_saadc_limits_set(uint8_t channel, int16_t limit_low, int16_t lim
         return NRFX_ERROR_INVALID_PARAM;
     }
 
-    nrf_saadc_channel_limits_set(NRF_SAADC, channel, limit_low, limit_high);
+    nrfy_saadc_channel_limits_set(NRF_SAADC, channel, limit_low, limit_high);
 
-    uint32_t int_mask = nrf_saadc_limit_int_get(channel, NRF_SAADC_LIMIT_LOW);
+    uint32_t int_mask = nrfy_saadc_limit_int_get(channel, NRF_SAADC_LIMIT_LOW);
     if (limit_low == INT16_MIN)
     {
         m_cb.limits_low_activated &= ~(1 << channel);
-        nrf_saadc_int_disable(NRF_SAADC, int_mask);
+        nrfy_saadc_int_disable(NRF_SAADC, int_mask);
     }
     else
     {
         m_cb.limits_low_activated |= (1 << channel);
-        nrf_saadc_int_enable(NRF_SAADC, int_mask);
+        nrfy_saadc_int_enable(NRF_SAADC, int_mask);
     }
 
-    int_mask = nrf_saadc_limit_int_get(channel, NRF_SAADC_LIMIT_HIGH);
+    int_mask = nrfy_saadc_limit_int_get(channel, NRF_SAADC_LIMIT_HIGH);
     if (limit_high == INT16_MAX)
     {
         m_cb.limits_high_activated &= ~(1 << channel);
-        nrf_saadc_int_disable(NRF_SAADC, int_mask);
+        nrfy_saadc_int_disable(NRF_SAADC, int_mask);
     }
     else
     {
         m_cb.limits_high_activated |= (1 << channel);
-        nrf_saadc_int_enable(NRF_SAADC, int_mask);
+        nrfy_saadc_int_enable(NRF_SAADC, int_mask);
     }
 
     return NRFX_SUCCESS;
@@ -715,42 +685,34 @@ nrfx_err_t nrfx_saadc_offset_calibrate(nrfx_saadc_event_handler_t calib_event_ha
     m_cb.saadc_state = NRF_SAADC_STATE_CALIBRATION;
     m_cb.calib_event_handler = calib_event_handler;
 
-    nrf_saadc_enable(NRF_SAADC);
+    nrfy_saadc_enable(NRF_SAADC);
 
-    uint32_t int_mask = nrf_saadc_int_enable_check(NRF_SAADC, ~0UL);
-    nrf_saadc_int_set(NRF_SAADC, 0);
-    nrf_saadc_task_trigger(NRF_SAADC, NRF_SAADC_TASK_CALIBRATEOFFSET);
+    uint32_t int_mask = nrfy_saadc_int_enable_check(NRF_SAADC, ~0UL);
+    nrfy_saadc_int_set(NRF_SAADC, 0);
     if (calib_event_handler)
     {
+        nrfy_saadc_calibrate(NRF_SAADC, false);
         // Make sure that LIMIT feature is disabled before offset calibration.
         int_mask &= ~(NRF_SAADC_INT_CH0LIMITL | NRF_SAADC_INT_CH0LIMITH);
-        nrf_saadc_int_set(NRF_SAADC, int_mask | NRF_SAADC_INT_STARTED | NRF_SAADC_INT_STOPPED |
-                                     NRF_SAADC_INT_END | NRF_SAADC_INT_CALIBRATEDONE);
+        nrfy_saadc_int_set(NRF_SAADC, int_mask | NRF_SAADC_INT_STARTED | NRF_SAADC_INT_STOPPED |
+                                      NRF_SAADC_INT_END | NRF_SAADC_INT_CALIBRATEDONE);
     }
     else
     {
-        while (!nrf_saadc_event_check(NRF_SAADC, NRF_SAADC_EVENT_CALIBRATEDONE))
-        {}
-        nrf_saadc_event_clear(NRF_SAADC, NRF_SAADC_EVENT_CALIBRATEDONE);
+        nrfy_saadc_calibrate(NRF_SAADC, true);
 
-        nrf_saadc_buffer_init(NRF_SAADC, m_cb.calib_samples, NRFX_ARRAY_SIZE(m_cb.calib_samples));
-        nrf_saadc_task_trigger(NRF_SAADC, NRF_SAADC_TASK_START);
-        while (!nrf_saadc_event_check(NRF_SAADC, NRF_SAADC_EVENT_STARTED))
-        {}
-        nrf_saadc_event_clear(NRF_SAADC, NRF_SAADC_EVENT_STARTED);
+        nrfy_saadc_buffer_t calib_buffer = {.p_buffer = m_cb.calib_samples,
+                                            .length   = NRFX_ARRAY_SIZE(m_cb.calib_samples)};
+        nrfy_saadc_buffer_set(NRF_SAADC, &calib_buffer, true, true);
 
-        nrf_saadc_task_trigger(NRF_SAADC, NRF_SAADC_TASK_STOP);
-        while (!nrf_saadc_event_check(NRF_SAADC, NRF_SAADC_EVENT_STOPPED))
-        {}
-        nrf_saadc_event_clear(NRF_SAADC, NRF_SAADC_EVENT_STOPPED);
-        nrf_saadc_event_clear(NRF_SAADC, NRF_SAADC_EVENT_END);
-
-        nrf_saadc_disable(NRF_SAADC);
+        nrfy_saadc_stop(NRF_SAADC, true);
+        nrfy_saadc_event_clear(NRF_SAADC, NRF_SAADC_EVENT_END);
+        nrfy_saadc_disable(NRF_SAADC);
         m_cb.saadc_state = m_cb.saadc_state_prev;
 
-        nrf_saadc_event_clear(NRF_SAADC, NRF_SAADC_EVENT_CH0_LIMITL);
-        nrf_saadc_event_clear(NRF_SAADC, NRF_SAADC_EVENT_CH0_LIMITH);
-        nrf_saadc_int_set(NRF_SAADC, int_mask);
+        nrfy_saadc_event_clear(NRF_SAADC, NRF_SAADC_EVENT_CH0_LIMITL);
+        nrfy_saadc_event_clear(NRF_SAADC, NRF_SAADC_EVENT_CH0_LIMITH);
+        nrfy_saadc_int_set(NRF_SAADC, int_mask);
     }
 
     return NRFX_SUCCESS;
@@ -759,7 +721,7 @@ nrfx_err_t nrfx_saadc_offset_calibrate(nrfx_saadc_event_handler_t calib_event_ha
 static void saadc_pre_calibration_state_restore(void)
 {
     nrf_saadc_disable(NRF_SAADC);
-    uint32_t int_mask = nrf_saadc_int_enable_check(NRF_SAADC, ~0UL) &
+    uint32_t int_mask = nrfy_saadc_int_enable_check(NRF_SAADC, ~0UL) &
                         ~(NRF_SAADC_INT_STARTED | NRF_SAADC_INT_STOPPED |
                           NRF_SAADC_INT_END | NRF_SAADC_INT_CALIBRATEDONE);
     m_cb.saadc_state = m_cb.saadc_state_prev;
@@ -769,8 +731,8 @@ static void saadc_pre_calibration_state_restore(void)
         // during mode configuration.
         int_mask |= NRF_SAADC_INT_STARTED | NRF_SAADC_INT_STOPPED | NRF_SAADC_INT_END;
     }
-    nrf_saadc_event_clear(NRF_SAADC, NRF_SAADC_EVENT_CH0_LIMITL);
-    nrf_saadc_event_clear(NRF_SAADC, NRF_SAADC_EVENT_CH0_LIMITH);
+    nrfy_saadc_event_clear(NRF_SAADC, NRF_SAADC_EVENT_CH0_LIMITL);
+    nrfy_saadc_event_clear(NRF_SAADC, NRF_SAADC_EVENT_CH0_LIMITH);
     if (m_cb.limits_low_activated & 0x1UL)
     {
         int_mask |= NRF_SAADC_INT_CH0LIMITL;
@@ -779,7 +741,7 @@ static void saadc_pre_calibration_state_restore(void)
     {
         int_mask |= NRF_SAADC_INT_CH0LIMITH;
     }
-    nrf_saadc_int_set(NRF_SAADC, int_mask);
+    nrfy_saadc_int_set(NRF_SAADC, int_mask);
 }
 
 static void saadc_event_started_handle(void)
@@ -792,23 +754,21 @@ static void saadc_event_started_handle(void)
             evt_data.type = NRFX_SAADC_EVT_READY;
             m_cb.event_handler(&evt_data);
 
-            if (nrf_saadc_continuous_mode_enable_check(NRF_SAADC))
+            if (nrfy_saadc_continuous_mode_enable_check(NRF_SAADC))
             {
                 // Trigger internal timer
-                nrf_saadc_task_trigger(NRF_SAADC, NRF_SAADC_TASK_SAMPLE);
+                nrfy_saadc_sample_start(NRF_SAADC, NULL);
             }
 
             m_cb.saadc_state = NRF_SAADC_STATE_ADV_MODE_SAMPLE_STARTED;
-            if (m_cb.p_buffer_secondary)
+            if (m_cb.buffer_secondary.p_buffer)
             {
-                nrf_saadc_buffer_init(NRF_SAADC,
-                                      m_cb.p_buffer_secondary,
-                                      m_cb.size_secondary);
+                nrfy_saadc_buffer_set(NRF_SAADC, &m_cb.buffer_secondary, false, false);
             }
             /* FALLTHROUGH */
 
         case NRF_SAADC_STATE_ADV_MODE_SAMPLE_STARTED:
-            if (!m_cb.p_buffer_secondary)
+            if (!m_cb.buffer_secondary.p_buffer)
             {
                 // Send next buffer request only if it was not provided earlier,
                 // before conversion start or outside of user's callback context.
@@ -818,13 +778,13 @@ static void saadc_event_started_handle(void)
             break;
 
         case NRF_SAADC_STATE_SIMPLE_MODE_SAMPLE:
-            nrf_saadc_task_trigger(NRF_SAADC, NRF_SAADC_TASK_SAMPLE);
+            nrfy_saadc_sample_start(NRF_SAADC, NULL);
             break;
 
         case NRF_SAADC_STATE_CALIBRATION:
             // Stop the SAADC immediately after the temporary buffer is latched to drop spurious samples.
             // This will cause STOPPED and END events to arrive.
-            nrf_saadc_task_trigger(NRF_SAADC, NRF_SAADC_TASK_STOP);
+            nrfy_saadc_stop(NRF_SAADC, false);
             break;
 
         default:
@@ -836,13 +796,13 @@ static void saadc_event_end_handle(void)
 {
     nrfx_saadc_evt_t evt_data;
     evt_data.type = NRFX_SAADC_EVT_DONE;
-    evt_data.data.done.p_buffer = m_cb.p_buffer_primary;
-    evt_data.data.done.size = m_cb.size_primary;
+    evt_data.data.done.p_buffer = m_cb.buffer_primary.p_buffer;
+    evt_data.data.done.size = m_cb.buffer_primary.length;
 
     switch (m_cb.saadc_state)
     {
         case NRF_SAADC_STATE_SIMPLE_MODE_SAMPLE:
-            nrf_saadc_disable(NRF_SAADC);
+            nrfy_saadc_disable(NRF_SAADC);
             m_cb.saadc_state = NRF_SAADC_STATE_SIMPLE_MODE;
             /* In the simple, non-blocking mode the event handler must be
              * called after the internal driver state is updated. This will
@@ -852,17 +812,16 @@ static void saadc_event_end_handle(void)
             break;
 
         case NRF_SAADC_STATE_ADV_MODE_SAMPLE_STARTED:
-            if (m_cb.start_on_end && m_cb.p_buffer_secondary)
+            if (m_cb.start_on_end && m_cb.buffer_secondary.p_buffer)
             {
-                nrf_saadc_task_trigger(NRF_SAADC, NRF_SAADC_TASK_START);
+                nrfy_saadc_buffer_latch(NRF_SAADC, false);
             }
             m_cb.event_handler(&evt_data);
-            m_cb.p_buffer_primary = m_cb.p_buffer_secondary;
-            m_cb.size_primary     = m_cb.size_secondary;
-            m_cb.p_buffer_secondary = NULL;
-            if (!m_cb.p_buffer_primary)
+            m_cb.buffer_primary = m_cb.buffer_secondary;
+            m_cb.buffer_secondary.p_buffer = NULL;
+            if (!m_cb.buffer_primary.p_buffer)
             {
-                nrf_saadc_disable(NRF_SAADC);
+                nrfy_saadc_disable(NRF_SAADC);
                 m_cb.saadc_state = NRF_SAADC_STATE_ADV_MODE;
                 evt_data.type = NRFX_SAADC_EVT_FINISHED;
                 m_cb.event_handler(&evt_data);
@@ -881,50 +840,62 @@ static void saadc_event_end_handle(void)
     }
 }
 
-static void saadc_event_limits_handle(uint8_t limits_activated, nrf_saadc_limit_t limit_type)
+static void saadc_event_limits_handle(void)
 {
-    while (limits_activated)
+    uint32_t limits_activated = nrfy_saadc_int_enable_check(NRF_SAADC,
+                                                            NRF_SAADC_ALL_CHANNELS_LIMITS_INT_MASK);
+    uint32_t limits_triggered = nrfy_saadc_events_process(NRF_SAADC, limits_activated, NULL) >>
+                                NRF_SAADC_LIMITS_INT_OFFSET;
+
+    while (limits_triggered)
     {
-        uint8_t channel = NRF_CTZ((uint32_t)limits_activated);
-        limits_activated &= ~(1 << channel);
+        uint8_t limit = NRF_CTZ((uint32_t)limits_triggered);
+        limits_triggered &= ~(1 << limit);
 
-        nrf_saadc_event_t event = nrf_saadc_limit_event_get(channel, limit_type);
-        if (nrf_saadc_event_check(NRF_SAADC, event))
-        {
-            nrf_saadc_event_clear(NRF_SAADC, event);
+         // There are two limits per channel.
+        uint8_t channel = limit / 2;
 
-            nrfx_saadc_evt_t evt_data;
-            evt_data.type = NRFX_SAADC_EVT_LIMIT;
-            evt_data.data.limit.channel = channel;
-            evt_data.data.limit.limit_type = limit_type;
-            m_cb.event_handler(&evt_data);
-        }
+        // Limits are organised into single pair (high limit and low limit) per channel.
+        // Do not assume whether high limit or low limit is first in the bitmask.
+        nrf_saadc_limit_t limit_type =
+            ((limit & 0x1) == (NRFY_EVENT_TO_INT_BITPOS(NRF_SAADC_EVENT_CH0_LIMITH) & 0x1)) ?
+            NRF_SAADC_LIMIT_HIGH : NRF_SAADC_LIMIT_LOW;
+
+        nrfx_saadc_evt_t evt_data;
+        evt_data.type = NRFX_SAADC_EVT_LIMIT;
+        evt_data.data.limit.channel = channel;
+        evt_data.data.limit.limit_type = limit_type;
+        m_cb.event_handler(&evt_data);
     }
 }
 
 void nrfx_saadc_irq_handler(void)
 {
-    if (nrf_saadc_event_check(NRF_SAADC, NRF_SAADC_EVENT_CALIBRATEDONE))
+    uint32_t evt_mask = NRFY_EVENT_TO_INT_BITMASK(NRF_SAADC_EVENT_STARTED) |
+                        NRFY_EVENT_TO_INT_BITMASK(NRF_SAADC_EVENT_STOPPED) |
+                        NRFY_EVENT_TO_INT_BITMASK(NRF_SAADC_EVENT_END) |
+                        NRFY_EVENT_TO_INT_BITMASK(NRF_SAADC_EVENT_CALIBRATEDONE);
+    evt_mask = nrfy_saadc_events_process(NRF_SAADC, evt_mask, &m_cb.buffer_primary);
+
+    if (evt_mask & NRFY_EVENT_TO_INT_BITMASK(NRF_SAADC_EVENT_CALIBRATEDONE))
     {
-        nrf_saadc_event_clear(NRF_SAADC, NRF_SAADC_EVENT_CALIBRATEDONE);
-        nrf_saadc_int_disable(NRF_SAADC, NRF_SAADC_INT_CALIBRATEDONE);
+        nrfy_saadc_int_disable(NRF_SAADC, NRF_SAADC_INT_CALIBRATEDONE);
         // Latch the temporary buffer to intercept any spurious samples that may appear after calibration.
-        nrf_saadc_buffer_init(NRF_SAADC, m_cb.calib_samples, NRFX_ARRAY_SIZE(m_cb.calib_samples));
-        nrf_saadc_task_trigger(NRF_SAADC, NRF_SAADC_TASK_START);
+        nrfy_saadc_buffer_t calib_buffer = {.p_buffer = m_cb.calib_samples,
+                                            .length  = NRFX_ARRAY_SIZE(m_cb.calib_samples)};
+        nrfy_saadc_buffer_set(NRF_SAADC, &calib_buffer, true, false);
     }
 
-    if (nrf_saadc_event_check(NRF_SAADC, NRF_SAADC_EVENT_STOPPED))
+    if (evt_mask & NRFY_EVENT_TO_INT_BITMASK(NRF_SAADC_EVENT_STOPPED))
     {
-        nrf_saadc_event_clear(NRF_SAADC, NRF_SAADC_EVENT_STOPPED);
-
         if (m_cb.saadc_state != NRF_SAADC_STATE_CALIBRATION)
         {
             // If there was ongoing conversion the STOP task also triggers the END event
-            m_cb.size_primary = nrf_saadc_amount_get(NRF_SAADC);
-            m_cb.p_buffer_secondary = NULL;
+            m_cb.buffer_primary.length = nrfy_saadc_amount_get(NRF_SAADC);
+            m_cb.buffer_secondary.p_buffer = NULL;
         }
 
-        if (nrf_saadc_int_enable_check(NRF_SAADC, NRF_SAADC_INT_CALIBRATEDONE))
+        if (nrfy_saadc_int_enable_check(NRF_SAADC, NRF_SAADC_INT_CALIBRATEDONE))
         {
             // If STOP event arrived before CALIBRATEDONE then the calibration was aborted
             // and END event will not appear.
@@ -934,22 +905,20 @@ void nrfx_saadc_irq_handler(void)
         /* fall-through to the END event handler */
     }
 
-    if (nrf_saadc_event_check(NRF_SAADC, NRF_SAADC_EVENT_END))
+    if (evt_mask & NRFY_EVENT_TO_INT_BITMASK(NRF_SAADC_EVENT_END))
     {
-        nrf_saadc_event_clear(NRF_SAADC, NRF_SAADC_EVENT_END);
         saadc_event_end_handle();
     }
 
-    if (nrf_saadc_event_check(NRF_SAADC, NRF_SAADC_EVENT_STARTED))
+    if (evt_mask & NRFY_EVENT_TO_INT_BITMASK(NRF_SAADC_EVENT_STARTED))
     {
-        nrf_saadc_event_clear(NRF_SAADC, NRF_SAADC_EVENT_STARTED);
         saadc_event_started_handle();
     }
 
     if (m_cb.saadc_state != NRF_SAADC_STATE_CALIBRATION)
     {
-        saadc_event_limits_handle(m_cb.limits_low_activated,  NRF_SAADC_LIMIT_LOW);
-        saadc_event_limits_handle(m_cb.limits_high_activated, NRF_SAADC_LIMIT_HIGH);
+        saadc_event_limits_handle();
     }
 }
+
 #endif // NRFX_CHECK(NRFX_SAADC_ENABLED)

--- a/nrfx/drivers/src/nrfx_spis.c
+++ b/nrfx/drivers/src/nrfx_spis.c
@@ -35,10 +35,7 @@
 
 #if NRFX_CHECK(NRFX_SPIS_ENABLED)
 
-#if !(NRFX_CHECK(NRFX_SPIS0_ENABLED) || \
-      NRFX_CHECK(NRFX_SPIS1_ENABLED) || \
-      NRFX_CHECK(NRFX_SPIS2_ENABLED) || \
-      NRFX_CHECK(NRFX_SPIS3_ENABLED))
+#if !NRFX_FEATURE_PRESENT(NRFX_SPIS, _ENABLED)
 #error "No enabled SPIS instances. Check <nrfx_config.h>."
 #endif
 
@@ -53,40 +50,12 @@
     (event == NRF_SPIS_EVENT_END      ? "NRF_SPIS_EVENT_END"      : \
                                         "UNKNOWN ERROR"))
 
-#define SPISX_LENGTH_VALIDATE(peripheral, drv_inst_idx, rx_len, tx_len) \
-    (((drv_inst_idx) == NRFX_CONCAT_3(NRFX_, peripheral, _INST_IDX)) && \
-     NRFX_EASYDMA_LENGTH_VALIDATE(peripheral, rx_len, tx_len))
+#define SPISX_LENGTH_VALIDATE(periph_name, prefix, i, drv_inst_idx, rx_len, tx_len) \
+    (((drv_inst_idx) == NRFX_CONCAT(NRFX_, periph_name, prefix, i, _INST_IDX)) && \
+     NRFX_EASYDMA_LENGTH_VALIDATE(NRFX_CONCAT(periph_name, prefix, i), rx_len, tx_len))
 
-#if NRFX_CHECK(NRFX_SPIS0_ENABLED)
-#define SPIS0_LENGTH_VALIDATE(...)  SPISX_LENGTH_VALIDATE(SPIS0, __VA_ARGS__)
-#else
-#define SPIS0_LENGTH_VALIDATE(...)  0
-#endif
-
-#if NRFX_CHECK(NRFX_SPIS1_ENABLED)
-#define SPIS1_LENGTH_VALIDATE(...)  SPISX_LENGTH_VALIDATE(SPIS1, __VA_ARGS__)
-#else
-#define SPIS1_LENGTH_VALIDATE(...)  0
-#endif
-
-#if NRFX_CHECK(NRFX_SPIS2_ENABLED)
-#define SPIS2_LENGTH_VALIDATE(...)  SPISX_LENGTH_VALIDATE(SPIS2, __VA_ARGS__)
-#else
-#define SPIS2_LENGTH_VALIDATE(...)  0
-#endif
-
-#if NRFX_CHECK(NRFX_SPIS3_ENABLED)
-#define SPIS3_LENGTH_VALIDATE(...)  SPISX_LENGTH_VALIDATE(SPIS3, __VA_ARGS__)
-#else
-#define SPIS3_LENGTH_VALIDATE(...)  0
-#endif
-
-#define SPIS_LENGTH_VALIDATE(drv_inst_idx, rx_len, tx_len)  \
-    (SPIS0_LENGTH_VALIDATE(drv_inst_idx, rx_len, tx_len) || \
-     SPIS1_LENGTH_VALIDATE(drv_inst_idx, rx_len, tx_len) || \
-     SPIS2_LENGTH_VALIDATE(drv_inst_idx, rx_len, tx_len) || \
-     SPIS3_LENGTH_VALIDATE(drv_inst_idx, rx_len, tx_len))
-
+#define SPIS_LENGTH_VALIDATE(drv_inst_idx, rx_len, tx_len)    \
+        (NRFX_FOREACH_ENABLED(SPIS, SPISX_LENGTH_VALIDATE, (||), (0), drv_inst_idx, rx_len, tx_len))
 
 #if NRFX_CHECK(NRFX_SPIS_NRF52_ANOMALY_109_WORKAROUND_ENABLED)
 #include <nrfx_gpiote.h>
@@ -95,8 +64,12 @@
 // on the CSN line. There is no need to do anything here. The handling of the
 // interrupt itself provides a protection for DMA transfers.
 static void csn_event_handler(nrfx_gpiote_pin_t     pin,
-                              nrf_gpiote_polarity_t action)
+                              nrfx_gpiote_trigger_t trigger,
+                              void *                p_context)
 {
+    (void)pin;
+    (void)trigger;
+    (void)p_context;
 }
 #endif
 
@@ -126,8 +99,7 @@ typedef struct
 
 static spis_cb_t m_cb[NRFX_SPIS_ENABLED_COUNT];
 
-static void configure_pins(NRF_SPIS_Type *            p_spis,
-                           nrfx_spis_config_t const * p_config)
+static nrfx_err_t pins_configure(nrfx_spis_config_t const * p_config)
 {
     if (!p_config->skip_gpio_cfg)
     {
@@ -137,8 +109,11 @@ static void configure_pins(NRF_SPIS_Type *            p_spis,
                      NRF_GPIO_PIN_NOPULL,
                      NRF_GPIO_PIN_S0S1,
                      NRF_GPIO_PIN_NOSENSE);
+#if NRF_GPIO_HAS_CLOCKPIN
+        nrfy_gpio_pin_clock_set(p_config->sck_pin, true);
+#endif
 
-        if (p_config->mosi_pin != NRFX_SPIS_PIN_NOT_USED)
+        if (p_config->mosi_pin != NRF_SPIS_PIN_NOT_CONNECTED)
         {
             nrf_gpio_cfg(p_config->mosi_pin,
                          NRF_GPIO_PIN_DIR_INPUT,
@@ -148,7 +123,7 @@ static void configure_pins(NRF_SPIS_Type *            p_spis,
                          NRF_GPIO_PIN_NOSENSE);
         }
 
-        if (p_config->miso_pin != NRFX_SPIS_PIN_NOT_USED)
+        if (p_config->miso_pin != NRF_SPIS_PIN_NOT_CONNECTED)
         {
             nrf_gpio_cfg(p_config->miso_pin,
                          NRF_GPIO_PIN_DIR_INPUT,
@@ -164,23 +139,97 @@ static void configure_pins(NRF_SPIS_Type *            p_spis,
                      p_config->csn_pullup,
                      NRF_GPIO_PIN_S0S1,
                      NRF_GPIO_PIN_NOSENSE);
+
+#if defined(USE_DMA_ISSUE_WORKAROUND)
+        // Configure a GPIOTE channel to generate interrupts on each falling edge
+        // on the CSN line. Handling of these interrupts will make the CPU active,
+        // and thus will protect the DMA transfers started by SPIS right after it
+        // is selected for communication.
+        // [the GPIOTE driver may be already initialized at this point (by this
+        //  driver when another SPIS instance is used, or by an application code),
+        //  so just ignore the returned value]
+        (void)nrfx_gpiote_init(NRFX_GPIOTE_DEFAULT_CONFIG_IRQ_PRIORITY);
+
+        uint8_t ch;
+        nrfx_err_t err_code;
+
+        err_code = nrfx_gpiote_channel_alloc(&ch);
+        if (err_code != NRFX_SUCCESS)
+        {
+            NRFX_LOG_ERROR("Function: %s, error code: %s.",
+                           __func__,
+                           NRFX_LOG_ERROR_STRING_GET(err_code));
+            return err_code;
+        }
+
+        nrfx_gpiote_trigger_config_t trigger_config = {
+            .trigger = NRFX_GPIOTE_TRIGGER_HITOLO,
+            .p_in_channel = &ch
+        };
+        nrfx_gpiote_handler_config_t handler_config = {
+            .handler = csn_event_handler
+        };
+
+        err_code = nrfx_gpiote_input_configure(p_config->csn_pin,
+                                               NULL,
+                                               &trigger_config,
+                                               &handler_config);
+        if (err_code != NRFX_SUCCESS)
+        {
+            NRFX_LOG_ERROR("Function: %s, error code: %s.",
+                           __func__,
+                           NRFX_LOG_ERROR_STRING_GET(err_code));
+            return err_code;
+        }
+
+        nrfx_gpiote_trigger_enable(p_config->csn_pin, true);
+#endif
+    }
+
+    return NRFX_SUCCESS;
+}
+
+static bool spis_configure(nrfx_spis_t const *        p_instance,
+                           nrfx_spis_config_t const * p_config)
+{
+    NRF_SPIS_Type * p_spis = p_instance->p_reg;
+    if (p_config->mode > NRF_SPIS_MODE_3)
+    {
+        return false;
+    }
+
+    if (pins_configure(p_config) != NRFX_SUCCESS)
+    {
+        return false;
     }
 
     if (!p_config->skip_psel_cfg)
     {
-        uint32_t mosi_pin = (p_config->mosi_pin != NRFX_SPIS_PIN_NOT_USED)
-                            ? p_config->mosi_pin
-                            : NRF_SPIS_PIN_NOT_CONNECTED;
-        uint32_t miso_pin = (p_config->miso_pin != NRFX_SPIS_PIN_NOT_USED)
-                            ? p_config->miso_pin
-                            : NRF_SPIS_PIN_NOT_CONNECTED;
-
         nrf_spis_pins_set(p_spis,
                           p_config->sck_pin,
-                          mosi_pin,
-                          miso_pin,
+                          p_config->mosi_pin,
+                          p_config->miso_pin,
                           p_config->csn_pin);
     }
+
+    // Configure SPI mode.
+    nrf_spis_configure(p_spis, p_config->mode, p_config->bit_order);
+
+    // Configure DEF and ORC characters.
+    nrf_spis_def_set(p_spis, p_config->def);
+    nrf_spis_orc_set(p_spis, p_config->orc);
+
+    // Clear possible pending events.
+    nrf_spis_event_clear(p_spis, NRF_SPIS_EVENT_END);
+    nrf_spis_event_clear(p_spis, NRF_SPIS_EVENT_ACQUIRED);
+
+    // Enable END_ACQUIRE shortcut.
+    nrf_spis_shorts_enable(p_spis, NRF_SPIS_SHORT_END_ACQUIRE);
+
+    NRFX_IRQ_PRIORITY_SET(nrfx_get_irq_number(p_instance->p_reg), p_config->irq_priority);
+    NRFX_IRQ_ENABLE(nrfx_get_irq_number(p_instance->p_reg));
+
+    return true;
 }
 
 nrfx_err_t nrfx_spis_init(nrfx_spis_t const *        p_instance,
@@ -204,28 +253,9 @@ nrfx_err_t nrfx_spis_init(nrfx_spis_t const *        p_instance,
         return err_code;
     }
 
-    if ((uint32_t)p_config->mode > (uint32_t)NRF_SPIS_MODE_3)
-    {
-        err_code = NRFX_ERROR_INVALID_PARAM;
-        NRFX_LOG_WARNING("Function: %s, error code: %s.",
-                         __func__,
-                         NRFX_LOG_ERROR_STRING_GET(err_code));
-        return err_code;
-    }
 #if NRFX_CHECK(NRFX_PRS_ENABLED)
     static nrfx_irq_handler_t const irq_handlers[NRFX_SPIS_ENABLED_COUNT] = {
-        #if NRFX_CHECK(NRFX_SPIS0_ENABLED)
-        nrfx_spis_0_irq_handler,
-        #endif
-        #if NRFX_CHECK(NRFX_SPIS1_ENABLED)
-        nrfx_spis_1_irq_handler,
-        #endif
-        #if NRFX_CHECK(NRFX_SPIS2_ENABLED)
-        nrfx_spis_2_irq_handler,
-        #endif
-        #if NRFX_CHECK(NRFX_SPIS3_ENABLED)
-        nrfx_spis_3_irq_handler,
-        #endif
+        NRFX_INSTANCE_IRQ_HANDLERS_LIST(SPIS, spis)
     };
     if (nrfx_prs_acquire(p_spis,
             irq_handlers[p_instance->drv_inst_idx]) != NRFX_SUCCESS)
@@ -238,61 +268,30 @@ nrfx_err_t nrfx_spis_init(nrfx_spis_t const *        p_instance,
     }
 #endif // NRFX_CHECK(NRFX_PRS_ENABLED)
 
-    p_cb->skip_gpio_cfg = p_config->skip_gpio_cfg;
+    p_cb->handler   = event_handler;
+    p_cb->p_context = p_context;
 
-    configure_pins(p_spis, p_config);
+    if (p_config)
+    {
+        p_cb->skip_gpio_cfg = p_config->skip_gpio_cfg;
+
+        if (!spis_configure(p_instance, p_config))
+        {
+            err_code = NRFX_ERROR_INVALID_PARAM;
+            NRFX_LOG_WARNING("Function: %s, error code: %s.",
+                            __func__,
+                            NRFX_LOG_ERROR_STRING_GET(err_code));
+            return err_code;
+        }
+    }
 
     nrf_spis_rx_buffer_set(p_spis, NULL, 0);
     nrf_spis_tx_buffer_set(p_spis, NULL, 0);
 
-    // Configure SPI mode.
-    nrf_spis_configure(p_spis, p_config->mode, p_config->bit_order);
-
-    // Configure DEF and ORC characters.
-    nrf_spis_def_set(p_spis, p_config->def);
-    nrf_spis_orc_set(p_spis, p_config->orc);
-
-    // Clear possible pending events.
-    nrf_spis_event_clear(p_spis, NRF_SPIS_EVENT_END);
-    nrf_spis_event_clear(p_spis, NRF_SPIS_EVENT_ACQUIRED);
-
-    // Enable END_ACQUIRE shortcut.
-    nrf_spis_shorts_enable(p_spis, NRF_SPIS_SHORT_END_ACQUIRE);
-
     p_cb->spi_state = SPIS_STATE_INIT;
-    p_cb->handler   = event_handler;
-    p_cb->p_context = p_context;
-
-#if defined(USE_DMA_ISSUE_WORKAROUND)
-    // Configure a GPIOTE channel to generate interrupts on each falling edge
-    // on the CSN line. Handling of these interrupts will make the CPU active,
-    // and thus will protect the DMA transfers started by SPIS right after it
-    // is selected for communication.
-    // [the GPIOTE driver may be already initialized at this point (by this
-    //  driver when another SPIS instance is used, or by an application code),
-    //  so just ignore the returned value]
-    (void)nrfx_gpiote_init(NRFX_GPIOTE_DEFAULT_CONFIG_IRQ_PRIORITY);
-    static nrfx_gpiote_in_config_t const csn_gpiote_config =
-        NRFX_GPIOTE_CONFIG_IN_SENSE_HITOLO(true);
-    nrfx_err_t gpiote_err_code = nrfx_gpiote_in_init(p_config->csn_pin,
-        &csn_gpiote_config, csn_event_handler);
-    if (gpiote_err_code != NRFX_SUCCESS)
-    {
-        err_code = NRFX_ERROR_INTERNAL;
-        NRFX_LOG_INFO("Function: %s, error code: %s.",
-                      __func__,
-                      NRFX_LOG_ERROR_STRING_GET(err_code));
-        return err_code;
-    }
-    nrfx_gpiote_in_event_enable(p_config->csn_pin, true);
-#endif
-
     // Enable IRQ.
     nrf_spis_int_enable(p_spis, NRF_SPIS_INT_ACQUIRED_MASK |
                                 NRF_SPIS_INT_END_MASK);
-    NRFX_IRQ_PRIORITY_SET(nrfx_get_irq_number(p_instance->p_reg),
-        p_config->irq_priority);
-    NRFX_IRQ_ENABLE(nrfx_get_irq_number(p_instance->p_reg));
 
     p_cb->state = NRFX_DRV_STATE_INITIALIZED;
 
@@ -303,6 +302,29 @@ nrfx_err_t nrfx_spis_init(nrfx_spis_t const *        p_instance,
     return NRFX_SUCCESS;
 }
 
+nrfx_err_t nrfx_spis_reconfigure(nrfx_spis_t const *        p_instance,
+                                 nrfx_spis_config_t const * p_config)
+{
+    NRFX_ASSERT(p_config);
+    nrfx_err_t err_code;
+    spis_cb_t * p_cb = &m_cb[p_instance->drv_inst_idx];
+
+    if (p_cb->state == NRFX_DRV_STATE_UNINITIALIZED)
+    {
+        return NRFX_ERROR_INVALID_STATE;
+    }
+    nrf_spis_disable(p_instance->p_reg);
+    if (spis_configure(p_instance, p_config))
+    {
+        err_code = NRFX_SUCCESS;
+    }
+    else
+    {
+        err_code = NRFX_ERROR_INVALID_PARAM;
+    }
+    nrf_spis_enable(p_instance->p_reg);
+    return err_code;
+}
 
 void nrfx_spis_uninit(nrfx_spis_t const * p_instance)
 {
@@ -456,7 +478,7 @@ nrfx_err_t nrfx_spis_buffers_set(nrfx_spis_t const * p_instance,
     return err_code;
 }
 
-static void spis_irq_handler(NRF_SPIS_Type * p_spis, spis_cb_t * p_cb)
+static void irq_handler(NRF_SPIS_Type * p_spis, spis_cb_t * p_cb)
 {
     // @note: as multiple events can be pending for processing, the correct event processing order
     // is as follows:
@@ -505,32 +527,6 @@ static void spis_irq_handler(NRF_SPIS_Type * p_spis, spis_cb_t * p_cb)
     }
 }
 
-#if NRFX_CHECK(NRFX_SPIS0_ENABLED)
-void nrfx_spis_0_irq_handler(void)
-{
-    spis_irq_handler(NRF_SPIS0, &m_cb[NRFX_SPIS0_INST_IDX]);
-}
-#endif
-
-#if NRFX_CHECK(NRFX_SPIS1_ENABLED)
-void nrfx_spis_1_irq_handler(void)
-{
-    spis_irq_handler(NRF_SPIS1, &m_cb[NRFX_SPIS1_INST_IDX]);
-}
-#endif
-
-#if NRFX_CHECK(NRFX_SPIS2_ENABLED)
-void nrfx_spis_2_irq_handler(void)
-{
-    spis_irq_handler(NRF_SPIS2, &m_cb[NRFX_SPIS2_INST_IDX]);
-}
-#endif
-
-#if NRFX_CHECK(NRFX_SPIS3_ENABLED)
-void nrfx_spis_3_irq_handler(void)
-{
-    spis_irq_handler(NRF_SPIS3, &m_cb[NRFX_SPIS3_INST_IDX]);
-}
-#endif
+NRFX_INSTANCE_IRQ_HANDLERS(SPIS, spis)
 
 #endif // NRFX_CHECK(NRFX_SPIS_ENABLED)

--- a/nrfx/drivers/src/nrfx_systick.c
+++ b/nrfx/drivers/src/nrfx_systick.c
@@ -65,7 +65,7 @@
  *
  * See @ref nrfx_systick_delay_ms source code for details.
  */
-#define NRFX_SYSTICK_MS_STEP (64U)
+#define NRFX_SYSTICK_MS_STEP (NRFX_SYSTICK_TICKS_MAX / (SystemCoreClock / NRFX_SYSTICK_MS))
 
 /**
  * @brief Checks if the given time is in correct range

--- a/nrfx/drivers/src/nrfx_temp.c
+++ b/nrfx/drivers/src/nrfx_temp.c
@@ -47,10 +47,10 @@
 #define NRFX_TEMP_TIME_US 4
 
 /** @brief Maximum attempts to check whether conversion passed.*/
-#define NRFX_TEMP_ATTEMPTS 10
+#define NRFX_TEMP_ATTEMPTS 100
 
 /** @brief Internal state of TEMP driver. */
-static nrfx_drv_state_t m_temp_state;
+static nrfx_drv_state_t m_temp_state = NRFX_DRV_STATE_UNINITIALIZED;
 
 /** @brief Pointer to handler to be called from interrupt routine. */
 static nrfx_temp_data_handler_t m_data_handler;
@@ -72,9 +72,7 @@ nrfx_err_t nrfx_temp_init(nrfx_temp_config_t const * p_config, nrfx_temp_data_ha
 
     if (m_data_handler)
     {
-        nrf_temp_int_enable(NRF_TEMP, NRF_TEMP_INT_DATARDY_MASK);
-        NRFX_IRQ_PRIORITY_SET(TEMP_IRQn, p_config->interrupt_priority);
-        NRFX_IRQ_ENABLE(TEMP_IRQn);
+        nrfy_temp_int_init(NRF_TEMP, 0, p_config->interrupt_priority, true);
     }
 
     m_temp_state = NRFX_DRV_STATE_INITIALIZED;
@@ -84,12 +82,12 @@ nrfx_err_t nrfx_temp_init(nrfx_temp_config_t const * p_config, nrfx_temp_data_ha
 void nrfx_temp_uninit(void)
 {
     NRFX_ASSERT(m_temp_state == NRFX_DRV_STATE_INITIALIZED);
-    nrf_temp_task_trigger(NRF_TEMP, NRF_TEMP_TASK_STOP);
 
+    nrfy_temp_task_trigger(NRF_TEMP, NRF_TEMP_TASK_STOP);
     if (m_data_handler)
     {
-        nrf_temp_int_disable(NRF_TEMP, NRF_TEMP_INT_DATARDY_MASK);
-        NRFX_IRQ_DISABLE(TEMP_IRQn);
+        nrfy_temp_int_disable(NRF_TEMP, NRF_TEMP_INT_DATARDY_MASK);
+        nrfy_temp_int_uninit(NRF_TEMP);
     }
 
     m_temp_state = NRFX_DRV_STATE_UNINITIALIZED;
@@ -109,13 +107,14 @@ nrfx_err_t nrfx_temp_measure(void)
     NRFX_ASSERT(m_temp_state == NRFX_DRV_STATE_INITIALIZED);
 
     nrfx_err_t result = NRFX_SUCCESS;
-    nrf_temp_event_clear(NRF_TEMP, NRF_TEMP_EVENT_DATARDY);
-    nrf_temp_task_trigger(NRF_TEMP, NRF_TEMP_TASK_START);
+
+    nrfy_temp_event_clear(NRF_TEMP, NRF_TEMP_EVENT_DATARDY);
+    nrfy_temp_task_trigger(NRF_TEMP, NRF_TEMP_TASK_START);
 
     if (!m_data_handler)
     {
         bool ev_result;
-        NRFX_WAIT_FOR(nrf_temp_event_check(NRF_TEMP, NRF_TEMP_EVENT_DATARDY),
+        NRFX_WAIT_FOR(nrfy_temp_event_check(NRF_TEMP, NRF_TEMP_EVENT_DATARDY),
                       NRFX_TEMP_ATTEMPTS,
                       NRFX_TEMP_TIME_US,
                       ev_result);
@@ -125,9 +124,9 @@ nrfx_err_t nrfx_temp_measure(void)
         }
         else
         {
-            nrf_temp_event_clear(NRF_TEMP, NRF_TEMP_EVENT_DATARDY);
+            nrfy_temp_event_clear(NRF_TEMP, NRF_TEMP_EVENT_DATARDY);
         }
-        nrf_temp_task_trigger(NRF_TEMP, NRF_TEMP_TASK_STOP);
+        nrfy_temp_task_trigger(NRF_TEMP, NRF_TEMP_TASK_STOP);
     }
 
     return result;
@@ -140,8 +139,7 @@ void nrfx_temp_irq_handler(void)
     nrf_temp_task_trigger(NRF_TEMP, NRF_TEMP_TASK_STOP);
     nrf_temp_event_clear(NRF_TEMP, NRF_TEMP_EVENT_DATARDY);
 
-    uint32_t raw_temp = nrfx_temp_result_get();
-
+    int32_t raw_temp = nrfx_temp_result_get();
     m_data_handler(raw_temp);
 }
 

--- a/nrfx/drivers/src/nrfx_twis.c
+++ b/nrfx/drivers/src/nrfx_twis.c
@@ -35,10 +35,7 @@
 
 #if NRFX_CHECK(NRFX_TWIS_ENABLED)
 
-#if !(NRFX_CHECK(NRFX_TWIS0_ENABLED) || \
-      NRFX_CHECK(NRFX_TWIS1_ENABLED) || \
-      NRFX_CHECK(NRFX_TWIS2_ENABLED) || \
-      NRFX_CHECK(NRFX_TWIS3_ENABLED))
+#if !NRFX_FEATURE_PRESENT(NRFX_TWIS, _ENABLED)
 #error "No enabled TWIS instances. Check <nrfx_config.h>."
 #endif
 
@@ -246,8 +243,7 @@ static inline void nrfx_twis_process_error(twis_control_block_t * p_cb,
     call_event_handler(p_cb, &evdata);
 }
 
-static void nrfx_twis_state_machine(NRF_TWIS_Type *        p_reg,
-                                    twis_control_block_t * p_cb)
+static void irq_handler(NRF_TWIS_Type * p_reg, twis_control_block_t * p_cb)
 {
     if (!NRFX_TWIS_NO_SYNC_MODE)
     {
@@ -440,11 +436,49 @@ static inline void nrfx_twis_preprocess_status(nrfx_twis_t const * p_instance)
         twis_control_block_t * p_cb  = &m_cb[p_instance->drv_inst_idx];
         if (NULL == p_cb->ev_handler)
         {
-            nrfx_twis_state_machine(p_reg, p_cb);
+            irq_handler(p_reg, p_cb);
         }
     }
 }
 
+static void twis_configure(nrfx_twis_t const *        p_instance,
+                           nrfx_twis_config_t const * p_config)
+{
+    uint32_t addr_mask = 0;
+    if (0 == (p_config->addr[0] | p_config->addr[1]))
+    {
+        addr_mask = NRF_TWIS_CONFIG_ADDRESS0_MASK;
+    }
+    else
+    {
+        if (0 != p_config->addr[0])
+        {
+            addr_mask |= NRF_TWIS_CONFIG_ADDRESS0_MASK;
+        }
+        if (0 != p_config->addr[1])
+        {
+            addr_mask |= NRF_TWIS_CONFIG_ADDRESS1_MASK;
+        }
+    }
+
+    if (!p_config->skip_psel_cfg)
+    {
+        nrf_twis_pins_set(p_instance->p_reg, p_config->scl_pin, p_config->sda_pin);
+    }
+    nrf_twis_address_set(p_instance->p_reg, 0, p_config->addr[0]);
+    nrf_twis_address_set(p_instance->p_reg, 1, p_config->addr[1]);
+    nrf_twis_config_address_set(p_instance->p_reg, (nrf_twis_config_addr_mask_t)addr_mask);
+
+    if (m_cb[p_instance->drv_inst_idx].ev_handler)
+    {
+        /* Peripheral interrupt configure
+        * (note - interrupts still needs to be configured in INTEN register.
+        * This is done in enable function) */
+        NRFX_IRQ_PRIORITY_SET(nrfx_get_irq_number(p_instance->p_reg),
+                              p_config->interrupt_priority);
+        NRFX_IRQ_ENABLE(nrfx_get_irq_number(p_instance->p_reg));
+    }
+}
 
 /* -------------------------------------------------------------------------
  * Implementation of interface functions
@@ -473,18 +507,7 @@ nrfx_err_t nrfx_twis_init(nrfx_twis_t const *        p_instance,
 
 #if NRFX_CHECK(NRFX_PRS_ENABLED)
     static nrfx_irq_handler_t const irq_handlers[NRFX_TWIS_ENABLED_COUNT] = {
-        #if NRFX_CHECK(NRFX_TWIS0_ENABLED)
-        nrfx_twis_0_irq_handler,
-        #endif
-        #if NRFX_CHECK(NRFX_TWIS1_ENABLED)
-        nrfx_twis_1_irq_handler,
-        #endif
-        #if NRFX_CHECK(NRFX_TWIS2_ENABLED)
-        nrfx_twis_2_irq_handler,
-        #endif
-        #if NRFX_CHECK(NRFX_TWIS3_ENABLED)
-        nrfx_twis_3_irq_handler,
-        #endif
+        NRFX_INSTANCE_IRQ_HANDLERS_LIST(TWIS, twis)
     };
     if (nrfx_prs_acquire(p_reg,
             irq_handlers[p_instance->drv_inst_idx]) != NRFX_SUCCESS)
@@ -502,47 +525,21 @@ nrfx_err_t nrfx_twis_init(nrfx_twis_t const *        p_instance,
         nrfx_twis_swreset(p_reg);
     }
 
-    p_cb->skip_gpio_cfg = p_config->skip_gpio_cfg;
-
-    if (!p_config->skip_gpio_cfg)
+    p_cb->ev_handler = event_handler;
+    if (p_config)
     {
-        nrfx_twis_config_pin(p_config->scl, p_config->scl_pull);
-        nrfx_twis_config_pin(p_config->sda, p_config->sda_pull);
-    }
-
-    if (!p_config->skip_psel_cfg)
-    {
-        nrf_twis_pins_set(p_reg, p_config->scl, p_config->sda);
-    }
-
-    uint32_t addr_mask = 0;
-    if (0 == (p_config->addr[0] | p_config->addr[1]))
-    {
-        addr_mask = NRF_TWIS_CONFIG_ADDRESS0_MASK;
-    }
-    else
-    {
-        if (0 != p_config->addr[0])
+        p_cb->skip_gpio_cfg = p_config->skip_gpio_cfg;
+        if (!p_config->skip_gpio_cfg)
         {
-            addr_mask |= NRF_TWIS_CONFIG_ADDRESS0_MASK;
+            NRFX_ASSERT(p_config->scl_pin != p_config->sda_pin);
+            nrfx_twis_config_pin(p_config->scl_pin, p_config->scl_pull);
+            nrfx_twis_config_pin(p_config->sda_pin, p_config->sda_pull);
+#if NRF_GPIO_HAS_CLOCKPIN
+            nrf_gpio_pin_clock_set(p_config->scl_pin, true);
+#endif
         }
-        if (0 != p_config->addr[1])
-        {
-            addr_mask |= NRF_TWIS_CONFIG_ADDRESS1_MASK;
-        }
+        twis_configure(p_instance, p_config);
     }
-
-    /* Peripheral interrupt configure
-     * (note - interrupts still needs to be configured in INTEN register.
-     * This is done in enable function) */
-    NRFX_IRQ_PRIORITY_SET(nrfx_get_irq_number(p_reg),
-                          p_config->interrupt_priority);
-    NRFX_IRQ_ENABLE(nrfx_get_irq_number(p_reg));
-
-    /* Configure */
-    nrf_twis_address_set       (p_reg, 0, p_config->addr[0]);
-    nrf_twis_address_set       (p_reg, 1, p_config->addr[1]);
-    nrf_twis_config_address_set(p_reg, (nrf_twis_config_addr_mask_t)addr_mask);
 
     /* Clear semaphore */
     if (!NRFX_TWIS_NO_SYNC_MODE)
@@ -551,13 +548,29 @@ nrfx_err_t nrfx_twis_init(nrfx_twis_t const *        p_instance,
     }
     /* Set internal instance variables */
     p_cb->substate   = NRFX_TWIS_SUBSTATE_IDLE;
-    p_cb->ev_handler = event_handler;
     p_cb->state      = NRFX_DRV_STATE_INITIALIZED;
     err_code = NRFX_SUCCESS;
     NRFX_LOG_INFO("Function: %s, error code: %s.", __func__, NRFX_LOG_ERROR_STRING_GET(err_code));
     return err_code;
 }
 
+nrfx_err_t nrfx_twis_reconfigure(nrfx_twis_t const *        p_instance,
+                                 nrfx_twis_config_t const * p_config)
+{
+    NRFX_ASSERT(p_config);
+    if (m_cb[p_instance->drv_inst_idx].state == NRFX_DRV_STATE_UNINITIALIZED)
+    {
+        return NRFX_ERROR_INVALID_STATE;
+    }
+    if (nrfx_twis_is_busy(p_instance))
+    {
+        return NRFX_ERROR_BUSY;
+    }
+    nrf_twis_disable(p_instance->p_reg);
+    twis_configure(p_instance, p_config);
+    nrf_twis_enable(p_instance->p_reg);
+    return NRFX_SUCCESS;
+}
 
 void nrfx_twis_uninit(nrfx_twis_t const * p_instance)
 {
@@ -636,7 +649,7 @@ nrfx_twis_error_get_and_clear_internal_try
     bne   nrfx_twis_error_get_and_clear_internal_try /* no - try again          */
     bx    lr
 }
-#elif defined ( __GNUC__ )
+#elif defined ( __GNUC__ ) && defined(ISA_ARM)
 static uint32_t nrfx_twis_error_get_and_clear_internal(uint32_t volatile * perror)
 {
     uint32_t ret;
@@ -657,6 +670,13 @@ static uint32_t nrfx_twis_error_get_and_clear_internal(uint32_t volatile * perro
     );
     (void)temp;
     return ret;
+}
+#elif defined ( __GNUC__ ) && defined(ISA_RISCV)
+static uint32_t nrfx_twis_error_get_and_clear_internal(uint32_t volatile * perror)
+{
+    uint32_t error = *perror;
+    *perror = 0;
+    return error;
 }
 #elif defined ( __ICCARM__ )
 static uint32_t nrfx_twis_error_get_and_clear_internal(uint32_t volatile * perror)
@@ -719,7 +739,12 @@ nrfx_err_t nrfx_twis_tx_prepare(nrfx_twis_t const * p_instance,
         return err_code;
     }
     /* Check data size */
-    if ((size & TWIS_TXD_MAXCNT_MAXCNT_Msk) != size)
+#if NRF_TWIS_HAS_DMA_REG
+    size_t maxsize = TWIS_DMA_TX_MAXCNT_MAXCNT_Msk;
+#else
+    size_t maxsize = TWIS_TXD_MAXCNT_MAXCNT_Msk;
+#endif
+    if ((size & maxsize) != size)
     {
         err_code = NRFX_ERROR_INVALID_LENGTH;
         NRFX_LOG_WARNING("Function: %s, error code: %s.",
@@ -763,7 +788,12 @@ nrfx_err_t nrfx_twis_rx_prepare(nrfx_twis_t const * p_instance,
         return err_code;
     }
     /* Check data size */
-    if ((size & TWIS_RXD_MAXCNT_MAXCNT_Msk) != size)
+#if NRF_TWIS_HAS_DMA_REG
+    size_t maxsize = TWIS_DMA_RX_MAXCNT_MAXCNT_Msk;
+#else
+    size_t maxsize = TWIS_RXD_MAXCNT_MAXCNT_Msk;
+#endif
+    if ((size & maxsize) != size)
     {
         err_code = NRFX_ERROR_INVALID_LENGTH;
         NRFX_LOG_WARNING("Function: %s, error code: %s.",
@@ -816,33 +846,6 @@ bool nrfx_twis_is_pending_rx(nrfx_twis_t const * p_instance)
     return NRFX_TWIS_SUBSTATE_WRITE_PENDING == p_cb->substate;
 }
 
-
-#if NRFX_CHECK(NRFX_TWIS0_ENABLED)
-void nrfx_twis_0_irq_handler(void)
-{
-    nrfx_twis_state_machine(NRF_TWIS0, &m_cb[NRFX_TWIS0_INST_IDX]);
-}
-#endif
-
-#if NRFX_CHECK(NRFX_TWIS1_ENABLED)
-void nrfx_twis_1_irq_handler(void)
-{
-    nrfx_twis_state_machine(NRF_TWIS1, &m_cb[NRFX_TWIS1_INST_IDX]);
-}
-#endif
-
-#if NRFX_CHECK(NRFX_TWIS2_ENABLED)
-void nrfx_twis_2_irq_handler(void)
-{
-    nrfx_twis_state_machine(NRF_TWIS2, &m_cb[NRFX_TWIS2_INST_IDX]);
-}
-#endif
-
-#if NRFX_CHECK(NRFX_TWIS3_ENABLED)
-void nrfx_twis_3_irq_handler(void)
-{
-    nrfx_twis_state_machine(NRF_TWIS3, &m_cb[NRFX_TWIS3_INST_IDX]);
-}
-#endif
+NRFX_INSTANCE_IRQ_HANDLERS(TWIS, twis)
 
 #endif // NRFX_CHECK(NRFX_TWIS_ENABLED)

--- a/nrfx/drivers/src/nrfx_uarte.c
+++ b/nrfx/drivers/src/nrfx_uarte.c
@@ -35,16 +35,13 @@
 
 #if NRFX_CHECK(NRFX_UARTE_ENABLED)
 
-#if !(NRFX_CHECK(NRFX_UARTE0_ENABLED) || \
-      NRFX_CHECK(NRFX_UARTE1_ENABLED) || \
-      NRFX_CHECK(NRFX_UARTE2_ENABLED) || \
-      NRFX_CHECK(NRFX_UARTE3_ENABLED))
+#if !NRFX_FEATURE_PRESENT(NRFX_UARTE, _ENABLED)
 #error "No enabled UARTE instances. Check <nrfx_config.h>."
 #endif
 
 #include <nrfx_uarte.h>
 #include "prs/nrfx_prs.h"
-#include <hal/nrf_gpio.h>
+#include <haly/nrfy_gpio.h>
 
 #define NRFX_LOG_MODULE UARTE
 #include <nrfx_log.h>
@@ -53,39 +50,12 @@
     (event == NRF_UARTE_EVENT_ERROR ? "NRF_UARTE_EVENT_ERROR" : \
                                       "UNKNOWN EVENT")
 
-#define UARTEX_LENGTH_VALIDATE(peripheral, drv_inst_idx, len1, len2)     \
-    (((drv_inst_idx) == NRFX_CONCAT_3(NRFX_, peripheral, _INST_IDX)) && \
-     NRFX_EASYDMA_LENGTH_VALIDATE(peripheral, len1, len2))
+#define UARTEX_LENGTH_VALIDATE(periph_name, prefix, i, drv_inst_idx, len1, len2) \
+    (((drv_inst_idx) == NRFX_CONCAT(NRFX_, periph_name, prefix, i, _INST_IDX)) && \
+     NRFX_EASYDMA_LENGTH_VALIDATE(NRFX_CONCAT(periph_name, prefix, i), len1, len2))
 
-#if NRFX_CHECK(NRFX_UARTE0_ENABLED)
-#define UARTE0_LENGTH_VALIDATE(...)  UARTEX_LENGTH_VALIDATE(UARTE0, __VA_ARGS__)
-#else
-#define UARTE0_LENGTH_VALIDATE(...)  0
-#endif
-
-#if NRFX_CHECK(NRFX_UARTE1_ENABLED)
-#define UARTE1_LENGTH_VALIDATE(...)  UARTEX_LENGTH_VALIDATE(UARTE1, __VA_ARGS__)
-#else
-#define UARTE1_LENGTH_VALIDATE(...)  0
-#endif
-
-#if NRFX_CHECK(NRFX_UARTE2_ENABLED)
-#define UARTE2_LENGTH_VALIDATE(...)  UARTEX_LENGTH_VALIDATE(UARTE2, __VA_ARGS__)
-#else
-#define UARTE2_LENGTH_VALIDATE(...)  0
-#endif
-
-#if NRFX_CHECK(NRFX_UARTE3_ENABLED)
-#define UARTE3_LENGTH_VALIDATE(...)  UARTEX_LENGTH_VALIDATE(UARTE3, __VA_ARGS__)
-#else
-#define UARTE3_LENGTH_VALIDATE(...)  0
-#endif
-
-#define UARTE_LENGTH_VALIDATE(drv_inst_idx, length)     \
-    (UARTE0_LENGTH_VALIDATE(drv_inst_idx, length, 0) || \
-     UARTE1_LENGTH_VALIDATE(drv_inst_idx, length, 0) || \
-     UARTE2_LENGTH_VALIDATE(drv_inst_idx, length, 0) || \
-     UARTE3_LENGTH_VALIDATE(drv_inst_idx, length, 0))
+#define UARTE_LENGTH_VALIDATE(drv_inst_idx, len)    \
+        (NRFX_FOREACH_ENABLED(UARTE, UARTEX_LENGTH_VALIDATE, (||), (0), drv_inst_idx, len, 0))
 
 typedef struct
 {
@@ -104,78 +74,72 @@ typedef struct
 } uarte_control_block_t;
 static uarte_control_block_t m_cb[NRFX_UARTE_ENABLED_COUNT];
 
-static void apply_config(nrfx_uarte_t        const * p_instance,
-                         nrfx_uarte_config_t const * p_config)
-{
-    nrf_uarte_baudrate_set(p_instance->p_reg, p_config->baudrate);
-    nrf_uarte_configure(p_instance->p_reg, &p_config->hal_cfg);
+static void apply_workaround_for_enable_anomaly(nrfx_uarte_t const * p_instance);
 
+static void uarte_configure(nrfx_uarte_t        const * p_instance,
+                            nrfx_uarte_config_t const * p_config)
+{
     if (!p_config->skip_gpio_cfg)
     {
-        if (p_config->pseltxd != NRF_UARTE_PSEL_DISCONNECTED)
+        if (p_config->txd_pin != NRF_UARTE_PSEL_DISCONNECTED)
         {
-            nrf_gpio_pin_set(p_config->pseltxd);
-            nrf_gpio_cfg_output(p_config->pseltxd);
+            nrfy_gpio_pin_set(p_config->txd_pin);
+            nrfy_gpio_cfg_output(p_config->txd_pin);
         }
-        if (p_config->pselrxd != NRF_UARTE_PSEL_DISCONNECTED)
+        if (p_config->rxd_pin != NRF_UARTE_PSEL_DISCONNECTED)
         {
-            nrf_gpio_cfg_input(p_config->pselrxd, NRF_GPIO_PIN_NOPULL);
+            nrfy_gpio_cfg_input(p_config->rxd_pin, NRF_GPIO_PIN_NOPULL);
         }
-    }
-    if (!p_config->skip_psel_cfg)
-    {
-        nrf_uarte_txrx_pins_set(p_instance->p_reg,
-                                p_config->pseltxd, p_config->pselrxd);
     }
 
-    if (p_config->hal_cfg.hwfc == NRF_UARTE_HWFC_ENABLED)
+    if (p_config->config.hwfc == NRF_UARTE_HWFC_ENABLED)
     {
         if (!p_config->skip_gpio_cfg)
         {
-            if (p_config->pselrts != NRF_UARTE_PSEL_DISCONNECTED)
+            if (p_config->cts_pin != NRF_UARTE_PSEL_DISCONNECTED)
             {
-                nrf_gpio_pin_set(p_config->pselrts);
-                nrf_gpio_cfg_output(p_config->pselrts);
+                nrfy_gpio_cfg_input(p_config->cts_pin, NRF_GPIO_PIN_NOPULL);
             }
-            if (p_config->pselcts != NRF_UARTE_PSEL_DISCONNECTED)
+            if (p_config->rts_pin != NRF_UARTE_PSEL_DISCONNECTED)
             {
-                nrf_gpio_cfg_input(p_config->pselcts, NRF_GPIO_PIN_NOPULL);
+                nrfy_gpio_pin_set(p_config->rts_pin);
+                nrfy_gpio_cfg_output(p_config->rts_pin);
+#if NRF_GPIO_HAS_CLOCKPIN
+                nrfy_gpio_pin_clock_set(p_config->rts_pin, true);
+#endif
             }
-        }
-        if (!p_config->skip_psel_cfg)
-        {
-            nrf_uarte_hwfc_pins_set(p_instance->p_reg,
-                                    p_config->pselrts, p_config->pselcts);
         }
     }
-}
 
-static void interrupts_enable(nrfx_uarte_t const * p_instance,
-                              uint8_t              interrupt_priority)
-{
-    nrf_uarte_event_clear(p_instance->p_reg, NRF_UARTE_EVENT_ENDRX);
-    nrf_uarte_event_clear(p_instance->p_reg, NRF_UARTE_EVENT_ENDTX);
-    nrf_uarte_event_clear(p_instance->p_reg, NRF_UARTE_EVENT_ERROR);
-    nrf_uarte_event_clear(p_instance->p_reg, NRF_UARTE_EVENT_RXTO);
-    nrf_uarte_event_clear(p_instance->p_reg, NRF_UARTE_EVENT_TXSTOPPED);
-    nrf_uarte_int_enable(p_instance->p_reg, NRF_UARTE_INT_ENDRX_MASK |
-                                            NRF_UARTE_INT_ENDTX_MASK |
-                                            NRF_UARTE_INT_ERROR_MASK |
-                                            NRF_UARTE_INT_RXTO_MASK  |
-                                            NRF_UARTE_INT_TXSTOPPED_MASK);
-    NRFX_IRQ_PRIORITY_SET(nrfx_get_irq_number((void *)p_instance->p_reg),
-                          interrupt_priority);
-    NRFX_IRQ_ENABLE(nrfx_get_irq_number((void *)p_instance->p_reg));
-}
+    nrfy_uarte_config_t nrfy_config =
+    {
+        .pins =
+        {
+            .txd_pin = p_config->txd_pin,
+            .rxd_pin = p_config->rxd_pin,
+            .rts_pin = p_config->rts_pin,
+            .cts_pin = p_config->cts_pin
+        },
+        .baudrate = p_config->baudrate,
+        .skip_psel_cfg = p_config->skip_psel_cfg
+    };
+    nrfy_config.config = p_config->config;
 
-static void interrupts_disable(nrfx_uarte_t const * p_instance)
-{
-    nrf_uarte_int_disable(p_instance->p_reg, NRF_UARTE_INT_ENDRX_MASK |
-                                             NRF_UARTE_INT_ENDTX_MASK |
-                                             NRF_UARTE_INT_ERROR_MASK |
-                                             NRF_UARTE_INT_RXTO_MASK  |
-                                             NRF_UARTE_INT_TXSTOPPED_MASK);
-    NRFX_IRQ_DISABLE(nrfx_get_irq_number((void *)p_instance->p_reg));
+    nrfy_uarte_periph_configure(p_instance->p_reg, &nrfy_config);
+
+    apply_workaround_for_enable_anomaly(p_instance);
+
+    if (m_cb[p_instance->drv_inst_idx].handler)
+    {
+        nrfy_uarte_int_init(p_instance->p_reg,
+                            NRFY_EVENT_TO_INT_BITMASK(NRF_UARTE_EVENT_ENDRX) |
+                            NRFY_EVENT_TO_INT_BITMASK(NRF_UARTE_EVENT_ENDTX) |
+                            NRFY_EVENT_TO_INT_BITMASK(NRF_UARTE_EVENT_ERROR) |
+                            NRFY_EVENT_TO_INT_BITMASK(NRF_UARTE_EVENT_RXTO)  |
+                            NRFY_EVENT_TO_INT_BITMASK(NRF_UARTE_EVENT_TXSTOPPED),
+                            p_config->interrupt_priority,
+                            true);
+    }
 }
 
 static void pins_to_default(nrfx_uarte_t const * p_instance)
@@ -183,38 +147,29 @@ static void pins_to_default(nrfx_uarte_t const * p_instance)
     uarte_control_block_t const * p_cb = &m_cb[p_instance->drv_inst_idx];
 
     /* Reset pins to default states */
-    uint32_t txd;
-    uint32_t rxd;
-    uint32_t rts;
-    uint32_t cts;
-
-    txd = nrf_uarte_tx_pin_get(p_instance->p_reg);
-    rxd = nrf_uarte_rx_pin_get(p_instance->p_reg);
-    rts = nrf_uarte_rts_pin_get(p_instance->p_reg);
-    cts = nrf_uarte_cts_pin_get(p_instance->p_reg);
+    nrfy_uarte_pins_t pins;
+    nrfy_uarte_pins_get(p_instance->p_reg, &pins);
     if (!p_cb->skip_psel_cfg)
     {
-        nrf_uarte_txrx_pins_disconnect(p_instance->p_reg);
-        nrf_uarte_hwfc_pins_disconnect(p_instance->p_reg);
+        nrfy_uarte_pins_disconnect(p_instance->p_reg);
     }
-
     if (!p_cb->skip_gpio_cfg)
     {
-        if (txd != NRF_UARTE_PSEL_DISCONNECTED)
+        if (pins.txd_pin != NRF_UARTE_PSEL_DISCONNECTED)
         {
-            nrf_gpio_cfg_default(txd);
+            nrfy_gpio_cfg_default(pins.txd_pin);
         }
-        if (rxd != NRF_UARTE_PSEL_DISCONNECTED)
+        if (pins.rxd_pin != NRF_UARTE_PSEL_DISCONNECTED)
         {
-            nrf_gpio_cfg_default(rxd);
+            nrfy_gpio_cfg_default(pins.rxd_pin);
         }
-        if (cts != NRF_UARTE_PSEL_DISCONNECTED)
+        if (pins.cts_pin != NRF_UARTE_PSEL_DISCONNECTED)
         {
-            nrf_gpio_cfg_default(cts);
+            nrfy_gpio_cfg_default(pins.cts_pin);
         }
-        if (rts != NRF_UARTE_PSEL_DISCONNECTED)
+        if (pins.rts_pin != NRF_UARTE_PSEL_DISCONNECTED)
         {
-            nrf_gpio_cfg_default(rts);
+            nrfy_gpio_cfg_default(pins.rts_pin);
         }
     }
 }
@@ -232,13 +187,13 @@ static void apply_workaround_for_enable_anomaly(nrfx_uarte_t const * p_instance)
 
     if (*txenable_reg == 1)
     {
-        nrf_uarte_task_trigger(p_instance->p_reg, NRF_UARTE_TASK_STOPTX);
+        nrfy_uarte_task_trigger(p_instance->p_reg, NRF_UARTE_TASK_STOPTX);
     }
 
     if (*rxenable_reg == 1)
     {
-        nrf_uarte_enable(p_instance->p_reg);
-        nrf_uarte_task_trigger(p_instance->p_reg, NRF_UARTE_TASK_STOPRX);
+        nrfy_uarte_enable(p_instance->p_reg);
+        nrfy_uarte_task_trigger(p_instance->p_reg, NRF_UARTE_TASK_STOPRX);
 
         bool workaround_succeded;
         // The UARTE is able to receive up to four bytes after the STOPRX task has been triggered.
@@ -251,8 +206,8 @@ static void apply_workaround_for_enable_anomaly(nrfx_uarte_t const * p_instance)
                            (void *)p_instance->p_reg);
         }
 
-        (void)nrf_uarte_errorsrc_get_and_clear(p_instance->p_reg);
-        nrf_uarte_disable(p_instance->p_reg);
+        (void)nrfy_uarte_errorsrc_get_and_clear(p_instance->p_reg);
+        nrfy_uarte_disable(p_instance->p_reg);
     }
 #else
     (void)(p_instance);
@@ -278,18 +233,7 @@ nrfx_err_t nrfx_uarte_init(nrfx_uarte_t const *        p_instance,
 
 #if NRFX_CHECK(NRFX_PRS_ENABLED)
     static nrfx_irq_handler_t const irq_handlers[NRFX_UARTE_ENABLED_COUNT] = {
-        #if NRFX_CHECK(NRFX_UARTE0_ENABLED)
-        nrfx_uarte_0_irq_handler,
-        #endif
-        #if NRFX_CHECK(NRFX_UARTE1_ENABLED)
-        nrfx_uarte_1_irq_handler,
-        #endif
-        #if NRFX_CHECK(NRFX_UARTE2_ENABLED)
-        nrfx_uarte_2_irq_handler,
-        #endif
-        #if NRFX_CHECK(NRFX_UARTE3_ENABLED)
-        nrfx_uarte_3_irq_handler,
-        #endif
+        NRFX_INSTANCE_IRQ_HANDLERS_LIST(UARTE, uarte)
     };
     if (nrfx_prs_acquire(p_instance->p_reg,
             irq_handlers[p_instance->drv_inst_idx]) != NRFX_SUCCESS)
@@ -302,22 +246,17 @@ nrfx_err_t nrfx_uarte_init(nrfx_uarte_t const *        p_instance,
     }
 #endif // NRFX_CHECK(NRFX_PRS_ENABLED)
 
-    p_cb->skip_gpio_cfg = p_config->skip_gpio_cfg;
-    p_cb->skip_psel_cfg = p_config->skip_psel_cfg;
+    p_cb->handler = event_handler;
 
-    apply_config(p_instance, p_config);
-
-    apply_workaround_for_enable_anomaly(p_instance);
-
-    p_cb->handler   = event_handler;
-    p_cb->p_context = p_config->p_context;
-
-    if (p_cb->handler)
+    if (p_config)
     {
-        interrupts_enable(p_instance, p_config->interrupt_priority);
+        p_cb->p_context = p_config->p_context;
+        p_cb->skip_gpio_cfg = p_config->skip_gpio_cfg;
+        p_cb->skip_psel_cfg = p_config->skip_psel_cfg;
+        uarte_configure(p_instance, p_config);
     }
 
-    nrf_uarte_enable(p_instance->p_reg);
+    nrfy_uarte_enable(p_instance->p_reg);
     p_cb->rx_buffer_length           = 0;
     p_cb->rx_secondary_buffer_length = 0;
     p_cb->tx_buffer_length           = 0;
@@ -328,49 +267,59 @@ nrfx_err_t nrfx_uarte_init(nrfx_uarte_t const *        p_instance,
     return err_code;
 }
 
+nrfx_err_t nrfx_uarte_reconfigure(nrfx_uarte_t const *        p_instance,
+                                  nrfx_uarte_config_t const * p_config)
+{
+    NRFX_ASSERT(p_config);
+    uarte_control_block_t * p_cb = &m_cb[p_instance->drv_inst_idx];
+
+    if (p_cb->state == NRFX_DRV_STATE_UNINITIALIZED)
+    {
+        return NRFX_ERROR_INVALID_STATE;
+    }
+    if (nrfx_uarte_tx_in_progress(p_instance))
+    {
+        return NRFX_ERROR_BUSY;
+    }
+    nrfy_uarte_disable(p_instance->p_reg);
+    if (p_cb->handler)
+    {
+        p_cb->p_context = p_config->p_context;
+    }
+    uarte_configure(p_instance, p_config);
+    nrfy_uarte_enable(p_instance->p_reg);
+    return NRFX_SUCCESS;
+}
+
 void nrfx_uarte_uninit(nrfx_uarte_t const * p_instance)
 {
     uarte_control_block_t * p_cb = &m_cb[p_instance->drv_inst_idx];
-    NRF_UARTE_Type * p_reg = p_instance->p_reg;
 
     if (p_cb->handler)
     {
-        interrupts_disable(p_instance);
+        nrfy_uarte_int_disable(p_instance->p_reg,
+                               NRF_UARTE_INT_ENDRX_MASK |
+                               NRF_UARTE_INT_ENDTX_MASK |
+                               NRF_UARTE_INT_ERROR_MASK |
+                               NRF_UARTE_INT_RXTO_MASK  |
+                               NRF_UARTE_INT_TXSTOPPED_MASK);
+        nrfy_uarte_int_uninit(p_instance->p_reg);
     }
     // Make sure all transfers are finished before UARTE is disabled
     // to achieve the lowest power consumption.
-    nrf_uarte_shorts_disable(p_reg, NRF_UARTE_SHORT_ENDRX_STARTRX);
+    nrfy_uarte_shorts_disable(p_instance->p_reg, NRF_UARTE_SHORT_ENDRX_STARTRX);
 
-    // Check if there is any ongoing reception.
-    if (p_cb->rx_buffer_length)
-    {
-        nrf_uarte_event_clear(p_reg, NRF_UARTE_EVENT_RXTO);
-        nrf_uarte_task_trigger(p_reg, NRF_UARTE_TASK_STOPRX);
-    }
+    nrfy_uarte_xfer_desc_t xfer_desc = {
+        .p_buffer = p_cb->p_rx_buffer,
+        .length   = p_cb->rx_buffer_length
+    };
+    nrfy_uarte_stop(p_instance->p_reg, &xfer_desc);
 
-    nrf_uarte_event_clear(p_reg, NRF_UARTE_EVENT_TXSTOPPED);
-    nrf_uarte_task_trigger(p_reg, NRF_UARTE_TASK_STOPTX);
-
-    // Wait for TXSTOPPED event and for RXTO event, provided that there was ongoing reception.
-    bool stopped;
-
-    // The UARTE is able to receive up to four bytes after the STOPRX task has been triggered.
-    // On lowest supported baud rate (1200 baud), with parity bit and two stop bits configured
-    // (resulting in 12 bits per data byte sent), this may take up to 40 ms.
-    NRFX_WAIT_FOR((nrf_uarte_event_check(p_reg, NRF_UARTE_EVENT_TXSTOPPED) &&
-                  (!p_cb->rx_buffer_length || nrf_uarte_event_check(p_reg, NRF_UARTE_EVENT_RXTO))),
-                  40000, 1, stopped);
-    if (!stopped)
-    {
-        NRFX_LOG_ERROR("Failed to stop instance with base address: %p.", (void *)p_instance->p_reg);
-    }
-
-    nrf_uarte_disable(p_reg);
-
+    nrfy_uarte_disable(p_instance->p_reg);
     pins_to_default(p_instance);
 
 #if NRFX_CHECK(NRFX_PRS_ENABLED)
-    nrfx_prs_release(p_reg);
+    nrfx_prs_release(p_instance->p_reg);
 #endif
 
     p_cb->state   = NRFX_DRV_STATE_UNINITIALIZED;
@@ -380,19 +329,21 @@ void nrfx_uarte_uninit(nrfx_uarte_t const * p_instance)
 
 nrfx_err_t nrfx_uarte_tx(nrfx_uarte_t const * p_instance,
                          uint8_t const *      p_data,
-                         size_t               length)
+                         size_t               length,
+                         uint32_t             flags)
 {
+    (void)flags;
     uarte_control_block_t * p_cb = &m_cb[p_instance->drv_inst_idx];
     NRFX_ASSERT(p_cb->state == NRFX_DRV_STATE_INITIALIZED);
     NRFX_ASSERT(p_data);
     NRFX_ASSERT(length > 0);
     NRFX_ASSERT(UARTE_LENGTH_VALIDATE(p_instance->drv_inst_idx, length));
 
-    nrfx_err_t err_code;
+    nrfx_err_t err_code = NRFX_SUCCESS;
 
     // EasyDMA requires that transfer buffers are placed in DataRAM,
     // signal error if the are not.
-    if (!nrfx_is_in_ram(p_data))
+    if (!nrf_dma_accessible_check(p_instance->p_reg, p_data))
     {
         err_code = NRFX_ERROR_INVALID_ADDR;
         NRFX_LOG_WARNING("Function: %s, error code: %s.",
@@ -417,25 +368,14 @@ nrfx_err_t nrfx_uarte_tx(nrfx_uarte_t const * p_instance,
     NRFX_LOG_HEXDUMP_DEBUG(p_cb->p_tx_buffer,
                            p_cb->tx_buffer_length * sizeof(p_cb->p_tx_buffer[0]));
 
-    err_code = NRFX_SUCCESS;
+    nrfy_uarte_event_clear(p_instance->p_reg, NRF_UARTE_EVENT_ENDTX);
+    nrfy_uarte_event_clear(p_instance->p_reg, NRF_UARTE_EVENT_TXSTOPPED);
+    nrfy_uarte_tx_buffer_set(p_instance->p_reg, p_cb->p_tx_buffer, p_cb->tx_buffer_length);
 
-    nrf_uarte_event_clear(p_instance->p_reg, NRF_UARTE_EVENT_ENDTX);
-    nrf_uarte_event_clear(p_instance->p_reg, NRF_UARTE_EVENT_TXSTOPPED);
-    nrf_uarte_tx_buffer_set(p_instance->p_reg, p_cb->p_tx_buffer, p_cb->tx_buffer_length);
-    nrf_uarte_task_trigger(p_instance->p_reg, NRF_UARTE_TASK_STARTTX);
-
+    uint32_t evt_mask = nrfy_uarte_tx_start(p_instance->p_reg, !p_cb->handler);
     if (p_cb->handler == NULL)
     {
-        bool endtx;
-        bool txstopped;
-        do
-        {
-            endtx     = nrf_uarte_event_check(p_instance->p_reg, NRF_UARTE_EVENT_ENDTX);
-            txstopped = nrf_uarte_event_check(p_instance->p_reg, NRF_UARTE_EVENT_TXSTOPPED);
-        }
-        while ((!endtx) && (!txstopped));
-
-        if (txstopped)
+        if (evt_mask & NRFY_EVENT_TO_INT_BITMASK(NRF_UARTE_EVENT_TXSTOPPED))
         {
             err_code = NRFX_ERROR_FORBIDDEN;
         }
@@ -443,14 +383,10 @@ nrfx_err_t nrfx_uarte_tx(nrfx_uarte_t const * p_instance,
         {
             // Transmitter has to be stopped by triggering the STOPTX task to achieve
             // the lowest possible level of the UARTE power consumption.
-            nrf_uarte_task_trigger(p_instance->p_reg, NRF_UARTE_TASK_STOPTX);
-
-            while (!nrf_uarte_event_check(p_instance->p_reg, NRF_UARTE_EVENT_TXSTOPPED))
-            {}
+            nrfy_uarte_stop(p_instance->p_reg, NULL);
         }
         p_cb->tx_buffer_length = 0;
     }
-
     NRFX_LOG_INFO("Function: %s, error code: %s.", __func__, NRFX_LOG_ERROR_STRING_GET(err_code));
     return err_code;
 }
@@ -466,16 +402,16 @@ nrfx_err_t nrfx_uarte_rx(nrfx_uarte_t const * p_instance,
 {
     uarte_control_block_t * p_cb = &m_cb[p_instance->drv_inst_idx];
 
-    NRFX_ASSERT(m_cb[p_instance->drv_inst_idx].state == NRFX_DRV_STATE_INITIALIZED);
+    NRFX_ASSERT(p_cb->state == NRFX_DRV_STATE_INITIALIZED);
     NRFX_ASSERT(p_data);
     NRFX_ASSERT(length > 0);
     NRFX_ASSERT(UARTE_LENGTH_VALIDATE(p_instance->drv_inst_idx, length));
 
-    nrfx_err_t err_code;
+    nrfx_err_t err_code = NRFX_SUCCESS;
 
     // EasyDMA requires that transfer buffers are placed in DataRAM,
     // signal error if the are not.
-    if (!nrfx_is_in_ram(p_data))
+    if (!nrf_dma_accessible_check(p_instance->p_reg, p_data))
     {
         err_code = NRFX_ERROR_INVALID_ADDR;
         NRFX_LOG_WARNING("Function: %s, error code: %s.",
@@ -488,8 +424,8 @@ nrfx_err_t nrfx_uarte_rx(nrfx_uarte_t const * p_instance,
 
     if (p_cb->handler)
     {
-        nrf_uarte_int_disable(p_instance->p_reg, NRF_UARTE_INT_ERROR_MASK |
-                                                 NRF_UARTE_INT_ENDRX_MASK);
+        nrfy_uarte_int_disable(p_instance->p_reg, NRF_UARTE_INT_ERROR_MASK |
+                                                  NRF_UARTE_INT_ENDRX_MASK);
     }
     if (p_cb->rx_buffer_length != 0)
     {
@@ -497,8 +433,8 @@ nrfx_err_t nrfx_uarte_rx(nrfx_uarte_t const * p_instance,
         {
             if (p_cb->handler)
             {
-                nrf_uarte_int_enable(p_instance->p_reg, NRF_UARTE_INT_ERROR_MASK |
-                                                        NRF_UARTE_INT_ENDRX_MASK);
+                nrfy_uarte_int_enable(p_instance->p_reg, NRF_UARTE_INT_ERROR_MASK |
+                                                         NRF_UARTE_INT_ENDRX_MASK);
             }
             err_code = NRFX_ERROR_BUSY;
             NRFX_LOG_WARNING("Function: %s, error code: %s.",
@@ -523,39 +459,34 @@ nrfx_err_t nrfx_uarte_rx(nrfx_uarte_t const * p_instance,
 
     NRFX_LOG_INFO("Transfer rx_len: %d.", length);
 
-    err_code = NRFX_SUCCESS;
-
-    nrf_uarte_event_clear(p_instance->p_reg, NRF_UARTE_EVENT_ENDRX);
-    nrf_uarte_event_clear(p_instance->p_reg, NRF_UARTE_EVENT_RXTO);
-    nrf_uarte_rx_buffer_set(p_instance->p_reg, p_data, length);
-    if (!second_buffer)
+    nrfy_uarte_event_clear(p_instance->p_reg, NRF_UARTE_EVENT_ENDRX);
+    nrfy_uarte_event_clear(p_instance->p_reg, NRF_UARTE_EVENT_RXTO);
+    nrfy_uarte_rx_buffer_set(p_instance->p_reg, p_data, length);
+    uint32_t evt_mask = 0;
+    if (second_buffer)
     {
-        nrf_uarte_task_trigger(p_instance->p_reg, NRF_UARTE_TASK_STARTRX);
+        nrfy_uarte_shorts_enable(p_instance->p_reg, NRF_UARTE_SHORT_ENDRX_STARTRX);
     }
     else
     {
-        nrf_uarte_shorts_enable(p_instance->p_reg, NRF_UARTE_SHORT_ENDRX_STARTRX);
+        nrfy_uarte_xfer_desc_t xfer_desc = {
+            .p_buffer = p_cb->p_rx_buffer,
+            .length   = p_cb->rx_buffer_length
+        };
+
+        evt_mask = nrfy_uarte_rx_start(p_instance->p_reg, !p_cb->handler ? &xfer_desc : NULL);
     }
 
-    if (m_cb[p_instance->drv_inst_idx].handler == NULL)
+    if (p_cb->handler == NULL)
     {
-        bool endrx;
-        bool rxto;
-        bool error;
-        do {
-            endrx  = nrf_uarte_event_check(p_instance->p_reg, NRF_UARTE_EVENT_ENDRX);
-            rxto   = nrf_uarte_event_check(p_instance->p_reg, NRF_UARTE_EVENT_RXTO);
-            error  = nrf_uarte_event_check(p_instance->p_reg, NRF_UARTE_EVENT_ERROR);
-        } while ((!endrx) && (!rxto) && (!error));
+        p_cb->rx_buffer_length = 0;
 
-        m_cb[p_instance->drv_inst_idx].rx_buffer_length = 0;
-
-        if (error)
+        if (evt_mask & NRFY_EVENT_TO_INT_BITMASK(NRF_UARTE_EVENT_ERROR))
         {
             err_code = NRFX_ERROR_INTERNAL;
         }
 
-        if (rxto)
+        if (evt_mask & NRFY_EVENT_TO_INT_BITMASK(NRF_UARTE_EVENT_RXTO))
         {
             err_code = NRFX_ERROR_FORBIDDEN;
         }
@@ -563,22 +494,25 @@ nrfx_err_t nrfx_uarte_rx(nrfx_uarte_t const * p_instance,
     else
     {
         p_cb->rx_aborted = false;
-        nrf_uarte_int_enable(p_instance->p_reg, NRF_UARTE_INT_ERROR_MASK |
-                                                NRF_UARTE_INT_ENDRX_MASK);
+        nrfy_uarte_int_enable(p_instance->p_reg, NRF_UARTE_INT_ERROR_MASK |
+                                                 NRF_UARTE_INT_ENDRX_MASK);
     }
     NRFX_LOG_INFO("Function: %s, error code: %s.", __func__, NRFX_LOG_ERROR_STRING_GET(err_code));
     return err_code;
 }
 
-bool nrfx_uarte_rx_ready(nrfx_uarte_t const * p_instance)
+nrfx_err_t nrfx_uarte_rx_ready(nrfx_uarte_t const * p_instance, size_t * p_rx_amount)
 {
-    return nrf_uarte_event_check(p_instance->p_reg, NRF_UARTE_EVENT_ENDRX);
+    (void)p_rx_amount;
+
+    return nrfy_uarte_event_check(p_instance->p_reg, NRF_UARTE_EVENT_ENDRX) ?
+            NRFX_SUCCESS : NRFX_ERROR_BUSY;
 }
 
 uint32_t nrfx_uarte_errorsrc_get(nrfx_uarte_t const * p_instance)
 {
-    nrf_uarte_event_clear(p_instance->p_reg, NRF_UARTE_EVENT_ERROR);
-    return nrf_uarte_errorsrc_get_and_clear(p_instance->p_reg);
+    nrfy_uarte_event_clear(p_instance->p_reg, NRF_UARTE_EVENT_ERROR);
+    return nrfy_uarte_errorsrc_get_and_clear(p_instance->p_reg);
 }
 
 static void rx_done_event(uarte_control_block_t * p_cb,
@@ -586,10 +520,9 @@ static void rx_done_event(uarte_control_block_t * p_cb,
                           uint8_t *               p_data)
 {
     nrfx_uarte_event_t event;
-
     event.type             = NRFX_UARTE_EVT_RX_DONE;
-    event.data.rxtx.bytes  = bytes;
-    event.data.rxtx.p_data = p_data;
+    event.data.rx.bytes  = bytes;
+    event.data.rx.p_data = p_data;
 
     p_cb->handler(&event, p_cb->p_context);
 }
@@ -598,58 +531,64 @@ static void tx_done_event(uarte_control_block_t * p_cb,
                           size_t                  bytes)
 {
     nrfx_uarte_event_t event;
-
     event.type             = NRFX_UARTE_EVT_TX_DONE;
-    event.data.rxtx.bytes  = bytes;
-    event.data.rxtx.p_data = (uint8_t *)p_cb->p_tx_buffer;
+    event.data.tx.bytes  = bytes;
+    event.data.tx.p_data = (uint8_t *)p_cb->p_tx_buffer;
 
     p_cb->tx_buffer_length = 0;
-
     p_cb->handler(&event, p_cb->p_context);
 }
 
-void nrfx_uarte_tx_abort(nrfx_uarte_t const * p_instance)
+nrfx_err_t nrfx_uarte_tx_abort(nrfx_uarte_t const * p_instance, bool sync)
 {
+    (void)sync;
     uarte_control_block_t * p_cb = &m_cb[p_instance->drv_inst_idx];
-
-    nrf_uarte_event_clear(p_instance->p_reg, NRF_UARTE_EVENT_TXSTOPPED);
-    nrf_uarte_task_trigger(p_instance->p_reg, NRF_UARTE_TASK_STOPTX);
-    if (p_cb->handler == NULL)
-    {
-        while (!nrf_uarte_event_check(p_instance->p_reg, NRF_UARTE_EVENT_TXSTOPPED))
-        {}
-    }
+    nrfy_uarte_tx_abort(p_instance->p_reg, !p_cb->handler ? true : false);
     NRFX_LOG_INFO("TX transaction aborted.");
+
+    return NRFX_SUCCESS;
 }
 
-void nrfx_uarte_rx_abort(nrfx_uarte_t const * p_instance)
+nrfx_err_t nrfx_uarte_rx_abort(nrfx_uarte_t const * p_instance, bool disable_all, bool sync)
 {
+    (void)disable_all;
+    (void)sync;
     uarte_control_block_t * p_cb = &m_cb[p_instance->drv_inst_idx];
 
     // Short between ENDRX event and STARTRX task must be disabled before
     // aborting transmission.
     if (p_cb->rx_secondary_buffer_length != 0)
     {
-        nrf_uarte_shorts_disable(p_instance->p_reg, NRF_UARTE_SHORT_ENDRX_STARTRX);
+        nrfy_uarte_shorts_disable(p_instance->p_reg, NRF_UARTE_SHORT_ENDRX_STARTRX);
     }
     p_cb->rx_aborted = true;
-    nrf_uarte_task_trigger(p_instance->p_reg, NRF_UARTE_TASK_STOPRX);
+    nrfy_uarte_task_trigger(p_instance->p_reg, NRF_UARTE_TASK_STOPRX);
     NRFX_LOG_INFO("RX transaction aborted.");
+
+    return NRFX_SUCCESS;
 }
 
-static void uarte_irq_handler(NRF_UARTE_Type *        p_uarte,
-                              uarte_control_block_t * p_cb)
+static void irq_handler(NRF_UARTE_Type * p_reg, uarte_control_block_t * p_cb)
 {
-    if (nrf_uarte_event_check(p_uarte, NRF_UARTE_EVENT_ERROR))
+    nrfy_uarte_xfer_desc_t xfer_desc = {
+        .p_buffer = p_cb->p_rx_buffer,
+        .length   = p_cb->rx_buffer_length
+    };
+    uint32_t evt_mask = nrfy_uarte_events_process(p_reg,
+                                            NRFY_EVENT_TO_INT_BITMASK(NRF_UARTE_EVENT_ERROR) |
+                                            NRFY_EVENT_TO_INT_BITMASK(NRF_UARTE_EVENT_ENDRX) |
+                                            NRFY_EVENT_TO_INT_BITMASK(NRF_UARTE_EVENT_ENDTX) |
+                                            NRFY_EVENT_TO_INT_BITMASK(NRF_UARTE_EVENT_RXTO)  |
+                                            NRFY_EVENT_TO_INT_BITMASK(NRF_UARTE_EVENT_TXSTOPPED),
+                                            &xfer_desc);
+
+    if (evt_mask & NRFY_EVENT_TO_INT_BITMASK(NRF_UARTE_EVENT_ERROR))
     {
         nrfx_uarte_event_t event;
-
-        nrf_uarte_event_clear(p_uarte, NRF_UARTE_EVENT_ERROR);
-
         event.type                   = NRFX_UARTE_EVT_ERROR;
-        event.data.error.error_mask  = nrf_uarte_errorsrc_get_and_clear(p_uarte);
-        event.data.error.rxtx.bytes  = nrf_uarte_rx_amount_get(p_uarte);
-        event.data.error.rxtx.p_data = p_cb->p_rx_buffer;
+        event.data.error.error_mask  = nrfy_uarte_errorsrc_get_and_clear(p_reg);
+        event.data.error.rx.bytes  = nrfy_uarte_rx_amount_get(p_reg);
+        event.data.error.rx.p_data = p_cb->p_rx_buffer;
 
         // Abort transfer.
         p_cb->rx_buffer_length = 0;
@@ -657,10 +596,8 @@ static void uarte_irq_handler(NRF_UARTE_Type *        p_uarte,
 
         p_cb->handler(&event, p_cb->p_context);
     }
-    else if (nrf_uarte_event_check(p_uarte, NRF_UARTE_EVENT_ENDRX))
+    else if (evt_mask & NRFY_EVENT_TO_INT_BITMASK(NRF_UARTE_EVENT_ENDRX))
     {
-        nrf_uarte_event_clear(p_uarte, NRF_UARTE_EVENT_ENDRX);
-
         // Aborted transfers are handled in RXTO event processing.
         if (!p_cb->rx_aborted)
         {
@@ -668,7 +605,7 @@ static void uarte_irq_handler(NRF_UARTE_Type *        p_uarte,
             if (p_cb->rx_secondary_buffer_length != 0)
             {
                 uint8_t * p_data = p_cb->p_rx_buffer;
-                nrf_uarte_shorts_disable(p_uarte, NRF_UARTE_SHORT_ENDRX_STARTRX);
+                nrfy_uarte_shorts_disable(p_reg, NRF_UARTE_SHORT_ENDRX_STARTRX);
                 p_cb->rx_buffer_length = p_cb->rx_secondary_buffer_length;
                 p_cb->p_rx_buffer = p_cb->p_rx_secondary_buffer;
                 p_cb->rx_secondary_buffer_length = 0;
@@ -682,70 +619,39 @@ static void uarte_irq_handler(NRF_UARTE_Type *        p_uarte,
         }
     }
 
-    if (nrf_uarte_event_check(p_uarte, NRF_UARTE_EVENT_RXTO))
+    if (evt_mask & NRFY_EVENT_TO_INT_BITMASK(NRF_UARTE_EVENT_RXTO))
     {
-        nrf_uarte_event_clear(p_uarte, NRF_UARTE_EVENT_RXTO);
-
         if (p_cb->rx_buffer_length != 0)
         {
             p_cb->rx_buffer_length = 0;
             // In case of using double-buffered reception both variables storing buffer length
             // have to be cleared to prevent incorrect behaviour of the driver.
             p_cb->rx_secondary_buffer_length = 0;
-            rx_done_event(p_cb, nrf_uarte_rx_amount_get(p_uarte), p_cb->p_rx_buffer);
+            rx_done_event(p_cb, nrfy_uarte_rx_amount_get(p_reg), p_cb->p_rx_buffer);
         }
     }
 
-    if (nrf_uarte_event_check(p_uarte, NRF_UARTE_EVENT_ENDTX))
+    if (evt_mask & NRFY_EVENT_TO_INT_BITMASK(NRF_UARTE_EVENT_ENDTX))
     {
-        nrf_uarte_event_clear(p_uarte, NRF_UARTE_EVENT_ENDTX);
-
         // Transmitter has to be stopped by triggering STOPTX task to achieve
         // the lowest possible level of the UARTE power consumption.
-        nrf_uarte_task_trigger(p_uarte, NRF_UARTE_TASK_STOPTX);
+        nrfy_uarte_task_trigger(p_reg, NRF_UARTE_TASK_STOPTX);
 
         if (p_cb->tx_buffer_length != 0)
         {
-            tx_done_event(p_cb, nrf_uarte_tx_amount_get(p_uarte));
+            tx_done_event(p_cb, nrfy_uarte_tx_amount_get(p_reg));
         }
     }
 
-    if (nrf_uarte_event_check(p_uarte, NRF_UARTE_EVENT_TXSTOPPED))
+    if (evt_mask & NRFY_EVENT_TO_INT_BITMASK(NRF_UARTE_EVENT_TXSTOPPED))
     {
-        nrf_uarte_event_clear(p_uarte, NRF_UARTE_EVENT_TXSTOPPED);
         if (p_cb->tx_buffer_length != 0)
         {
-            tx_done_event(p_cb, nrf_uarte_tx_amount_get(p_uarte));
+            tx_done_event(p_cb, nrfy_uarte_tx_amount_get(p_reg));
         }
     }
 }
 
-#if NRFX_CHECK(NRFX_UARTE0_ENABLED)
-void nrfx_uarte_0_irq_handler(void)
-{
-    uarte_irq_handler(NRF_UARTE0, &m_cb[NRFX_UARTE0_INST_IDX]);
-}
-#endif
-
-#if NRFX_CHECK(NRFX_UARTE1_ENABLED)
-void nrfx_uarte_1_irq_handler(void)
-{
-    uarte_irq_handler(NRF_UARTE1, &m_cb[NRFX_UARTE1_INST_IDX]);
-}
-#endif
-
-#if NRFX_CHECK(NRFX_UARTE2_ENABLED)
-void nrfx_uarte_2_irq_handler(void)
-{
-    uarte_irq_handler(NRF_UARTE2, &m_cb[NRFX_UARTE2_INST_IDX]);
-}
-#endif
-
-#if NRFX_CHECK(NRFX_UARTE3_ENABLED)
-void nrfx_uarte_3_irq_handler(void)
-{
-    uarte_irq_handler(NRF_UARTE3, &m_cb[NRFX_UARTE3_INST_IDX]);
-}
-#endif
+NRFX_INSTANCE_IRQ_HANDLERS(UARTE, uarte)
 
 #endif // NRFX_CHECK(NRFX_UARTE_ENABLED)

--- a/nrfx/drivers/src/prs/nrfx_prs.c
+++ b/nrfx/drivers/src/prs/nrfx_prs.c
@@ -73,7 +73,18 @@ PRS_BOX_DEFINE(3)
 #if defined(NRFX_PRS_BOX_4_ADDR) && NRFX_CHECK(NRFX_PRS_BOX_4_ENABLED)
 PRS_BOX_DEFINE(4)
 #endif
-
+#if defined(NRFX_PRS_BOX_5_ADDR) && NRFX_CHECK(NRFX_PRS_BOX_5_ENABLED)
+PRS_BOX_DEFINE(5)
+#endif
+#if defined(NRFX_PRS_BOX_6_ADDR) && NRFX_CHECK(NRFX_PRS_BOX_6_ENABLED)
+PRS_BOX_DEFINE(6)
+#endif
+#if defined(NRFX_PRS_BOX_7_ADDR) && NRFX_CHECK(NRFX_PRS_BOX_7_ENABLED)
+PRS_BOX_DEFINE(7)
+#endif
+#if defined(NRFX_PRS_BOX_8_ADDR) && NRFX_CHECK(NRFX_PRS_BOX_8_ENABLED)
+PRS_BOX_DEFINE(8)
+#endif
 
 static prs_box_t * prs_box_get(void const * p_base_addr)
 {
@@ -99,6 +110,22 @@ static prs_box_t * prs_box_get(void const * p_base_addr)
 #endif
 #if defined(NRFX_PRS_BOX_4_ADDR) && NRFX_CHECK(NRFX_PRS_BOX_4_ENABLED)
     if (IS_PRS_BOX(4, p_base_addr)) { return &m_prs_box_4; }
+    else
+#endif
+#if defined(NRFX_PRS_BOX_5_ADDR) && NRFX_CHECK(NRFX_PRS_BOX_5_ENABLED)
+    if (IS_PRS_BOX(5, p_base_addr)) { return &m_prs_box_5; }
+    else
+#endif
+#if defined(NRFX_PRS_BOX_6_ADDR) && NRFX_CHECK(NRFX_PRS_BOX_6_ENABLED)
+    if (IS_PRS_BOX(6, p_base_addr)) { return &m_prs_box_6; }
+    else
+#endif
+#if defined(NRFX_PRS_BOX_7_ADDR) && NRFX_CHECK(NRFX_PRS_BOX_7_ENABLED)
+    if (IS_PRS_BOX(7, p_base_addr)) { return &m_prs_box_7; }
+    else
+#endif
+#if defined(NRFX_PRS_BOX_8_ADDR) && NRFX_CHECK(NRFX_PRS_BOX_8_ENABLED)
+    if (IS_PRS_BOX(8, p_base_addr)) { return &m_prs_box_8; }
     else
 #endif
     {

--- a/nrfx/drivers/src/prs/nrfx_prs.h
+++ b/nrfx/drivers/src/prs/nrfx_prs.h
@@ -109,7 +109,7 @@ extern "C" {
     #define NRFX_PRS_BOX_2_ADDR     NRF_UARTE2
     // UARTE3, SPIM3, SPIS3, TWIM3, TWIS3
     #define NRFX_PRS_BOX_3_ADDR     NRF_UARTE3
-#else
+#elif !defined(NRF_PRS_BOX_EXT)
     #error "Unknown device."
 #endif
 
@@ -153,6 +153,10 @@ void nrfx_prs_box_1_irq_handler(void);
 void nrfx_prs_box_2_irq_handler(void);
 void nrfx_prs_box_3_irq_handler(void);
 void nrfx_prs_box_4_irq_handler(void);
+void nrfx_prs_box_5_irq_handler(void);
+void nrfx_prs_box_6_irq_handler(void);
+void nrfx_prs_box_7_irq_handler(void);
+void nrfx_prs_box_8_irq_handler(void);
 
 
 #ifdef __cplusplus

--- a/nrfx/hal/nrf_aar.h
+++ b/nrfx/hal/nrf_aar.h
@@ -413,7 +413,7 @@ NRF_STATIC_INLINE void nrf_aar_subscribe_set(NRF_AAR_Type * p_reg,
                                              uint8_t        channel)
 {
     *((volatile uint32_t *) ((uint8_t *) p_reg + (uint32_t) task + 0x80uL)) =
-            ((uint32_t)channel | AAR_SUBSCRIBE_START_EN_Msk);
+            ((uint32_t)channel | NRF_SUBSCRIBE_PUBLISH_ENABLE);
 }
 
 NRF_STATIC_INLINE void nrf_aar_subscribe_clear(NRF_AAR_Type * p_reg,
@@ -427,7 +427,7 @@ NRF_STATIC_INLINE void nrf_aar_publish_set(NRF_AAR_Type *  p_reg,
                                            uint8_t         channel)
 {
     *((volatile uint32_t *) ((uint8_t *) p_reg + (uint32_t) event + 0x80uL)) =
-            ((uint32_t)channel | AAR_PUBLISH_END_EN_Msk);
+            ((uint32_t)channel | NRF_SUBSCRIBE_PUBLISH_ENABLE);
 }
 
 NRF_STATIC_INLINE void nrf_aar_publish_clear(NRF_AAR_Type *  p_reg,

--- a/nrfx/hal/nrf_cache.h
+++ b/nrfx/hal/nrf_cache.h
@@ -47,12 +47,161 @@ extern "C" {
  * @brief   The hardware access layer for managing the CACHE peripheral.
  */
 
+#if defined(CACHEDATA_SET_WAY_DU_DATA_Data_Msk) || defined(CACHEDATA_SET_WAY_DATA0_Data_Msk) || \
+    defined(__NRFX_DOXYGEN__)
+/** @brief Presence of the CACHEDATA feature. */
+#define NRF_CACHE_HAS_CACHEDATA 1
+#else
+#define NRF_CACHE_HAS_CACHEDATA 0
+#endif
+
+#if defined(CACHEDATA_SET_WAY_DU_DATA_Data_Msk) || defined(__NRFX_DOXYGEN__)
+/** @brief Presence of the CACHE data units feature. */
+#define NRF_CACHE_HAS_CACHEDATA_DU 1
+#else
+#define NRF_CACHE_HAS_CACHEDATA_DU 0
+#endif
+
+#if defined(CACHEINFO_SET_WAY_INFO_TAG_Msk) || defined(CACHEINFO_SET_WAY_TAG_Msk) || \
+    defined(__NRFX_DOXYGEN__)
+/** @brief Presence of the CACHEINFO feature. */
+#define NRF_CACHE_HAS_CACHEINFO 1
+#else
+#define NRF_CACHE_HAS_CACHEINFO 0
+#endif
+
+#if defined(CACHE_TASKS_INVALIDATECACHE_TASKS_INVALIDATECACHE_Msk) || defined(__NRFX_DOXYGEN__)
+/** @brief Symbol indicating whether cache tasks are supported. */
+#define NRF_CACHE_HAS_TASKS 1
+#else
+#define NRF_CACHE_HAS_TASKS 0
+#endif
+
+#if defined(CACHE_TASKS_CLEANCACHE_TASKS_CLEANCACHE_Msk) || defined(__NRFX_DOXYGEN__)
+/** @brief Symbol indicating whether the CLEAN cache/line tasks are supported. */
+#define NRF_CACHE_HAS_TASK_CLEAN 1
+#else
+#define NRF_CACHE_HAS_TASK_CLEAN 0
+#endif
+
+#if defined(CACHE_TASKS_FLUSHCACHE_TASKS_FLUSHCACHE_Msk) || defined(__NRFX_DOXYGEN__)
+/** @brief Symbol indicating whether the FLUSH cache/line tasks are supported. */
+#define NRF_CACHE_HAS_TASK_FLUSH 1
+#else
+#define NRF_CACHE_HAS_TASK_FLUSH 0
+#endif
+
+#if defined(CACHE_STATUS_READY_Msk) || defined(__NRFX_DOXYGEN__)
+/** @brief Symbol indicating whether status check is supported. */
+#define NRF_CACHE_HAS_STATUS 1
+#else
+#define NRF_CACHE_HAS_STATUS 0
+#endif
+
+#if defined(CACHE_MODE_RAMSIZE_Msk) || defined(__NRFX_DOXYGEN__)
+/** @brief Symbol indicating whether splitting the dedicated RAM between cache and generic memory is supported. */
+#define NRF_CACHE_HAS_RAMSIZE 1
+#else
+#define NRF_CACHE_HAS_RAMSIZE 0
+#endif
+
+#if defined(CACHEINFO_SET_WAY_D0_Msk) || defined(__NRFX_DOXYGEN__)
+/** @brief Symbol indicating whether dirtiness check functionality for cache is supported. */
+#define NRF_CACHE_HAS_DU_DIRTY 1
+#else
+#define NRF_CACHE_HAS_DU_DIRTY 0
+#endif
+
+#if defined(CACHEINFO_SET_WAY_DUV0_Msk) || defined(CACHEINFO_SET_WAY_INFO_DUV0_Msk) || defined(__NRFX_DOXYGEN__)
+/** @brief Symbol indicating whether data unit validation functionality for cache is supported. */
+#define NRF_CACHE_HAS_DU_VALIDATION 1
+#else
+#define NRF_CACHE_HAS_DU_VALIDATION 0
+#endif
+
+#if defined(CACHEINFO_SET_WAY_INFO_DUV0_Msk) || defined(__NRFX_DOXYGEN__)
+/** @brief Symbol indicating whether data unit validation functionality for cache is supported. */
+#define NRF_CACHE_HAS_SET_WAY_INFO 1
+#else
+#define NRF_CACHE_HAS_SET_WAY_INFO 0
+#endif
+
+#if NRF_CACHE_HAS_CACHEDATA
+/** @brief Max number of words in CACHEDATA data units. */
+#define NRF_CACHEDATA_DATA_WORDS_MAX CACHEDATA_SET_WAY_DU_DATA_MaxCount
+/** @brief Max number of CACHEDATA data units. */
+#define NRF_CACHEDATA_DATA_UNITS_MAX CACHEDATA_SET_WAY_DU_MaxCount
+/** @brief Max number of CACHEDATA ways. */
+#define NRF_CACHEDATA_WAY_INDEX_MAX  CACHEDATA_SET_WAY_MaxCount
+/** @brief Max number of CACHEDATA sets. */
+#define NRF_CACHEDATA_SET_INDEX_MAX  CACHEDATA_SET_MaxCount
+#endif
+
+#if NRF_CACHE_HAS_CACHEINFO
+/** @brief Max number of CACHEINFO ways. */
+#define NRF_CACHEINFO_WAY_INDEX_MAX  CACHEINFO_SET_WAY_MaxCount
+/** @brief Max number of CACHEINFO sets. */
+#define NRF_CACHEINFO_SET_INDEX_MAX  CACHEINFO_SET_MaxCount
+#endif
+
+#if NRF_CACHE_HAS_RAMSIZE
+/** @brief Max enumerator value of RAMSIZE field. */
+#define NRF_CACHE_MODE_RAMSIZE_MAX CACHE_MODE_RAMSIZE_Max
+#endif
+
+#if NRF_CACHE_HAS_TASKS
+/** @brief CACHE tasks. */
+typedef enum
+{
+#if NRF_CACHE_HAS_TASK_CLEAN
+    NRF_CACHE_TASK_CLEANCACHE      = offsetof(NRF_CACHE_Type, TASKS_CLEANCACHE),      /**< Clean the whole cache. */
+    NRF_CACHE_TASK_CLEANLINE       = offsetof(NRF_CACHE_Type, TASKS_CLEANLINE),       /**< Clean the cache line. */
+#endif
+#if NRF_CACHE_HAS_TASK_FLUSH
+    NRF_CACHE_TASK_FLUSHCACHE      = offsetof(NRF_CACHE_Type, TASKS_FLUSHCACHE),      /**< Flush the whole cache. */
+    NRF_CACHE_TASK_FLUSHLINE       = offsetof(NRF_CACHE_Type, TASKS_FLUSHLINE),       /**< Flush the cache line. */
+#endif
+    NRF_CACHE_TASK_SAVE            = offsetof(NRF_CACHE_Type, TASKS_SAVE),            /**< Save the state to a retained memory space. */
+    NRF_CACHE_TASK_RESTORE         = offsetof(NRF_CACHE_Type, TASKS_RESTORE),         /**< Restore the state from a retained memory space. */
+    NRF_CACHE_TASK_INVALIDATECACHE = offsetof(NRF_CACHE_Type, TASKS_INVALIDATECACHE), /**< Invalidate the whole cache. */
+    NRF_CACHE_TASK_INVALIDATELINE  = offsetof(NRF_CACHE_Type, TASKS_INVALIDATELINE),  /**< Invalidate the cache line. */
+    NRF_CACHE_TASK_ERASE           = offsetof(NRF_CACHE_Type, TASKS_ERASE),           /**< Erase the whole cache. */
+} nrf_cache_task_t;
+#endif
+
 /** @brief Cache regions. */
 typedef enum
 {
     NRF_CACHE_REGION_FLASH = 0, ///< Cache region related to Flash access.
     NRF_CACHE_REGION_XIP   = 1, ///< Cache region related to XIP access.
 } nrf_cache_region_t;
+
+#if NRF_CACHE_HAS_RAMSIZE
+/** @brief Dedicated RAM size used for cache memory. */
+typedef enum
+{
+    NRF_CACHE_RAMSIZE_ALL     = CACHE_MODE_RAMSIZE_All,     ///< All RAM is used for cache memory.
+    NRF_CACHE_RAMSIZE_HALF    = CACHE_MODE_RAMSIZE_Half,    ///< Half of the RAM is used for cache memory.
+    NRF_CACHE_RAMSIZE_QUARTER = CACHE_MODE_RAMSIZE_Quarter, ///< Quarter of the RAM is used for cache memory.
+    NRF_CACHE_RAMSIZE_NONE    = CACHE_MODE_RAMSIZE_None     ///< None of the RAM is used for cache memory.
+} nrf_cache_ramsize_t;
+#endif
+
+/** @brief Structure describing location of the data stored in cache depending on a cache set and way. */
+typedef struct
+{
+    uint32_t set; ///< Cache set containing data to get.
+    uint8_t  way; ///< Cache way containing data to get.
+} nrf_cache_set_way_loc_t;
+
+/** @brief Structure describing location of the data stored in cache depending on data unit and word. */
+typedef struct
+{
+#if NRF_CACHE_HAS_CACHEDATA_DU
+    uint8_t du;   ///< Data unit that containing data to get.
+#endif
+    uint8_t word; ///< Index of a specific data word.
+} nrf_cache_du_word_loc_t;
 
 /**
  * @brief Function for enabling the CACHE peripheral.
@@ -181,13 +330,44 @@ NRF_STATIC_INLINE uint32_t nrf_cache_data_miss_counter_get(NRF_CACHE_Type const 
  * In this mode, the cache data contents can be used as the read/write RAM.
  * Only the data content of the cache is available as RAM.
  *
- * @note -Enabling the RAM mode causes the RAM to be cleared.
- * @note -Disabling the RAM mode causes the cache to be invalidated.
+ * @note Enabling the RAM mode causes the RAM to be cleared.
+ * @note Disabling the RAM mode causes the cache to be invalidated.
  *
  * @param[in] p_reg  Pointer to the structure of registers of the peripheral.
  * @param[in] enable True if the cache RAM mode is to be enabled, false otherwise.
  */
 NRF_STATIC_INLINE void nrf_cache_ram_mode_set(NRF_CACHE_Type * p_reg, bool enable);
+
+/**
+ * @brief Function for checking whether the cache is in RAM mode.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ *
+ * @return True if the cache RAM mode is enabled, false otherwise.
+ */
+NRF_STATIC_INLINE bool nrf_cache_ram_mode_check(NRF_CACHE_Type const * p_reg);
+
+#if NRF_CACHE_HAS_RAMSIZE
+/**
+ * @brief Function for setting the configuration of splitting the dedicated cache RAM.
+ *
+ * @details Dedicated cache RAM can be splitted into cache memory and generic memory.
+ *          By default, all dedicated RAM is used for cache memory.
+ *
+ * @param[in] p_reg   Pointer to the structure of registers of the peripheral.
+ * @param[in] ramsize Dedicated cache RAM split configuration.
+ */
+NRF_STATIC_INLINE void nrf_cache_ramsize_set(NRF_CACHE_Type * p_reg, nrf_cache_ramsize_t ramsize);
+
+/**
+ * @brief Function for getting the configuration of splitting the dedicated cache RAM.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ *
+ * @return Configuration of dedicated cache RAM split.
+ */
+NRF_STATIC_INLINE nrf_cache_ramsize_t nrf_cache_ramsize_get(NRF_CACHE_Type const * p_reg);
+#endif
 
 /**
  * @brief Function for blocking the cache content access.
@@ -214,51 +394,48 @@ NRF_STATIC_INLINE void nrf_cache_read_lock_enable(NRF_CACHE_Type * p_reg);
  */
 NRF_STATIC_INLINE void nrf_cache_update_lock_set(NRF_CACHE_Type * p_reg, bool enable);
 
+#if NRF_CACHE_HAS_CACHEDATA
 /**
  * @brief Function for getting the cache data word.
  *
  * @note When operating in the RAM mode, the cache data is accessible as a general purpose RAM.
  *
- * @param[in] p_reg Pointer to the structure of registers of the peripheral.
- * @param[in] set   Set that contains the data to get.
- * @param[in] way   Way that contains the data to get.
- * @param[in] word  Data word index to get.
+ * @param[in] p_reg     Pointer to the structure of registers of the peripheral.
+ * @param[in] p_set_way Pointer to the structure of location parameters depending on a cache set and way.
+ * @param[in] p_du_word Pointer to the structure of location parameters depending on data unit and word.
  *
  * @return 32-bit data word.
  */
-NRF_STATIC_INLINE uint32_t nrf_cache_data_get(NRF_CACHEDATA_Type const * p_reg,
-                                              uint32_t                   set,
-                                              uint8_t                    way,
-                                              uint8_t                    word);
+NRF_STATIC_INLINE uint32_t nrf_cache_data_get(NRF_CACHEDATA_Type const *      p_reg,
+                                              nrf_cache_set_way_loc_t const * p_set_way,
+                                              nrf_cache_du_word_loc_t const * p_du_word);
+#endif
 
+#if NRF_CACHE_HAS_CACHEINFO
 /**
  * @brief Function for getting the tag associated with the specified set and way.
  *
  * The tag is used to check if an entry in the cache matches the address that is being fetched.
  *
- * @param[in] p_reg Pointer to the structure of registers of the peripheral.
- * @param[in] set   Set that contains the tag to get.
- * @param[in] way   Way that contains the tag to get.
+ * @param[in] p_reg     Pointer to the structure of registers of the peripheral.
+ * @param[in] p_set_way Pointer to the structure of location parameters depending on a cache set and way.
  *
  * @return Tag value.
  */
-NRF_STATIC_INLINE uint32_t nrf_cache_tag_get(NRF_CACHEINFO_Type const * p_reg,
-                                             uint32_t                   set,
-                                             uint8_t                    way);
+NRF_STATIC_INLINE uint32_t nrf_cache_tag_get(NRF_CACHEINFO_Type const *      p_reg,
+                                             nrf_cache_set_way_loc_t const * p_set_way);
 
 /**
  * @brief Function for checking the validity of a cache line associated with the specified set and way.
  *
- * @param[in] p_reg Pointer to the structure of registers of the peripheral.
- * @param[in] set   Set that contains the cache line to check.
- * @param[in] way   Way that contains the cache line to check.
+ * @param[in] p_reg     Pointer to the structure of registers of the peripheral.
+ * @param[in] p_set_way Pointer to the structure of location parameters depending on a cache set and way.
  *
  * @retval true  Cache line is valid.
  * @retval false Cache line is invalid.
  */
-NRF_STATIC_INLINE bool nrf_cache_line_validity_check(NRF_CACHEINFO_Type const * p_reg,
-                                                     uint32_t                   set,
-                                                     uint8_t                    way);
+NRF_STATIC_INLINE bool nrf_cache_line_validity_check(NRF_CACHEINFO_Type const *      p_reg,
+                                                     nrf_cache_set_way_loc_t const * p_set_way);
 
 /**
  * @brief Function for getting the most recently used way in the specified set.
@@ -271,6 +448,79 @@ NRF_STATIC_INLINE bool nrf_cache_line_validity_check(NRF_CACHEINFO_Type const * 
  * @return The most recently used way in the specified set.
  */
 NRF_STATIC_INLINE uint8_t nrf_cache_mru_get(NRF_CACHEINFO_Type const * p_reg, uint32_t set);
+#endif
+
+#if NRF_CACHE_HAS_DU_VALIDATION
+/**
+ * @brief Function for checking the validity of a data unit associated with the specified set and way.
+ *
+ * @param[in] p_reg     Pointer to the structure of registers of the peripheral.
+ * @param[in] p_set_way Pointer to the structure of location parameters depending on a cache set and way.
+ * @param[in] p_du_word Pointer to the structure of location parameters depending on data unit and word.
+ *
+ * @retval true  Data unit is valid.
+ * @retval false Data unit is invalid.
+ */
+NRF_STATIC_INLINE bool nrf_cache_data_unit_validity_check(NRF_CACHEINFO_Type const *      p_reg,
+                                                          nrf_cache_set_way_loc_t const * p_set_way,
+                                                          nrf_cache_du_word_loc_t const * p_du_word);
+#endif
+
+#if NRF_CACHE_HAS_DU_DIRTY
+/**
+ * @brief Function for checking the dirtiness of a data unit associated with the specified set and way.
+ *
+ * @param[in] p_reg     Pointer to the structure of registers of the peripheral.
+ * @param[in] p_set_way Pointer to the structure of location parameters depending on a cache set and way.
+ * @param[in] p_du_word Pointer to the structure of location parameters depending on data unit and word.
+ *
+ * @retval true  Data unit is dirty.
+ * @retval false Data unit is clean.
+ */
+NRF_STATIC_INLINE bool nrf_cache_is_data_unit_dirty_check(NRF_CACHEINFO_Type const *      p_reg,
+                                                          nrf_cache_set_way_loc_t const * p_set_way,
+                                                          nrf_cache_du_word_loc_t const * p_du_word);
+#endif
+
+#if NRF_CACHE_HAS_TASKS
+/**
+ * @brief Function to set the memory address covered by the line to be maintained.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ * @param[in] addr  Cache line adress.
+ */
+NRF_STATIC_INLINE void nrf_cache_lineaddr_set(NRF_CACHE_Type * p_reg, uint32_t addr);
+
+/**
+ * @brief Function for triggering the specified CACHE task.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ * @param[in] task  Task.
+ */
+NRF_STATIC_INLINE void nrf_cache_task_trigger(NRF_CACHE_Type * p_reg, nrf_cache_task_t task);
+
+/**
+ * @brief Function for returning the address of the specified task register.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ * @param[in] task  Task.
+ *
+ * @return Task address.
+ */
+NRF_STATIC_INLINE uint32_t nrf_cache_task_address_get(NRF_CACHE_Type const * p_reg,
+                                                      nrf_cache_task_t       task);
+#endif
+
+#if NRF_CACHE_HAS_STATUS
+/**
+ * @brief Function for checking if the cache is busy or not.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ *
+ * @return True if the cache is busy, false otherwise.
+ */
+NRF_STATIC_INLINE bool nrf_cache_busy_check(NRF_CACHE_Type const * p_reg);
+#endif
 
 #ifndef NRF_DECLARE_ONLY
 
@@ -286,63 +536,129 @@ NRF_STATIC_INLINE void nrf_cache_disable(NRF_CACHE_Type * p_reg)
 
 NRF_STATIC_INLINE void nrf_cache_invalidate(NRF_CACHE_Type * p_reg)
 {
+#if NRF_CACHE_HAS_TASKS
+    nrf_cache_task_trigger(p_reg, NRF_CACHE_TASK_INVALIDATECACHE);
+#else
     p_reg->INVALIDATE = CACHE_INVALIDATE_INVALIDATE_Invalidate;
+#endif
 }
 
 NRF_STATIC_INLINE void nrf_cache_erase(NRF_CACHE_Type * p_reg)
 {
+#if NRF_CACHE_HAS_TASKS
+    nrf_cache_task_trigger(p_reg, NRF_CACHE_TASK_ERASE);
+#else
     p_reg->ERASE = CACHE_ERASE_ERASE_Erase;
+#endif
 }
 
 NRF_STATIC_INLINE bool nrf_cache_erase_status_check(NRF_CACHE_Type const * p_reg)
 {
-    return (bool)(p_reg->ERASESTATUS & CACHE_ERASESTATUS_ERASESTATUS_Msk);
+#if NRF_CACHE_HAS_STATUS
+    return (!nrf_cache_busy_check(p_reg));
+#else
+    return (p_reg->ERASESTATUS & CACHE_ERASESTATUS_ERASESTATUS_Msk) ==
+        (CACHE_ERASESTATUS_ERASESTATUS_Finished << CACHE_ERASESTATUS_ERASESTATUS_Pos);
+#endif
 }
 
 NRF_STATIC_INLINE void nrf_cache_erase_status_clear(NRF_CACHE_Type * p_reg)
 {
+#if NRF_CACHE_HAS_TASKS
+    /* No task for erasing the status */
+    (void)p_reg;
+#else
     p_reg->ERASESTATUS = 0;
+#endif
 }
 
 NRF_STATIC_INLINE void nrf_cache_profiling_set(NRF_CACHE_Type * p_reg, bool enable)
 {
+#if defined(CACHE_PROFILINGENABLE_ENABLE_Msk)
     p_reg->PROFILINGENABLE =
         (enable ? CACHE_PROFILINGENABLE_ENABLE_Enable : CACHE_PROFILINGENABLE_ENABLE_Disable);
+#elif defined(CACHE_PROFILING_ENABLE_ENABLE_Msk)
+    p_reg->PROFILING.ENABLE =
+        (enable ? CACHE_PROFILING_ENABLE_ENABLE_Enable : CACHE_PROFILING_ENABLE_ENABLE_Disable);
+#endif
 }
 
 NRF_STATIC_INLINE void nrf_cache_profiling_counters_clear(NRF_CACHE_Type * p_reg)
 {
+#if defined(CACHE_PROFILINGCLEAR_CLEAR_Msk)
     p_reg->PROFILINGCLEAR = (CACHE_PROFILINGCLEAR_CLEAR_Clear << CACHE_PROFILINGCLEAR_CLEAR_Pos);
+#elif defined(CACHE_PROFILING_CLEAR_CLEAR_Msk)
+    p_reg->PROFILING.CLEAR = (CACHE_PROFILING_CLEAR_CLEAR_Clear << CACHE_PROFILING_CLEAR_CLEAR_Pos);
+#endif
 }
 
 NRF_STATIC_INLINE uint32_t nrf_cache_instruction_hit_counter_get(NRF_CACHE_Type const * p_reg,
                                                                  nrf_cache_region_t     region)
 {
+#if defined(CACHE_PROFILING_IHIT_HITS_Msk)
     return p_reg->PROFILING[region].IHIT;
+#elif defined(CACHE_PROFILING_HIT_HITS_Msk)
+    (void)region;
+    return p_reg->PROFILING.HIT;
+#endif
 }
 
 NRF_STATIC_INLINE uint32_t nrf_cache_instruction_miss_counter_get(NRF_CACHE_Type const * p_reg,
                                                                   nrf_cache_region_t     region)
 {
+#if defined(CACHE_PROFILING_IMISS_MISSES_Msk)
     return p_reg->PROFILING[region].IMISS;
+#elif defined(CACHE_PROFILING_MISS_MISSES_Msk)
+    (void)region;
+    return p_reg->PROFILING.MISS;
+#endif
 }
 
 NRF_STATIC_INLINE uint32_t nrf_cache_data_hit_counter_get(NRF_CACHE_Type const * p_reg,
                                                           nrf_cache_region_t     region)
 {
+#if defined(CACHE_PROFILING_DHIT_HITS_Msk)
     return p_reg->PROFILING[region].DHIT;
+#elif defined(CACHE_PROFILING_HIT_HITS_Msk)
+    (void)region;
+    return p_reg->PROFILING.HIT;
+#endif
 }
 
 NRF_STATIC_INLINE uint32_t nrf_cache_data_miss_counter_get(NRF_CACHE_Type const * p_reg,
                                                            nrf_cache_region_t     region)
 {
+#if defined(CACHE_PROFILING_DMISS_MISSES_Msk)
     return p_reg->PROFILING[region].DMISS;
+#elif defined(CACHE_PROFILING_MISS_MISSES_Msk)
+    (void)region;
+    return p_reg->PROFILING.MISS;
+#endif
 }
 
 NRF_STATIC_INLINE void nrf_cache_ram_mode_set(NRF_CACHE_Type * p_reg, bool enable)
 {
-    p_reg->MODE = (enable ? CACHE_MODE_MODE_Ram : CACHE_MODE_MODE_Cache);
+    p_reg->MODE = ((p_reg->MODE & ~CACHE_MODE_MODE_Msk) |
+                   ((enable ? CACHE_MODE_MODE_Ram : CACHE_MODE_MODE_Cache)
+                   << CACHE_MODE_MODE_Pos));
 }
+
+NRF_STATIC_INLINE bool nrf_cache_ram_mode_check(NRF_CACHE_Type const * p_reg)
+{
+    return (p_reg->MODE & CACHE_MODE_MODE_Msk) == (CACHE_MODE_MODE_Ram << CACHE_MODE_MODE_Pos);
+}
+
+#if NRF_CACHE_HAS_RAMSIZE
+NRF_STATIC_INLINE void nrf_cache_ramsize_set(NRF_CACHE_Type * p_reg, nrf_cache_ramsize_t ramsize)
+{
+    p_reg->MODE = ((p_reg->MODE & ~CACHE_MODE_RAMSIZE_Msk) | (ramsize << CACHE_MODE_RAMSIZE_Pos));
+}
+
+NRF_STATIC_INLINE nrf_cache_ramsize_t nrf_cache_ramsize_get(NRF_CACHE_Type const * p_reg)
+{
+    return (nrf_cache_ramsize_t)((p_reg->MODE & CACHE_MODE_RAMSIZE_Msk) >> CACHE_MODE_RAMSIZE_Pos);
+}
+#endif
 
 NRF_STATIC_INLINE void nrf_cache_read_lock_enable(NRF_CACHE_Type * p_reg)
 {
@@ -355,13 +671,21 @@ NRF_STATIC_INLINE void nrf_cache_update_lock_set(NRF_CACHE_Type * p_reg, bool en
         (enable ? CACHE_WRITELOCK_WRITELOCK_Locked : CACHE_WRITELOCK_WRITELOCK_Unlocked);
 }
 
-NRF_STATIC_INLINE uint32_t nrf_cache_data_get(NRF_CACHEDATA_Type const * p_reg,
-                                              uint32_t                   set,
-                                              uint8_t                    way,
-                                              uint8_t                    word)
+#if NRF_CACHE_HAS_CACHEDATA
+NRF_STATIC_INLINE uint32_t nrf_cache_data_get(NRF_CACHEDATA_Type const *      p_reg,
+                                              nrf_cache_set_way_loc_t const * p_set_way,
+                                              nrf_cache_du_word_loc_t const * p_du_word)
 {
-    volatile CACHEDATA_SET_WAY_Type const * reg = &p_reg->SET[set].WAY[way];
-    switch (word)
+#if NRF_CACHE_HAS_CACHEDATA_DU
+    NRFX_ASSERT(p_du_word->word < NRF_CACHEDATA_DATA_WORDS_MAX);
+    NRFX_ASSERT(p_du_word->du < NRF_CACHEDATA_DATA_UNITS_MAX);
+    NRFX_ASSERT(p_set_way->way < NRF_CACHEDATA_WAY_INDEX_MAX);
+    NRFX_ASSERT(p_set_way->set < NRF_CACHEDATA_SET_INDEX_MAX);
+
+    return p_reg->SET[p_set_way->set].WAY[p_set_way->way].DU[p_du_word->du].DATA[p_du_word->word];
+#else
+    volatile CACHEDATA_SET_WAY_Type const * reg = &p_reg->SET[p_set_way->set].WAY[p_set_way->way];
+    switch (p_du_word->word)
     {
         case 0: return reg->DATA0;
         case 1: return reg->DATA1;
@@ -371,26 +695,145 @@ NRF_STATIC_INLINE uint32_t nrf_cache_data_get(NRF_CACHEDATA_Type const * p_reg,
             NRFX_ASSERT(false);
             return 0;
     }
+#endif
+}
+#endif
+
+#if NRF_CACHE_HAS_CACHEINFO
+NRF_STATIC_INLINE uint32_t nrf_cache_tag_get(NRF_CACHEINFO_Type const *      p_reg,
+                                             nrf_cache_set_way_loc_t const * p_set_way)
+{
+#if defined(CACHEINFO_SET_WAY_INFO_TAG_Msk)
+    NRFX_ASSERT(p_set_way->way < NRF_CACHEINFO_WAY_INDEX_MAX);
+    NRFX_ASSERT(p_set_way->set < NRF_CACHEINFO_SET_INDEX_MAX);
+    return (p_reg->SET[p_set_way->set].WAY[p_set_way->way].INFO & CACHEINFO_SET_WAY_INFO_TAG_Msk);
+#else
+    return (p_reg->SET[p_set_way->set].WAY[p_set_way->way] & CACHEINFO_SET_WAY_TAG_Msk);
+#endif
 }
 
-NRF_STATIC_INLINE uint32_t nrf_cache_tag_get(NRF_CACHEINFO_Type const * p_reg,
-                                             uint32_t                   set,
-                                             uint8_t                    way)
+NRF_STATIC_INLINE bool nrf_cache_line_validity_check(NRF_CACHEINFO_Type const *      p_reg,
+                                                     nrf_cache_set_way_loc_t const * p_set_way)
 {
-    return (p_reg->SET[set].WAY[way] & CACHEINFO_SET_WAY_TAG_Msk);
-}
-
-NRF_STATIC_INLINE bool nrf_cache_line_validity_check(NRF_CACHEINFO_Type const * p_reg,
-                                                     uint32_t                   set,
-                                                     uint8_t                    way)
-{
-    return (bool)(p_reg->SET[set].WAY[way] & CACHEINFO_SET_WAY_V_Msk);
+#if defined(CACHEINFO_SET_WAY_INFO_V_Msk)
+    NRFX_ASSERT(p_set_way->way < NRF_CACHEINFO_WAY_INDEX_MAX);
+    NRFX_ASSERT(p_set_way->set < NRF_CACHEINFO_SET_INDEX_MAX);
+    return (p_reg->SET[p_set_way->set].WAY[p_set_way->way].INFO & CACHEINFO_SET_WAY_INFO_V_Msk) ==
+        (CACHEINFO_SET_WAY_INFO_V_Valid << CACHEINFO_SET_WAY_INFO_V_Pos);
+#else
+    return (p_reg->SET[p_set_way->set].WAY[p_set_way->way] & CACHEINFO_SET_WAY_V_Msk) ==
+        (CACHEINFO_SET_WAY_V_Valid << CACHEINFO_SET_WAY_V_Pos);
+#endif
 }
 
 NRF_STATIC_INLINE uint8_t nrf_cache_mru_get(NRF_CACHEINFO_Type const * p_reg, uint32_t set)
 {
+#if defined(CACHEINFO_SET_WAY_INFO_MRU_Pos)
+    NRFX_ASSERT(set < NRF_CACHEINFO_SET_INDEX_MAX);
+    return ((p_reg->SET[set].WAY[0].INFO & CACHEINFO_SET_WAY_INFO_MRU_Msk) >>
+        CACHEINFO_SET_WAY_INFO_MRU_Pos);
+#else
     return ((p_reg->SET[set].WAY[0] & CACHEINFO_SET_WAY_MRU_Msk) >> CACHEINFO_SET_WAY_MRU_Pos);
+#endif
 }
+
+#if NRF_CACHE_HAS_DU_VALIDATION
+NRF_STATIC_INLINE bool nrf_cache_data_unit_validity_check(NRF_CACHEINFO_Type const *      p_reg,
+                                                          nrf_cache_set_way_loc_t const * p_set_way,
+                                                          nrf_cache_du_word_loc_t const * p_du_word)
+{
+    (void)p_du_word->word;
+    NRFX_ASSERT(p_set_way->way < NRF_CACHEINFO_WAY_INDEX_MAX);
+    NRFX_ASSERT(p_set_way->set < NRF_CACHEINFO_SET_INDEX_MAX);
+    switch (p_du_word->du)
+    {
+#if NRF_CACHE_HAS_SET_WAY_INFO
+        case 0:
+            return (p_reg->SET[p_set_way->set].WAY[p_set_way->way].INFO &
+                    CACHEINFO_SET_WAY_INFO_DUV0_Msk) ==
+                   (CACHEINFO_SET_WAY_INFO_DUV0_Valid << CACHEINFO_SET_WAY_INFO_DUV0_Pos);
+        case 1:
+            return (p_reg->SET[p_set_way->set].WAY[p_set_way->way].INFO &
+                    CACHEINFO_SET_WAY_INFO_DUV1_Msk) ==
+                   (CACHEINFO_SET_WAY_INFO_DUV1_Valid << CACHEINFO_SET_WAY_INFO_DUV1_Pos);
+        case 2:
+            return (p_reg->SET[p_set_way->set].WAY[p_set_way->way].INFO &
+                    CACHEINFO_SET_WAY_INFO_DUV2_Msk) ==
+                   (CACHEINFO_SET_WAY_INFO_DUV2_Valid << CACHEINFO_SET_WAY_INFO_DUV2_Pos);
+        case 3:
+            return (p_reg->SET[p_set_way->set].WAY[p_set_way->way].INFO &
+                    CACHEINFO_SET_WAY_INFO_DUV3_Msk) ==
+                   (CACHEINFO_SET_WAY_INFO_DUV3_Valid << CACHEINFO_SET_WAY_INFO_DUV3_Pos);
+#else
+        case 0:
+            return (p_reg->SET[p_set_way->set].WAY[p_set_way->way] & CACHEINFO_SET_WAY_DUV0_Msk) ==
+                   (CACHEINFO_SET_WAY_DUV0_Valid << CACHEINFO_SET_WAY_DUV0_Pos);
+        case 1:
+            return (p_reg->SET[p_set_way->set].WAY[p_set_way->way] & CACHEINFO_SET_WAY_DUV1_Msk) ==
+                   (CACHEINFO_SET_WAY_DUV1_Valid << CACHEINFO_SET_WAY_DUV1_Pos);
+        case 2:
+            return (p_reg->SET[p_set_way->set].WAY[p_set_way->way] & CACHEINFO_SET_WAY_DUV2_Msk) ==
+                   (CACHEINFO_SET_WAY_DUV2_Valid << CACHEINFO_SET_WAY_DUV2_Pos);
+        case 3:
+            return (p_reg->SET[p_set_way->set].WAY[p_set_way->way] & CACHEINFO_SET_WAY_DUV3_Msk) ==
+                   (CACHEINFO_SET_WAY_DUV3_Valid << CACHEINFO_SET_WAY_DUV3_Pos);
+#endif
+        default:
+            NRFX_ASSERT(false);
+            return false;
+    }
+}
+#endif // NRF_CACHE_HAS_DU_VALIDATION
+
+#if NRF_CACHE_HAS_DU_DIRTY
+NRF_STATIC_INLINE bool nrf_cache_is_data_unit_dirty_check(NRF_CACHEINFO_Type const *      p_reg,
+                                                          nrf_cache_set_way_loc_t const * p_set_way,
+                                                          nrf_cache_du_word_loc_t const * p_du_word)
+{
+    (void)p_du_word->word;
+    NRFX_ASSERT(p_set_way->way < NRF_CACHEINFO_WAY_INDEX_MAX);
+    NRFX_ASSERT(p_set_way->set < NRF_CACHEINFO_SET_INDEX_MAX);
+    switch (p_du_word->du)
+    {
+        case 0:
+            return (p_reg->SET[p_set_way->set].WAY[p_set_way->way] & CACHEINFO_SET_WAY_D0_Msk) ==
+                (CACHEINFO_SET_WAY_D0_Dirty << CACHEINFO_SET_WAY_D0_Pos);
+        case 1:
+            return (p_reg->SET[p_set_way->set].WAY[p_set_way->way] & CACHEINFO_SET_WAY_D1_Msk) ==
+                (CACHEINFO_SET_WAY_D1_Dirty << CACHEINFO_SET_WAY_D1_Pos);
+        default:
+            NRFX_ASSERT(false);
+            return false;
+    }
+}
+#endif
+#endif // NRF_CACHE_HAS_CACHEINFO
+
+#if NRF_CACHE_HAS_TASKS
+NRF_STATIC_INLINE void nrf_cache_lineaddr_set(NRF_CACHE_Type * p_reg, uint32_t addr)
+{
+    p_reg->LINEADDR = addr;
+}
+
+NRF_STATIC_INLINE void nrf_cache_task_trigger(NRF_CACHE_Type * p_reg, nrf_cache_task_t task)
+{
+    *((volatile uint32_t *)((uint8_t *)p_reg + (uint32_t)task)) = 0x1UL;
+}
+
+NRF_STATIC_INLINE uint32_t nrf_cache_task_address_get(NRF_CACHE_Type const * p_reg,
+                                                      nrf_cache_task_t       task)
+{
+    return (uint32_t)p_reg + (uint32_t)task;
+}
+#endif
+
+#if NRF_CACHE_HAS_STATUS
+NRF_STATIC_INLINE bool nrf_cache_busy_check(NRF_CACHE_Type const * p_reg)
+{
+    return (p_reg->STATUS & CACHE_STATUS_READY_Msk) ==
+        (CACHE_STATUS_READY_Busy << CACHE_STATUS_READY_Pos);
+}
+#endif
 
 #endif // NRF_DECLARE_ONLY
 

--- a/nrfx/hal/nrf_ccm.h
+++ b/nrfx/hal/nrf_ccm.h
@@ -35,6 +35,9 @@
 #define NRF_CCM_H__
 
 #include <nrfx.h>
+#ifdef EASYVDMA_PRESENT
+#include <helpers/nrf_vdma.h>
+#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -47,13 +50,300 @@ extern "C" {
  * @brief   Hardware access layer for managing the AES CCM peripheral.
  */
 
+#if defined(CCM_TASKS_KSGEN_TASKS_KSGEN_Msk) || defined(__NRFX_DOXYGEN__)
+/** @brief Presence of the KSGEN task. */
+#define NRF_CCM_HAS_TASK_KSGEN 1
+#else
+#define NRF_CCM_HAS_TASK_KSGEN 0
+#endif
+
+#if defined(CCM_TASKS_CRYPT_TASKS_CRYPT_Msk) || defined(__NRFX_DOXYGEN__)
+/** @brief Presence of the CRYPT task. */
+#define NRF_CCM_HAS_TASK_CRYPT 1
+#else
+#define NRF_CCM_HAS_TASK_CRYPT 0
+#endif
+
+#if defined(CCM_TASKS_START_TASKS_START_Msk) || defined(__NRFX_DOXYGEN__)
+/** @brief Presence of the START task. */
+#define NRF_CCM_HAS_TASK_START 1
+#else
+#define NRF_CCM_HAS_TASK_START 0
+#endif
+
+#if defined(CCM_TASKS_RATEOVERRIDE_TASKS_RATEOVERRIDE_Msk) || defined(__NRFX_DOXYGEN__)
+/** @brief Presence of the RATEOVERRIDE task. */
+#define NRF_CCM_HAS_TASK_RATEOVERRIDE 1
+#else
+#define NRF_CCM_HAS_TASK_RATEOVERRIDE 0
+#endif
+
+#if defined(CCM_EVENTS_ENDKSGEN_EVENTS_ENDKSGEN_Msk) || defined(CCM_INTENSET_ENDKSGEN_Msk) || \
+    defined(__NRFX_DOXYGEN__)
+/** @brief Presence of the ENDKSGEN event. */
+#define NRF_CCM_HAS_EVENT_ENDKSGEN 1
+#else
+#define NRF_CCM_HAS_EVENT_ENDKSGEN 0
+#endif
+
+#if defined(CCM_EVENTS_ENDCRYPT_EVENTS_ENDCRYPT_Msk) || defined(CCM_INTENSET_ENDCRYPT_Msk) || \
+    defined(__NRFX_DOXYGEN__)
+/** @brief Presence of the ENDCRYPT event. */
+#define NRF_CCM_HAS_EVENT_ENDCRYPT 1
+#else
+#define NRF_CCM_HAS_EVENT_ENDCRYPT 0
+#endif
+
+#if defined(CCM_EVENTS_END_EVENTS_END_Msk) || defined(__NRFX_DOXYGEN__)
+/** @brief Presence of the END event. */
+#define NRF_CCM_HAS_EVENT_END 1
+#else
+#define NRF_CCM_HAS_EVENT_END 0
+#endif
+
+#if defined(CCM_ADATAMASK_ADATAMASK_Msk) || defined(__NRFX_DOXYGEN__)
+/** @brief Presence of the ADATAMASK register. */
+#define NRF_CCM_HAS_ADATAMASK 1
+#else
+#define NRF_CCM_HAS_ADATAMASK 0
+#endif
+
+#if defined(CCM_CNFPTR_CNFPTR_Msk) || defined(__NRFX_DOXYGEN__)
+/** @brief Presence of the CNFPTR register. */
+#define NRF_CCM_HAS_CNFPTR 1
+#else
+#define NRF_CCM_HAS_CNFPTR 0
+#endif
+
+#if defined(CCM_IN_AMOUNT_AMOUNT_Msk) || defined(__NRFX_DOXYGEN__)
+/** @brief Presence of the IN.AMOUNT register. */
+#define NRF_CCM_HAS_IN_AMOUNT 1
+#else
+#define NRF_CCM_HAS_IN_AMOUNT 0
+#endif
+
+#if defined(CCM_OUT_AMOUNT_AMOUNT_Msk) || defined(__NRFX_DOXYGEN__)
+/** @brief Presence of the OUT.AMOUNT register. */
+#define NRF_CCM_HAS_OUT_AMOUNT 1
+#else
+#define NRF_CCM_HAS_OUT_AMOUNT 0
+#endif
+
+#if defined(CCM_RATEOVERRIDE_RATEOVERRIDE_Pos) || defined(__NRFX_DOXYGEN__)
+/** @brief Presence of the RATEOVERRIDE register. */
+#define NRF_CCM_HAS_RATEOVERRIDE 1
+#else
+#define NRF_CCM_HAS_RATEOVERRIDE 0
+#endif
+
+#if defined(CCM_ERRORSTATUS_ERRORSTATUS_Msk) || defined(__NRFX_DOXYGEN__)
+/** @brief Presence of the ERRORSTATUS register. */
+#define NRF_CCM_HAS_ERRORSTATUS 1
+#else
+#define NRF_CCM_HAS_ERRORSTATUS 0
+#endif
+
+#if defined(CCM_MICSTATUS_MICSTATUS_Msk) || defined(__NRFX_DOXYGEN__)
+/** @brief Presence of the MICSTATUS register. */
+#define NRF_CCM_HAS_MICSTATUS 1
+#else
+#define NRF_CCM_HAS_MICSTATUS 0
+#endif
+
+#if defined(CCM_MACSTATUS_MACSTATUS_Msk) || defined(__NRFX_DOXYGEN__)
+/** @brief Presence of the MACSTATUS register. */
+#define NRF_CCM_HAS_MACSTATUS 1
+#else
+#define NRF_CCM_HAS_MACSTATUS 0
+#endif
+
+#if defined(CCM_KEY_VALUE_VALUE_Msk) || defined(__NRFX_DOXYGEN__)
+/** @brief Presence of the KEY register. */
+#define NRF_CCM_HAS_KEY 1
+#else
+#define NRF_CCM_HAS_KEY 0
+#endif
+
+#if defined(CCM_NONCE_VALUE_VALUE_Msk) || defined(__NRFX_DOXYGEN__)
+/** @brief Presence of the NONCE register. */
+#define NRF_CCM_HAS_NONCE 1
+#else
+#define NRF_CCM_HAS_NONCE 0
+#endif
+
+#if defined(CCM_INPTR_INPTR_Msk) || defined(__NRFX_DOXYGEN__)
+/** @brief Presence of the INPTR register. */
+#define NRF_CCM_HAS_INPTR 1
+#else
+#define NRF_CCM_HAS_INPTR 0
+#endif
+
+#if defined(CCM_OUTPTR_OUTPTR_Msk) || defined(__NRFX_DOXYGEN__)
+/** @brief Presence of the OUTPTR register. */
+#define NRF_CCM_HAS_OUTPTR 1
+#else
+#define NRF_CCM_HAS_OUTPTR 0
+#endif
+
+#if defined(CCM_IN_PTR_PTR_Msk) || defined(__NRFX_DOXYGEN__)
+/** @brief Presence of the IN.PTR register. */
+#define NRF_CCM_HAS_IN_PTR 1
+#else
+#define NRF_CCM_HAS_IN_PTR 0
+#endif
+
+#if defined(CCM_OUT_PTR_PTR_Msk) || defined(__NRFX_DOXYGEN__)
+/** @brief Presence of the OUT.PTR register. */
+#define NRF_CCM_HAS_OUT_PTR 1
+#else
+#define NRF_CCM_HAS_OUT_PTR 0
+#endif
+
+#if defined(CCM_SCRATCHPTR_SCRATCHPTR_Msk) || defined(__NRFX_DOXYGEN__)
+/** @brief Presence of the SCRATCHPTR register. */
+#define NRF_CCM_HAS_SCRATCHPTR 1
+#else
+#define NRF_CCM_HAS_SCRATCHPTR 0
+#endif
+
+#if defined(CCM_MAXPACKETSIZE_MAXPACKETSIZE_Pos) || defined(__NRFX_DOXYGEN__)
+/** @brief Presence of the MAXPACKETSIZE. */
+#define NRF_CCM_HAS_MAXPACKETSIZE 1
+#else
+#define NRF_CCM_HAS_MAXPACKETSIZE 0
+#endif
+
+#if defined(CCM_MODE_MODE_FastDecryption) || defined(__NRFX_DOXYGEN__)
+/** Presence of AES fast decrypt mode. */
+#define NRF_CCM_HAS_MODE_FAST_DECRYPTION 1
+#else
+#define NRF_CCM_HAS_MODE_FAST_DECRYPTION 0
+#endif
+
+#if defined(CCM_MODE_PROTOCOL_Msk) || defined(__NRFX_DOXYGEN__)
+/** @brief Presence of protocol and packet format selection. */
+#define NRF_CCM_HAS_MODE_PROTOCOL 1
+#else
+#define NRF_CCM_HAS_MODE_PROTOCOL 0
+#endif
+
+#if defined(CCM_MODE_PROTOCOL_Ble) || defined(__NRFX_DOXYGEN__)
+/** @brief Presence of the BLE packet format. */
+#define NRF_CCM_HAS_MODE_PROTOCOL_BLE 1
+#else
+#define NRF_CCM_HAS_MODE_PROTOCOL_BLE 0
+#endif
+
+#if defined(CCM_MODE_PROTOCOL_Ieee802154) || defined(__NRFX_DOXYGEN__)
+/** @brief Presence of the 802.15.4 packet format. */
+#define NRF_CCM_HAS_MODE_PROTOCOL_IEEE802154 1
+#else
+#define NRF_CCM_HAS_MODE_PROTOCOL_IEEE802154 0
+#endif
+
+#if defined(CCM_MODE_LENGTH_Msk) || defined(__NRFX_DOXYGEN__)
+/** @brief Presence of the packet lengh configuration. */
+#define NRF_CCM_HAS_MODE_LENGTH 1
+#else
+#define NRF_CCM_HAS_MODE_LENGTH 0
+#endif
+
+#if defined(CCM_MODE_DATARATE_125Kbps) || defined(__NRFX_DOXYGEN__)
+/** @brief Support for 125 Kbps radio data rate. */
+#define NRF_CCM_HAS_MODE_DATARATE_125KBPS 1
+#else
+#define NRF_CCM_HAS_MODE_DATARATE_125KBPS 0
+#endif
+
+/** @brief Support for 125 Kbit radio data rate. */
+#if !NRF_CCM_HAS_MODE_DATARATE_125KBPS && \
+    (defined(CCM_MODE_DATARATE_125Kbit) || defined(__NRFX_DOXYGEN__))
+#define NRF_CCM_HAS_MODE_DATARATE_125KBIT 1
+#else
+#define NRF_CCM_HAS_MODE_DATARATE_125KBIT 0
+#endif
+
+#if defined(CCM_MODE_DATARATE_250Kbit) || defined(__NRFX_DOXYGEN__)
+/** @brief Support for 250 Kbit radio data rate. */
+#define NRF_CCM_HAS_MODE_DATARATE_250Kbit 1
+#else
+#define NRF_CCM_HAS_MODE_DATARATE_250Kbit 0
+#endif
+
+#if defined(CCM_MODE_DATARATE_500Kbps) || defined(__NRFX_DOXYGEN__)
+/** @brief Support for 500 Kbps radio data rate. */
+#define NRF_CCM_HAS_MODE_DATARATE_500KBPS 1
+#else
+#define NRF_CCM_HAS_MODE_DATARATE_500KBPS 0
+#endif
+
+/** @brief Support for 500 Kbit radio data rate. */
+#if !NRF_CCM_HAS_MODE_DATARATE_500KBPS && \
+    (defined(CCM_MODE_DATARATE_500Kbit) || defined(__NRFX_DOXYGEN__))
+#define NRF_CCM_HAS_MODE_DATARATE_500KBIT 1
+#else
+#define NRF_CCM_HAS_MODE_DATARATE_500KBIT 0
+#endif
+
+#if defined(CCM_MODE_DATARATE_4Mbit) || defined(__NRFX_DOXYGEN__)
+/** @brief Support for 4 Mbit radio data rate. */
+#define NRF_CCM_HAS_MODE_DATARATE_4MBIT 1
+#else
+#define NRF_CCM_HAS_MODE_DATARATE_4MBIT 0
+#endif
+
+#if defined(CCM_MODE_MACLEN_Msk) || defined(__NRFX_DOXYGEN__)
+/** @brief Presence of the CCM MAC length. */
+#define NRF_CCM_HAS_MODE_MACLEN 1
+#else
+#define NRF_CCM_HAS_MODE_MACLEN 0
+#endif
+
+#if defined(CCM_MODE_DATARATE_Pos) || defined(__NRFX_DOXYGEN__)
+/** @brief Presence of the radio data rate that the CCM shall run synchronous with. */
+#define NRF_CCM_HAS_DATARATE 1
+#else
+#define NRF_CCM_HAS_DATARATE 0
+#endif
+
+#if defined(CCM_HEADERMASK_HEADERMASK_Msk) || defined(__NRFX_DOXYGEN__)
+/** @brief Presence of the HEADERMASK register. */
+#define NRF_CCM_HAS_HEADERMASK 1
+#else
+#define NRF_CCM_HAS_HEADERMASK 0
+#endif
+
+#if NRF_CCM_HAS_CNFPTR
+/** @brief AES key size. */
+#define NRF_CCM_KEY_SIZE    16
+/** @brief Initialization vector size. */
+#define NRF_CCM_IV_SIZE     8
+/** @brief Packet counter configuration size. */
+#define NRF_CCM_PKTCTR_SIZE 9
+
+/** @brief CCM data structure. */
+typedef struct __PACKED
+{
+    uint8_t key[NRF_CCM_KEY_SIZE];       ///< 16-byte AES key.
+    uint8_t pktctr[NRF_CCM_PKTCTR_SIZE]; ///< Packet counter configuration.
+    uint8_t iv[NRF_CCM_IV_SIZE];         ///< 8-byte initialization vector (IV).
+} nrf_ccm_cnf_t;
+#endif
+
 /** @brief CCM tasks. */
 typedef enum
 {
+#if NRF_CCM_HAS_TASK_KSGEN
     NRF_CCM_TASK_KSGEN        = offsetof(NRF_CCM_Type, TASKS_KSGEN),        ///< Start generation of key-stream.
+#endif
+#if NRF_CCM_HAS_TASK_CRYPT
     NRF_CCM_TASK_CRYPT        = offsetof(NRF_CCM_Type, TASKS_CRYPT),        ///< Start encryption/decryption.
+#endif
     NRF_CCM_TASK_STOP         = offsetof(NRF_CCM_Type, TASKS_STOP),         ///< Stop encryption/decryption.
-#if defined(CCM_RATEOVERRIDE_RATEOVERRIDE_Pos) || defined(__NRFX_DOXYGEN__)
+#if NRF_CCM_HAS_TASK_START
+    NRF_CCM_TASK_START        = offsetof(NRF_CCM_Type, TASKS_START),        ///< Start encryption/decryption.
+#endif
+#if NRF_CCM_HAS_TASK_RATEOVERRIDE
     NRF_CCM_TASK_RATEOVERRIDE = offsetof(NRF_CCM_Type, TASKS_RATEOVERRIDE), ///< Override DATARATE setting in MODE register.
 #endif
 } nrf_ccm_task_t;
@@ -61,64 +351,142 @@ typedef enum
 /** @brief CCM events. */
 typedef enum
 {
-    NRF_CCM_EVENT_ENDKSGEN = offsetof(NRF_CCM_Type, EVENTS_ENDKSGEN), ///< Keystream generation complete.
-    NRF_CCM_EVENT_ENDCRYPT = offsetof(NRF_CCM_Type, EVENTS_ENDCRYPT), ///< Encrypt/decrypt complete.
-    NRF_CCM_EVENT_ERROR    = offsetof(NRF_CCM_Type, EVENTS_ERROR),    ///< CCM error event.
+#if NRF_CCM_HAS_EVENT_ENDKSGEN
+    NRF_CCM_EVENT_ENDKSGEN  = offsetof(NRF_CCM_Type, EVENTS_ENDKSGEN),  ///< Keystream generation complete.
+#endif
+#if NRF_CCM_HAS_EVENT_ENDCRYPT
+    NRF_CCM_EVENT_ENDCRYPT  = offsetof(NRF_CCM_Type, EVENTS_ENDCRYPT),  ///< Encrypt/decrypt complete.
+#endif
+    NRF_CCM_EVENT_ERROR     = offsetof(NRF_CCM_Type, EVENTS_ERROR),     ///< CCM error event.
+#if NRF_CCM_HAS_EVENT_END
+    NRF_CCM_EVENT_END       = offsetof(NRF_CCM_Type, EVENTS_END),       ///< Encrypt/decrypt complete.
+#endif
 } nrf_ccm_event_t;
 
+#if NRF_CCM_HAS_EVENT_ENDKSGEN
 /** @brief Types of CCM shorts. */
 typedef enum
 {
     NRF_CCM_SHORT_ENDKSGEN_CRYPT_MASK = CCM_SHORTS_ENDKSGEN_CRYPT_Msk, ///< Shortcut for starting encryption/decryption when the key-stream generation is complete.
 } nrf_ccm_short_mask_t;
+#endif // NRF_CCM_HAS_EVENT_ENDKSGEN
 
 /** @brief CCM interrupts. */
 typedef enum
 {
-    NRF_CCM_INT_ENDKSGEN_MASK  = CCM_INTENSET_ENDKSGEN_Msk, ///< Interrupt on ENDKSGEN event.
-    NRF_CCM_INT_ENDCRYPT_MASK  = CCM_INTENSET_ENDCRYPT_Msk, ///< Interrupt on ENDCRYPT event.
-    NRF_CCM_INT_ERROR_MASK     = CCM_INTENSET_ERROR_Msk,    ///< Interrupt on ERROR event.
+#if NRF_CCM_HAS_EVENT_ENDKSGEN
+    NRF_CCM_INT_ENDKSGEN_MASK  = CCM_INTENSET_ENDKSGEN_Msk,  ///< Interrupt on ENDKSGEN event.
+#endif
+#if NRF_CCM_HAS_EVENT_ENDCRYPT
+    NRF_CCM_INT_ENDCRYPT_MASK  = CCM_INTENSET_ENDCRYPT_Msk,  ///< Interrupt on ENDCRYPT event.
+#endif
+    NRF_CCM_INT_ERROR_MASK     = CCM_INTENSET_ERROR_Msk,     ///< Interrupt on ERROR event.
+#if NRF_CCM_HAS_EVENT_END
+    NRF_CCM_INT_END_MASK       = CCM_INTENSET_END_Msk,       ///< Interrupt on END event.
+#endif
 } nrf_ccm_int_mask_t;
+
+#if NRF_CCM_HAS_ERRORSTATUS
+/** @brief CCM error status when ERROR event is generated. */
+typedef enum
+{
+    NRF_CCM_ERROR_NO_ERROR             = CCM_ERRORSTATUS_ERRORSTATUS_NoError,            ///< No errors have occurred.
+    NRF_CCM_ERROR_PREMATURE_INPTR_END  = CCM_ERRORSTATUS_ERRORSTATUS_PrematureInptrEnd,  ///< End of INPTR job list before CCM data structure was read.
+    NRF_CCM_ERROR_PREMATURE_OUTPTR_END = CCM_ERRORSTATUS_ERRORSTATUS_PrematureOutptrEnd, ///< End of OUTPTR job list before CCM data structure was read.
+    NRF_CCM_ERROR_ENCRYPTION_TOO_SLOW  = CCM_ERRORSTATUS_ERRORSTATUS_EncryptionTooSlow,  ///< Encryption did not complete in time.
+} nrf_ccm_error_t;
+#endif
 
 /** @brief CCM modes of operation. */
 typedef enum
 {
-    NRF_CCM_MODE_ENCRYPTION = CCM_MODE_MODE_Encryption, ///< Encryption mode.
-    NRF_CCM_MODE_DECRYPTION = CCM_MODE_MODE_Decryption, ///< Decryption mode.
+    NRF_CCM_MODE_ENCRYPTION      = CCM_MODE_MODE_Encryption,     ///< Encryption mode.
+    NRF_CCM_MODE_DECRYPTION      = CCM_MODE_MODE_Decryption,     ///< Decryption mode.
+#if NRF_CCM_HAS_MODE_FAST_DECRYPTION
+    NRF_CCM_MODE_FAST_DECRYPTION = CCM_MODE_MODE_FastDecryption, ///< Fast decryption mode.
+#endif
 } nrf_ccm_mode_t;
 
-#if defined(CCM_MODE_DATARATE_Pos) || defined(__NRFX_DOXYGEN__)
+#if NRF_CCM_HAS_DATARATE
 /** @brief CCM data rates. */
 typedef enum
 {
-    NRF_CCM_DATARATE_1M   = CCM_MODE_DATARATE_1Mbit,   ///< 1 Mbps.
-    NRF_CCM_DATARATE_2M   = CCM_MODE_DATARATE_2Mbit,   ///< 2 Mbps.
-#if defined(CCM_MODE_DATARATE_125Kbps) || defined(__NRFX_DOXYGEN__)
+
+#if NRF_CCM_HAS_MODE_DATARATE_125KBPS
     NRF_CCM_DATARATE_125K = CCM_MODE_DATARATE_125Kbps, ///< 125 Kbps.
 #endif
-#if defined(CCM_MODE_DATARATE_500Kbps) || defined(__NRFX_DOXYGEN__)
+#if NRF_CCM_HAS_MODE_DATARATE_125KBIT
+    NRF_CCM_DATARATE_125K = CCM_MODE_DATARATE_125Kbit, ///< 125 Kbps.
+#endif
+#if NRF_CCM_HAS_MODE_DATARATE_250Kbit
+    NRF_CCM_DATARATE_250K = CCM_MODE_DATARATE_250Kbit, ///< 250 Kbps.
+#endif
+#if NRF_CCM_HAS_MODE_DATARATE_500KBPS
     NRF_CCM_DATARATE_500K = CCM_MODE_DATARATE_500Kbps, ///< 500 Kbps.
 #endif
+#if NRF_CCM_HAS_MODE_DATARATE_500KBIT
+    NRF_CCM_DATARATE_500K = CCM_MODE_DATARATE_500Kbit, ///< 500 Kbit.
+#endif
+    NRF_CCM_DATARATE_1M   = CCM_MODE_DATARATE_1Mbit,   ///< 1 Mbps.
+    NRF_CCM_DATARATE_2M   = CCM_MODE_DATARATE_2Mbit,   ///< 2 Mbps.
+#if NRF_CCM_HAS_MODE_DATARATE_4MBIT
+    NRF_CCM_DATARATE_4M   = CCM_MODE_DATARATE_4Mbit,   ///< 4 Mbps.
+#endif
 } nrf_ccm_datarate_t;
-#endif // defined(CCM_MODE_DATARATE_Pos) || defined(__NRFX_DOXYGEN__)
+#endif // NRF_CCM_HAS_DATARATE
 
-#if defined(CCM_MODE_LENGTH_Pos) || defined(__NRFX_DOXYGEN__)
+#if NRF_CCM_HAS_MODE_PROTOCOL
+/** @brief CCM protocol and packet format. */
+typedef enum
+{
+#if NRF_CCM_HAS_MODE_PROTOCOL_BLE
+    NRF_CCM_MODE_PROTOCOL_BLE        = CCM_MODE_PROTOCOL_Ble,        ///< BLE packet format.
+#endif
+#if NRF_CCM_HAS_MODE_PROTOCOL_IEEE802154
+    NRF_CCM_MODE_PROTOCOL_IEEE802154 = CCM_MODE_PROTOCOL_Ieee802154, ///< 802.15.4 packet format.
+#endif
+} nrf_ccm_protocol_t;
+#endif // NRF_CCM_HAS_MODE_PROTOCOL
+
+#if NRF_CCM_HAS_MODE_LENGTH
 /** @brief CCM packet length options. */
 typedef enum
 {
     NRF_CCM_LENGTH_DEFAULT  = CCM_MODE_LENGTH_Default,  ///< Default length.
     NRF_CCM_LENGTH_EXTENDED = CCM_MODE_LENGTH_Extended, ///< Extended length.
 } nrf_ccm_length_t;
-#endif // defined(CCM_MODE_LENGTH_Pos) || defined(__NRFX_DOXYGEN__)
+#endif // NRF_CCM_HAS_MODE_LENGTH
+
+#if NRF_CCM_HAS_MODE_MACLEN
+/** @brief CCM MAC length. */
+typedef enum
+{
+    NRF_CCM_MODE_MACLEN_M0  = CCM_MODE_MACLEN_M0,  ///< 0 bytes.
+    NRF_CCM_MODE_MACLEN_M4  = CCM_MODE_MACLEN_M4,  ///< 4 bytes.
+    NRF_CCM_MODE_MACLEN_M6  = CCM_MODE_MACLEN_M6,  ///< 6 bytes.
+    NRF_CCM_MODE_MACLEN_M8  = CCM_MODE_MACLEN_M8,  ///< 8 bytes.
+    NRF_CCM_MODE_MACLEN_M10 = CCM_MODE_MACLEN_M10, ///< 10 bytes.
+    NRF_CCM_MODE_MACLEN_M12 = CCM_MODE_MACLEN_M12, ///< 12 bytes.
+    NRF_CCM_MODE_MACLEN_M14 = CCM_MODE_MACLEN_M14, ///< 14 bytes.
+    NRF_CCM_MODE_MACLEN_M16 = CCM_MODE_MACLEN_M16, ///< 16 bytes.
+} nrf_ccm_maclen_t;
+#endif // NRF_CCM_HAS_MODE_MACLEN
 
 /** @brief CCM configuration. */
-typedef struct {
-    nrf_ccm_mode_t     mode;     ///< Operation mode.
-#if defined(CCM_MODE_DATARATE_Pos) || defined(__NRFX_DOXYGEN__)
-    nrf_ccm_datarate_t datarate; ///< Data rate.
+typedef struct
+{
+    nrf_ccm_mode_t     mode;       ///< Operation mode.
+#if NRF_CCM_HAS_MODE_PROTOCOL
+    nrf_ccm_protocol_t protocol;   ///< Protocol and packet format.
 #endif
-#if defined(CCM_MODE_LENGTH_Pos) || defined(__NRFX_DOXYGEN__)
-    nrf_ccm_length_t   length;   ///< Lenght of the CCM packet.
+#if NRF_CCM_HAS_DATARATE
+    nrf_ccm_datarate_t datarate;   ///< Data rate.
+#endif
+#if NRF_CCM_HAS_MODE_LENGTH
+    nrf_ccm_length_t   length;     ///< Length of the CCM packet.
+#endif
+#if NRF_CCM_HAS_MODE_MACLEN
+    nrf_ccm_maclen_t   mac_length; ///< Length of the CCM MAC.
 #endif
 } nrf_ccm_config_t;
 
@@ -174,6 +542,7 @@ NRF_STATIC_INLINE bool nrf_ccm_event_check(NRF_CCM_Type const * p_reg,
 NRF_STATIC_INLINE uint32_t nrf_ccm_event_address_get(NRF_CCM_Type const * p_reg,
                                                      nrf_ccm_event_t      event);
 
+#if NRF_CCM_HAS_EVENT_ENDKSGEN
 /**
  * @brief Function for enabling the specified shortcuts.
  *
@@ -200,6 +569,7 @@ NRF_STATIC_INLINE void nrf_ccm_shorts_disable(NRF_CCM_Type * p_reg,
  */
 NRF_STATIC_INLINE void nrf_ccm_shorts_set(NRF_CCM_Type * p_reg,
                                           uint32_t       mask);
+#endif // NRF_CCM_HAS_EVENT_ENDKSGEN
 
 /**
  * @brief Function for enabling specified interrupts.
@@ -250,7 +620,7 @@ NRF_STATIC_INLINE void nrf_ccm_disable(NRF_CCM_Type * p_reg);
 NRF_STATIC_INLINE void nrf_ccm_configure(NRF_CCM_Type *           p_reg,
                                          nrf_ccm_config_t const * p_config);
 
-#if defined(CCM_MAXPACKETSIZE_MAXPACKETSIZE_Pos) || defined(__NRFX_DOXYGEN__)
+#if NRF_CCM_HAS_MAXPACKETSIZE
 /**
  * @brief Function for setting the length of key-stream generated
  *        when the packet length is configured as extended.
@@ -260,8 +630,9 @@ NRF_STATIC_INLINE void nrf_ccm_configure(NRF_CCM_Type *           p_reg,
  */
 NRF_STATIC_INLINE void nrf_ccm_maxpacketsize_set(NRF_CCM_Type * p_reg,
                                                  uint8_t        size);
-#endif // defined(CCM_MAXPACKETSIZE_MAXPACKETSIZE_Pos) || defined(__NRFX_DOXYGEN__)
+#endif // NRF_CCM_HAS_MAXPACKETSIZE
 
+#if NRF_CCM_HAS_MICSTATUS
 /**
  * @brief Function for getting the MIC check result.
  *
@@ -271,7 +642,32 @@ NRF_STATIC_INLINE void nrf_ccm_maxpacketsize_set(NRF_CCM_Type * p_reg,
  * @retval false The MIC check failed.
  */
 NRF_STATIC_INLINE bool nrf_ccm_micstatus_get(NRF_CCM_Type const * p_reg);
+#endif // NRF_CCM_HAS_MICSTATUS
 
+#if NRF_CCM_HAS_MACSTATUS
+/**
+ * @brief Function for getting the MAC check result.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ *
+ * @retval true  The MAC check passed.
+ * @retval false The MAC check failed.
+ */
+NRF_STATIC_INLINE bool nrf_ccm_macstatus_get(NRF_CCM_Type const * p_reg);
+#endif // NRF_CCM_HAS_MACSTATUS
+
+#if NRF_CCM_HAS_ERRORSTATUS
+/**
+ * @brief Function for getting the error status when ERROR event is generated.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ *
+ * @retval Error status when the ERROR event is generated.
+ */
+NRF_STATIC_INLINE nrf_ccm_error_t nrf_ccm_errorstatus_get(NRF_CCM_Type const * p_reg);
+#endif // NRF_CCM_HAS_ERRORSTATUS
+
+#if NRF_CCM_HAS_CNFPTR
 /**
  * @brief Function for setting the pointer to the data structure
  *        holding the AES key and the CCM NONCE vector.
@@ -279,8 +675,8 @@ NRF_STATIC_INLINE bool nrf_ccm_micstatus_get(NRF_CCM_Type const * p_reg);
  * @param[in] p_reg  Pointer to the structure of registers of the peripheral.
  * @param[in] p_data Pointer to the data structure.
  */
-NRF_STATIC_INLINE void nrf_ccm_cnfptr_set(NRF_CCM_Type *   p_reg,
-                                          uint32_t const * p_data);
+NRF_STATIC_INLINE void nrf_ccm_cnfptr_set(NRF_CCM_Type *        p_reg,
+                                          nrf_ccm_cnf_t const * p_data);
 
 /**
  * @brief Function for getting the pointer to the data structure
@@ -290,8 +686,64 @@ NRF_STATIC_INLINE void nrf_ccm_cnfptr_set(NRF_CCM_Type *   p_reg,
  *
  * @return Pointer to the data structure.
  */
-NRF_STATIC_INLINE uint32_t * nrf_ccm_cnfptr_get(NRF_CCM_Type const * p_reg);
+NRF_STATIC_INLINE nrf_ccm_cnf_t * nrf_ccm_cnfptr_get(NRF_CCM_Type const * p_reg);
+#endif // NRF_CCM_HAS_CNFPTR
 
+#if NRF_CCM_HAS_KEY
+/**
+ * @brief Function for setting the AES key.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ * @param[in] p_key Pointer to the AES 128-bit key value. The key shall be stored
+ *                  in big endian byte order.
+ */
+NRF_STATIC_INLINE void nrf_ccm_key_set(NRF_CCM_Type   * p_reg,
+                                       uint32_t const * p_key);
+/**
+ * @brief Function for getting the AES key.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ *
+ * @return Pointer to the AES 128-bit key value. The key is stored in big endian byte order.
+ */
+NRF_STATIC_INLINE uint32_t const * nrf_ccm_key_get(NRF_CCM_Type const * p_reg);
+
+#endif // NRF_CCM_HAS_KEY
+
+#if NRF_CCM_HAS_NONCE
+/**
+ * @brief Function for setting the AES nonce.
+ *
+ * @param[in] p_reg   Pointer to the structure of registers of the peripheral.
+ * @param[in] p_nonce Pointer to the AES 13-byte nonce value. The nonce shall be stored
+ *                    in big endian byte order.
+ */
+NRF_STATIC_INLINE void nrf_ccm_nonce_set(NRF_CCM_Type *   p_reg,
+                                         uint32_t const * p_nonce);
+
+/**
+ * @brief Function for getting the AES nonce.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ *
+ * @return Pointer to the AES 13-byte nonce value. The nonce is stored in big endian byte order.
+ */
+NRF_STATIC_INLINE uint32_t const * nrf_ccm_nonce_get(NRF_CCM_Type const * p_reg);
+#endif // NRF_CCM_HAS_NONCE
+
+#if NRF_CCM_HAS_IN_AMOUNT
+/**
+ * @brief Function for getting number of bytes read from the input data,
+ *        not including the job list structure.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ *
+ * @return Number of bytes read from the input data.
+ */
+NRF_STATIC_INLINE uint32_t nrf_ccm_in_amount_get(NRF_CCM_Type const * p_reg);
+#endif // NRF_CCM_HAS_IN_AMOUNT
+
+#if NRF_CCM_HAS_INPTR
 /**
  * @brief Function for setting the input data pointer.
  *
@@ -309,7 +761,33 @@ NRF_STATIC_INLINE void nrf_ccm_inptr_set(NRF_CCM_Type *   p_reg,
  * @return Input data pointer.
  */
 NRF_STATIC_INLINE uint32_t * nrf_ccm_inptr_get(NRF_CCM_Type const * p_reg);
+#endif // NRF_CCM_HAS_INPTR
 
+#if NRF_CCM_HAS_IN_PTR
+/**
+ * @brief Function for setting the pointer to a job list containing unencrypted
+ *        CCM data structure in Encryption mode or encrypted CCM data structure
+ *        in Decryption mode.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ * @param[in] p_job Pointer to a job list.
+ */
+NRF_STATIC_INLINE void nrf_ccm_in_ptr_set(NRF_CCM_Type *         p_reg,
+                                          nrf_vdma_job_t const * p_job);
+
+/**
+ * @brief Function for getting the pointer to job list containing unencrypted
+ *        CCM data structure in Encryption mode or encrypted CCM data structure
+ *        in Decryption mode.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ *
+ * @return Pointer to a job list.
+ */
+NRF_STATIC_INLINE nrf_vdma_job_t * nrf_ccm_in_ptr_get(NRF_CCM_Type const * p_reg);
+#endif // NRF_CCM_HAS_IN_PTR
+
+#if NRF_CCM_HAS_OUTPTR
 /**
  * @brief Function for setting the output data pointer.
  *
@@ -327,7 +805,45 @@ NRF_STATIC_INLINE void nrf_ccm_outptr_set(NRF_CCM_Type *   p_reg,
  * @return Output data pointer.
  */
 NRF_STATIC_INLINE uint32_t * nrf_ccm_outptr_get(NRF_CCM_Type const * p_reg);
+#endif // NRF_CCM_HAS_OUTPTR
 
+#if NRF_CCM_HAS_OUT_PTR
+/**
+ * @brief Function for setting the pointer to a job list containing encrypted
+ *        CCM data structure in Encryption mode or decrypted CCM data structure
+ *        in Decryption mode.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ * @param[in] p_job Pointer to a job list.
+ */
+NRF_STATIC_INLINE void nrf_ccm_out_ptr_set(NRF_CCM_Type *         p_reg,
+                                           nrf_vdma_job_t const * p_job);
+
+/**
+ * @brief Function for getting the pointer to a job list containing encrypted
+ *        CCM data structure in Encryption mode or decrypted CCM data structure
+ *        in Decryption mode.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ *
+ * @return Pointer to the job list.
+ */
+NRF_STATIC_INLINE nrf_vdma_job_t * nrf_ccm_out_ptr_get(NRF_CCM_Type const * p_reg);
+#endif // NRF_CCM_HAS_OUT_PTR
+
+#if NRF_CCM_HAS_OUT_AMOUNT
+/**
+ * @brief Function for getting number of bytes available in the output data,
+ *        not including the job list structure.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ *
+ * @return Number of bytes available in the output data.
+ */
+NRF_STATIC_INLINE uint32_t nrf_ccm_out_amount_get(NRF_CCM_Type const * p_reg);
+#endif // NRF_CCM_HAS_OUT_AMOUNT
+
+#if NRF_CCM_HAS_SCRATCHPTR
 /**
  * @brief Function for setting the pointer to the scratch area used for
  *        temporary storage.
@@ -345,9 +861,10 @@ NRF_STATIC_INLINE void nrf_ccm_scratchptr_set(NRF_CCM_Type *   p_reg,
  *
  * @return Pointer to the scratch area.
  */
-NRF_STATIC_INLINE uint32_t * nrf_ccm_stratchptr_get(NRF_CCM_Type const * p_reg);
+NRF_STATIC_INLINE uint32_t * nrf_ccm_scratchptr_get(NRF_CCM_Type const * p_reg);
+#endif // NRF_CCM_HAS_SCRATCHPTR
 
-#if defined(CCM_RATEOVERRIDE_RATEOVERRIDE_Pos) || defined(__NRFX_DOXYGEN__)
+#if NRF_CCM_HAS_RATEOVERRIDE
 /**
  * @brief Function for setting the data rate override value.
  *
@@ -357,7 +874,57 @@ NRF_STATIC_INLINE uint32_t * nrf_ccm_stratchptr_get(NRF_CCM_Type const * p_reg);
  */
 NRF_STATIC_INLINE void nrf_ccm_datarate_override_set(NRF_CCM_Type *     p_reg,
                                                      nrf_ccm_datarate_t datarate);
-#endif // defined(CCM_RATEOVERRIDE_RATEOVERRIDE_Pos) || defined(__NRFX_DOXYGEN__)
+
+/**
+ * @brief Function for getting data override setting.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ *
+ * @return Data override setting.
+ */
+NRF_STATIC_INLINE nrf_ccm_datarate_t nrf_ccm_datarate_override_get(NRF_CCM_Type const * p_reg);
+#endif // NRF_CCM_HAS_RATEOVERRIDE
+
+#if NRF_CCM_HAS_ADATAMASK
+/**
+ * @brief Function for setting the CCM adata mask.
+ *
+ * @param[in] p_reg     Pointer to the structure of registers of the peripheral.
+ * @param[in] adata_msk CCM adata mask.
+ */
+NRF_STATIC_INLINE void nrf_ccm_adatamask_set(NRF_CCM_Type * p_reg,
+                                             uint8_t        adata_msk);
+
+/**
+ * @brief Function for getting bitmask for the first adata byte.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ *
+ * @return CCM adata mask.
+ */
+NRF_STATIC_INLINE uint32_t nrf_ccm_adatamask_get(NRF_CCM_Type const * p_reg);
+#endif // NRF_CCM_HAS_ADATAMASK
+
+#if NRF_CCM_HAS_HEADERMASK
+/**
+ * @brief Function for setting the CCM header mask.
+ *
+ * @param[in] p_reg      Pointer to the structure of registers of the peripheral.
+ * @param[in] header_msk CCM header mask.
+ */
+NRF_STATIC_INLINE void nrf_ccm_headermask_set(NRF_CCM_Type * p_reg,
+                                              uint8_t        header_msk);
+
+/**
+ * @brief Function for getting the bitmask for packet header (S0) before MIC
+ *        generation/authentication.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ *
+ * @return CCM header mask.
+ */
+NRF_STATIC_INLINE uint32_t nrf_ccm_headermask_get(NRF_CCM_Type const * p_reg);
+#endif // NRF_CCM_HAS_HEADERMASK
 
 #if defined(DPPI_PRESENT) || defined(__NRFX_DOXYGEN__)
 /**
@@ -438,7 +1005,7 @@ NRF_STATIC_INLINE uint32_t nrf_ccm_event_address_get(NRF_CCM_Type const * p_reg,
     return ((uint32_t)p_reg + (uint32_t)event);
 }
 
-
+#if NRF_CCM_HAS_EVENT_ENDKSGEN
 NRF_STATIC_INLINE void nrf_ccm_shorts_enable(NRF_CCM_Type * p_reg,
                                              uint32_t       mask)
 {
@@ -456,6 +1023,7 @@ NRF_STATIC_INLINE void nrf_ccm_shorts_set(NRF_CCM_Type * p_reg,
 {
     p_reg->SHORTS = mask;
 }
+#endif // NRF_CCM_HAS_EVENT_ENDKSGEN
 
 NRF_STATIC_INLINE void nrf_ccm_int_enable(NRF_CCM_Type * p_reg, uint32_t mask)
 {
@@ -485,17 +1053,23 @@ NRF_STATIC_INLINE void nrf_ccm_disable(NRF_CCM_Type * p_reg)
 NRF_STATIC_INLINE void nrf_ccm_configure(NRF_CCM_Type *           p_reg,
                                          nrf_ccm_config_t const * p_config)
 {
-    p_reg->MODE = (((uint32_t)p_config->mode     << CCM_MODE_MODE_Pos) |
-#if defined(CCM_MODE_DATARATE_Pos)
-                   ((uint32_t)p_config->datarate << CCM_MODE_DATARATE_Pos) |
+    p_reg->MODE = (((uint32_t)p_config->mode       << CCM_MODE_MODE_Pos)     |
+#if NRF_CCM_HAS_MODE_PROTOCOL
+                   ((uint32_t)p_config->protocol   << CCM_MODE_PROTOCOL_Pos) |
 #endif
-#if defined(CCM_MODE_LENGTH_Pos)
-                   ((uint32_t)p_config->length   << CCM_MODE_LENGTH_Pos) |
+#if NRF_CCM_HAS_DATARATE
+                   ((uint32_t)p_config->datarate   << CCM_MODE_DATARATE_Pos) |
+#endif
+#if NRF_CCM_HAS_MODE_LENGTH
+                   ((uint32_t)p_config->length     << CCM_MODE_LENGTH_Pos)   |
+#endif
+#if NRF_CCM_HAS_MODE_MACLEN
+                   ((uint32_t)p_config->mac_length << CCM_MODE_MACLEN_Pos)   |
 #endif
                    0);
 }
 
-#if defined(CCM_MAXPACKETSIZE_MAXPACKETSIZE_Pos)
+#if NRF_CCM_HAS_MAXPACKETSIZE
 NRF_STATIC_INLINE void nrf_ccm_maxpacketsize_set(NRF_CCM_Type * p_reg,
                                                  uint8_t        size)
 {
@@ -503,29 +1077,96 @@ NRF_STATIC_INLINE void nrf_ccm_maxpacketsize_set(NRF_CCM_Type * p_reg,
 
     p_reg->MAXPACKETSIZE = size;
 }
-#endif // defined(CCM_MAXPACKETSIZE_MAXPACKETSIZE_Pos)
+#endif // defined(NRF_CCM_HAS_MAXPACKETSIZE)
 
+#if NRF_CCM_HAS_MICSTATUS
 NRF_STATIC_INLINE bool nrf_ccm_micstatus_get(NRF_CCM_Type const * p_reg)
 {
     return (bool)(p_reg->MICSTATUS);
 }
+#endif // NRF_CCM_HAS_MICSTATUS
 
-NRF_STATIC_INLINE void nrf_ccm_cnfptr_set(NRF_CCM_Type *   p_reg,
-                                          uint32_t const * p_data)
+#if NRF_CCM_HAS_MACSTATUS
+NRF_STATIC_INLINE bool nrf_ccm_macstatus_get(NRF_CCM_Type const * p_reg)
+{
+    return (bool)(p_reg->MACSTATUS);
+}
+#endif // NRF_CCM_HAS_MACSTATUS
+
+#if NRF_CCM_HAS_ERRORSTATUS
+NRF_STATIC_INLINE nrf_ccm_error_t nrf_ccm_errorstatus_get(NRF_CCM_Type const * p_reg)
+{
+    return (nrf_ccm_error_t)(p_reg->ERRORSTATUS);
+}
+#endif // NRF_CCM_HAS_ERRORSTATUS
+
+#if NRF_CCM_HAS_CNFPTR
+NRF_STATIC_INLINE void nrf_ccm_cnfptr_set(NRF_CCM_Type *        p_reg,
+                                          nrf_ccm_cnf_t const * p_data)
 {
     p_reg->CNFPTR = (uint32_t)p_data;
 }
 
-NRF_STATIC_INLINE uint32_t * nrf_ccm_cnfptr_get(NRF_CCM_Type const * p_reg)
+NRF_STATIC_INLINE nrf_ccm_cnf_t * nrf_ccm_cnfptr_get(NRF_CCM_Type const * p_reg)
 {
 #if defined(NRF5340_XXAA_NETWORK)
     // Apply workaround for anomaly 10.
-    return (uint32_t *)(p_reg->CNFPTR | 0x01000000);
+    return (nrf_ccm_cnf_t *)(p_reg->CNFPTR | 0x01000000);
 #else
-    return (uint32_t *)(p_reg->CNFPTR);
-#endif
+    return (nrf_ccm_cnf_t *)(p_reg->CNFPTR);
+#endif // NRF5340_XXAA_NETWORK
+}
+#endif // NRF_CCM_HAS_CNFPTR
+
+#if NRF_CCM_HAS_KEY
+NRF_STATIC_INLINE void nrf_ccm_key_set(NRF_CCM_Type   * p_reg,
+                                       uint32_t const * p_key)
+{
+    NRFX_ASSERT(p_key);
+    for (uint8_t i = 0; i < CCM_KEY_VALUE_MaxCount; i++)
+    {
+        p_reg->KEY.VALUE[i] = p_key[i];
+    }
 }
 
+NRF_STATIC_INLINE uint32_t const * nrf_ccm_key_get(NRF_CCM_Type const * p_reg)
+{
+    return (uint32_t *)(p_reg->KEY.VALUE);
+}
+#endif // NRF_CCM_HAS_KEY
+
+#if NRF_CCM_HAS_NONCE
+NRF_STATIC_INLINE void nrf_ccm_nonce_set(NRF_CCM_Type *   p_reg,
+                                         uint32_t const * p_nonce)
+{
+    NRFX_ASSERT(p_nonce);
+    for (uint8_t i = 0; i < CCM_NONCE_VALUE_MaxCount; i++)
+    {
+        p_reg->NONCE.VALUE[i] = p_nonce[i];
+    }
+}
+
+NRF_STATIC_INLINE uint32_t const * nrf_ccm_nonce_get(NRF_CCM_Type const * p_reg)
+{
+    return (uint32_t *)(p_reg->NONCE.VALUE);
+}
+#endif // NRF_CCM_HAS_NONCE
+
+#if NRF_CCM_HAS_IN_AMOUNT
+NRF_STATIC_INLINE uint32_t nrf_ccm_in_amount_get(NRF_CCM_Type const * p_reg)
+{
+    return p_reg->IN.AMOUNT;
+}
+#endif // NRF_CCM_HAS_IN_AMOUNT
+
+#if NRF_CCM_HAS_OUT_AMOUNT
+NRF_STATIC_INLINE uint32_t nrf_ccm_out_amount_get(NRF_CCM_Type const * p_reg)
+{
+    return p_reg->OUT.AMOUNT;
+}
+#endif // NRF_CCM_HAS_OUT_AMOUNT
+
+#if NRF_CCM_HAS_INPTR
 NRF_STATIC_INLINE void nrf_ccm_inptr_set(NRF_CCM_Type *   p_reg,
                                          uint32_t const * p_data)
 {
@@ -539,9 +1180,24 @@ NRF_STATIC_INLINE uint32_t * nrf_ccm_inptr_get(NRF_CCM_Type const * p_reg)
     return (uint32_t *)(p_reg->INPTR | 0x01000000);
 #else
     return (uint32_t *)(p_reg->INPTR);
-#endif
+#endif // defined(NRF5340_XXAA_NETWORK)
+}
+#endif // NRF_CCM_HAS_INPTR
+
+#if NRF_CCM_HAS_IN_PTR
+NRF_STATIC_INLINE void nrf_ccm_in_ptr_set(NRF_CCM_Type *         p_reg,
+                                          nrf_vdma_job_t const * p_job)
+{
+    p_reg->IN.PTR = (uint32_t)p_job;
 }
 
+NRF_STATIC_INLINE nrf_vdma_job_t * nrf_ccm_in_ptr_get(NRF_CCM_Type const * p_reg)
+{
+    return (nrf_vdma_job_t *)(p_reg->IN.PTR);
+}
+#endif // NRF_CCM_HAS_IN_PTR
+
+#if NRF_CCM_HAS_OUTPTR
 NRF_STATIC_INLINE void nrf_ccm_outptr_set(NRF_CCM_Type *   p_reg,
                                           uint32_t const * p_data)
 {
@@ -557,28 +1213,75 @@ NRF_STATIC_INLINE uint32_t * nrf_ccm_outptr_get(NRF_CCM_Type const * p_reg)
     return (uint32_t *)(p_reg->OUTPTR);
 #endif
 }
+#endif // NRF_CCM_HAS_OUTPTR
 
+#if NRF_CCM_HAS_OUT_PTR
+NRF_STATIC_INLINE void nrf_ccm_out_ptr_set(NRF_CCM_Type *         p_reg,
+                                           nrf_vdma_job_t const * p_job)
+{
+    p_reg->OUT.PTR = (uint32_t)p_job;
+}
+
+NRF_STATIC_INLINE nrf_vdma_job_t * nrf_ccm_out_ptr_get(NRF_CCM_Type const * p_reg)
+{
+    return (nrf_vdma_job_t *)(p_reg->OUT.PTR);
+}
+#endif // NRF_CCM_HAS_OUT_PTR
+
+#if NRF_CCM_HAS_SCRATCHPTR
 NRF_STATIC_INLINE void nrf_ccm_scratchptr_set(NRF_CCM_Type *   p_reg,
                                               uint32_t const * p_area)
 {
     p_reg->SCRATCHPTR = (uint32_t)p_area;
 }
 
-NRF_STATIC_INLINE uint32_t * nrf_ccm_stratchptr_get(NRF_CCM_Type const * p_reg)
+NRF_STATIC_INLINE uint32_t * nrf_ccm_scratchptr_get(NRF_CCM_Type const * p_reg)
 {
 #if defined(NRF5340_XXAA_NETWORK)
     // Apply workaround for anomaly 10.
     return (uint32_t *)(p_reg->SCRATCHPTR | 0x01000000);
 #else
     return (uint32_t *)(p_reg->SCRATCHPTR);
-#endif
+#endif // defined(NRF5340_XXAA_NETWORK)
 }
+#endif // NRF_CCM_HAS_SCRATCHPTR
 
-#if defined(CCM_RATEOVERRIDE_RATEOVERRIDE_Pos)
+#if NRF_CCM_HAS_RATEOVERRIDE
 NRF_STATIC_INLINE void nrf_ccm_datarate_override_set(NRF_CCM_Type *     p_reg,
                                                      nrf_ccm_datarate_t datarate)
 {
     p_reg->RATEOVERRIDE = ((uint32_t)datarate << CCM_RATEOVERRIDE_RATEOVERRIDE_Pos);
+}
+
+NRF_STATIC_INLINE nrf_ccm_datarate_t nrf_ccm_datarate_override_get(NRF_CCM_Type const * p_reg)
+{
+    return (nrf_ccm_datarate_t)(p_reg->RATEOVERRIDE);
+}
+#endif // NRF_CCM_HAS_RATEOVERRIDE
+
+#if NRF_CCM_HAS_ADATAMASK
+NRF_STATIC_INLINE void nrf_ccm_adatamask_set(NRF_CCM_Type * p_reg,
+                                             uint8_t        adata_msk)
+{
+    p_reg->ADATAMASK = (uint32_t)adata_msk;
+}
+
+NRF_STATIC_INLINE uint32_t nrf_ccm_adatamask_get(NRF_CCM_Type const * p_reg)
+{
+    return (uint32_t)(p_reg->ADATAMASK);
+}
+#endif // NRF_CCM_HAS_ADATAMASK
+
+#if NRF_CCM_HAS_HEADERMASK
+NRF_STATIC_INLINE void nrf_ccm_headermask_set(NRF_CCM_Type * p_reg,
+                                              uint8_t        header_msk)
+{
+    p_reg->HEADERMASK = (uint32_t)header_msk;
+}
+
+NRF_STATIC_INLINE uint32_t nrf_ccm_headermask_get(NRF_CCM_Type const * p_reg)
+{
+    return (uint32_t)(p_reg->HEADERMASK);
 }
 #endif
 
@@ -588,7 +1291,7 @@ NRF_STATIC_INLINE void nrf_ccm_subscribe_set(NRF_CCM_Type * p_reg,
                                              uint8_t        channel)
 {
     *((volatile uint32_t *) ((uint8_t *) p_reg + (uint32_t) task + 0x80uL)) =
-            ((uint32_t)channel | CCM_SUBSCRIBE_KSGEN_EN_Msk);
+            ((uint32_t)channel | NRF_SUBSCRIBE_PUBLISH_ENABLE);
 }
 
 NRF_STATIC_INLINE void nrf_ccm_subscribe_clear(NRF_CCM_Type * p_reg,
@@ -602,7 +1305,7 @@ NRF_STATIC_INLINE void nrf_ccm_publish_set(NRF_CCM_Type *  p_reg,
                                            uint8_t         channel)
 {
     *((volatile uint32_t *) ((uint8_t *) p_reg + (uint32_t) event + 0x80uL)) =
-            ((uint32_t)channel | CCM_PUBLISH_ENDKSGEN_EN_Msk);
+            ((uint32_t)channel | NRF_SUBSCRIBE_PUBLISH_ENABLE);
 }
 
 NRF_STATIC_INLINE void nrf_ccm_publish_clear(NRF_CCM_Type *  p_reg,

--- a/nrfx/hal/nrf_clock.h
+++ b/nrfx/hal/nrf_clock.h
@@ -57,14 +57,14 @@ extern "C" {
 #endif
 
 #if defined(CLOCK_INTENSET_DONE_Msk) || defined(__NRFX_DOXYGEN__)
-/** @brief Presence of the Low Frequency Clock calibration. */
+/** @brief Symbol indicating whether the Low Frequency Clock calibration is present. */
 #define NRF_CLOCK_HAS_CALIBRATION 1
 #else
 #define NRF_CLOCK_HAS_CALIBRATION 0
 #endif
 
 #if defined(CLOCK_CTIV_CTIV_Msk) || defined(__NRFX_DOXYGEN__)
-/** @brief Presence of the Low Frequency Clock calibration timer. */
+/** @brief Symbol indicating whether the Low Frequency Clock calibration timer is present. */
 #define NRF_CLOCK_HAS_CALIBRATION_TIMER 1
 #else
 #define NRF_CLOCK_HAS_CALIBRATION_TIMER 0
@@ -72,7 +72,7 @@ extern "C" {
 
 #if (defined(CLOCK_INTENSET_HFCLK192MSTARTED_Msk) && !defined(NRF5340_XXAA_NETWORK)) \
     || defined(__NRFX_DOXYGEN__)
-/** @brief Presence of the 192 MHz clock. */
+/** @brief Symbol indicating whether the 192 MHz clock is present. */
 #define NRF_CLOCK_HAS_HFCLK192M 1
 #else
 #define NRF_CLOCK_HAS_HFCLK192M 0
@@ -80,24 +80,116 @@ extern "C" {
 
 #if (defined(CLOCK_INTENSET_HFCLKAUDIOSTARTED_Msk) && !defined(NRF5340_XXAA_NETWORK)) \
     || defined(__NRFX_DOXYGEN__)
-/** @brief Presence of the Audio clock. */
+/** @brief Symbol indicating whether the Audio clock is present. */
 #define NRF_CLOCK_HAS_HFCLKAUDIO 1
 #else
 #define NRF_CLOCK_HAS_HFCLKAUDIO 0
 #endif
 
+#if (defined(CLOCK_HFCLKCTRL_HCLK_Div1) && !defined(NRF5340_XXAA_NETWORK)) \
+    || defined(__NRFX_DOXYGEN__)
+/** @brief Symbol indicating whether the HFCLK frequency configuration is present. */
+#define NRF_CLOCK_HAS_HFCLK_DIV 1
+#else
+#define NRF_CLOCK_HAS_HFCLK_DIV 0
+#endif
+
 #if defined(CLOCK_LFCLKALWAYSRUN_ALWAYSRUN_Msk) || defined(__NRFX_DOXYGEN__)
-/** @brief Presence of ALWAYSRUN registers. */
+/** @brief Symbol indicating whether the ALWAYSRUN register is present. */
 #define NRF_CLOCK_HAS_ALWAYSRUN 1
 #else
 #define NRF_CLOCK_HAS_ALWAYSRUN 0
 #endif
 
 #if defined(CLOCK_HFCLKSRC_SRC_Msk) || defined(__NRFX_DOXYGEN__)
-/** @brief Presence of HFCLKSRC register. */
+/** @brief Symbol indicating whether the HFCLKSRC register is present. */
 #define NRF_CLOCK_HAS_HFCLKSRC 1
 #else
 #define NRF_CLOCK_HAS_HFCLKSRC 0
+#endif
+
+#if defined(CLOCK_TASKS_PLLSTART_TASKS_PLLSTART_Msk) || defined(__NRFX_DOXYGEN__)
+/** @brief Symbol indicating whether the PLL section is present. */
+#define NRF_CLOCK_HAS_PLL 1
+#else
+#define NRF_CLOCK_HAS_PLL 0
+#endif
+
+#if defined(CLOCK_TASKS_XOSTART_TASKS_XOSTART_Msk) || defined(__NRFX_DOXYGEN__)
+/** @brief Symbol indicating whether XO registers are present. */
+#define NRF_CLOCK_HAS_XO 1
+#else
+#define NRF_CLOCK_HAS_XO 0
+#endif
+
+#if defined(CLOCK_LFCLK_SRC_SRC_Msk) || defined(__NRFX_DOXYGEN__)
+/** @brief Symbol indicating whether the CLOCK type contains LFCLK subtype. */
+#define NRF_CLOCK_HAS_LFCLK_TYPE 1
+#else
+#define NRF_CLOCK_HAS_LFCLK_TYPE 0
+#endif
+
+#if defined(CLOCK_LFCLKSRCCOPY_SRC_Msk) || defined(__NRFX_DOXYGEN__)
+/** @brief Symbol indicating whether the CLOCK has LFCLKSRCCOPY register. */
+#define NRF_CLOCK_HAS_LFCLKSRCCOPY 1
+#else
+#define NRF_CLOCK_HAS_LFCLKSRCCOPY 0
+#endif
+
+#if NRF_CLOCK_HAS_LFCLK_TYPE
+#define NRF_CLOCK_LFCLKRUN_STATUS_NotTriggered CLOCK_LFCLK_RUN_STATUS_NotTriggered /**< Task LFCLKSTART/HFCLKSTART has not been triggered definiton. */
+#define NRF_CLOCK_LFCLKRUN_STATUS_Triggered    CLOCK_LFCLK_RUN_STATUS_Triggered    /**< Task LFCLKSTART/HFCLKSTART has been triggered. */
+#define NRF_CLOCK_INTENSET_LFCLKSTARTED_Msk    CLOCK_INTENSET_LFCLKSTARTED_Msk     /**< Interrupt on LFCLKSTARTED event mask definition. */
+#define NRF_LFCLKRUN                           LFCLK.RUN                           /**< LF clock RUN register definition. */
+#define NRF_LFCLKSTAT                          LFCLK.STAT                          /**< LF clock STAT register definition. */
+#define NRF_LFCLKSRC                           LFCLK.SRC                           /**< LF clock SRC register definition. */
+#define NRF_CLOCK_LFCLKRUN_STATUS_Msk          CLOCK_LFCLK_RUN_STATUS_Msk          /**< LF clock RUN status mask definition. */
+#define NRF_CLOCK_LFCLKRUN_STATUS_Pos          CLOCK_LFCLK_RUN_STATUS_Pos          /**< LF clock RUN status position definition. */
+#define NRF_CLOCK_LFCLKSTAT_SRC_Msk            CLOCK_LFCLK_STAT_SRC_Msk            /**< LF clock STAT source mask definition. */
+#define NRF_CLOCK_LFCLKSTAT_SRC_Pos            CLOCK_LFCLK_STAT_SRC_Pos            /**< LF clock STAT source position definition. */
+#define NRF_CLOCK_LFCLKSTAT_STATE_Msk          CLOCK_LFCLK_STAT_STATE_Msk          /**< LF clock STAT state mask definition. */
+#define NRF_CLOCK_LFCLKSTAT_STATE_Pos          CLOCK_LFCLK_STAT_STATE_Pos          /**< LF clock STAT state position definition. */
+#else
+#define NRF_CLOCK_LFCLKRUN_STATUS_NotTriggered CLOCK_LFCLKRUN_STATUS_NotTriggered
+#define NRF_CLOCK_LFCLKRUN_STATUS_Triggered    CLOCK_LFCLKRUN_STATUS_Triggered
+#define NRF_CLOCK_INTENSET_LFCLKSTARTED_Msk    CLOCK_INTENSET_LFCLKSTARTED_Msk
+#define NRF_LFCLKRUN                           LFCLKRUN
+#define NRF_LFCLKSTAT                          LFCLKSTAT
+#define NRF_LFCLKSRC                           LFCLKSRC
+#define NRF_CLOCK_LFCLKRUN_STATUS_Msk          CLOCK_LFCLKRUN_STATUS_Msk
+#define NRF_CLOCK_LFCLKRUN_STATUS_Pos          CLOCK_LFCLKRUN_STATUS_Pos
+#define NRF_CLOCK_LFCLKSTAT_SRC_Msk            CLOCK_LFCLKSTAT_SRC_Msk
+#define NRF_CLOCK_LFCLKSTAT_SRC_Pos            CLOCK_LFCLKSTAT_SRC_Pos
+#define NRF_CLOCK_LFCLKSTAT_STATE_Msk          CLOCK_LFCLKSTAT_STATE_Msk
+#define NRF_CLOCK_LFCLKSTAT_STATE_Pos          CLOCK_LFCLKSTAT_STATE_Pos
+#endif
+
+#if NRF_CLOCK_HAS_XO
+#define NRF_CLOCK_INTENSET_HFCLKSTARTED_Msk CLOCK_INTEN_XOSTARTED_Msk /**< HF clock bit mask in interrupt register. */
+#define NRF_TASKS_HFCLKSTART                TASKS_XOSTART             /**< Task HF clock start definition. */
+#define NRF_TASKS_HFCLKSTOP                 TASKS_XOSTOP              /**< Task HF clock stop definition. */
+#define NRF_EVENTS_HFCLKSTARTED             EVENTS_XOSTARTED          /**< Event HF clock startrd definition. */
+#define NRF_HFCLKRUN                        XO.RUN                    /**< HF clock RUN register definition. */
+#define NRF_HFCLKSTAT                       XO.STAT                   /**< HF clock STAT register definition. */
+#define NRF_CLOCK_HFCLKRUN_STATUS_Msk       CLOCK_XO_RUN_STATUS_Msk   /**< HF clock RUN status mask definition. */
+#define NRF_CLOCK_HFCLKRUN_STATUS_Pos       CLOCK_XO_RUN_STATUS_Pos   /**< HF clock RUN status position definition. */
+#define NRF_CLOCK_HFCLKSTAT_SRC_Msk         CLOCK_XO_STAT_SRC_Msk     /**< HF clock STAT source mask definition. */
+#define NRF_CLOCK_HFCLKSTAT_SRC_Pos         CLOCK_XO_STAT_SRC_Pos     /**< HF clock STAT source position definition. */
+#define NRF_CLOCK_HFCLKSTAT_STATE_Msk       CLOCK_XO_STAT_STATE_Msk   /**< HF clock STAT state mask definition. */
+#define NRF_CLOCK_HFCLKSTAT_STATE_Pos       CLOCK_XO_STAT_STATE_Pos   /**< HF clock STAT state position definition. */
+#else
+#define NRF_CLOCK_INTENSET_HFCLKSTARTED_Msk CLOCK_INTENSET_HFCLKSTARTED_Msk
+#define NRF_TASKS_HFCLKSTART                TASKS_HFCLKSTART
+#define NRF_TASKS_HFCLKSTOP                 TASKS_HFCLKSTOP
+#define NRF_EVENTS_HFCLKSTARTED             EVENTS_HFCLKSTARTED
+#define NRF_HFCLKRUN                        HFCLKRUN
+#define NRF_HFCLKSTAT                       HFCLKSTAT
+#define NRF_CLOCK_HFCLKRUN_STATUS_Msk       CLOCK_HFCLKRUN_STATUS_Msk
+#define NRF_CLOCK_HFCLKRUN_STATUS_Pos       CLOCK_HFCLKRUN_STATUS_Pos
+#define NRF_CLOCK_HFCLKSTAT_SRC_Msk         CLOCK_HFCLKSTAT_SRC_Msk
+#define NRF_CLOCK_HFCLKSTAT_SRC_Pos         CLOCK_HFCLKSTAT_SRC_Pos
+#define NRF_CLOCK_HFCLKSTAT_STATE_Msk       CLOCK_HFCLKSTAT_STATE_Msk
+#define NRF_CLOCK_HFCLKSTAT_STATE_Pos       CLOCK_HFCLKSTAT_STATE_Pos
 #endif
 
 /**
@@ -112,34 +204,38 @@ typedef enum
 
 #if defined(CLOCK_LFCLKSRC_SRC_RC) || defined(__NRFX_DOXYGEN__)
     NRF_CLOCK_LFCLK_RC    = CLOCK_LFCLKSRC_SRC_RC,     /**< Internal 32 kHz RC oscillator. */
+#elif NRF_CLOCK_HAS_LFCLK_TYPE
+    NRF_CLOCK_LFCLK_RC    = CLOCK_LFCLK_SRC_SRC_LFRC,  /**< Internal 32 kHz RC oscillator. */
 #else
     NRF_CLOCK_LFCLK_RC    = CLOCK_LFCLKSRC_SRC_LFRC,   /**< Internal 32 kHz RC oscillator. */
 #endif
 
 #if defined(CLOCK_LFCLKSRC_SRC_Xtal) || defined(__NRFX_DOXYGEN__)
-    NRF_CLOCK_LFCLK_Xtal  = CLOCK_LFCLKSRC_SRC_Xtal,   /**< External 32 kHz crystal. */
+    NRF_CLOCK_LFCLK_XTAL  = CLOCK_LFCLKSRC_SRC_Xtal,   /**< External 32 kHz crystal. */
+#elif NRF_CLOCK_HAS_LFCLK_TYPE
+    NRF_CLOCK_LFCLK_XTAL  = CLOCK_LFCLK_SRC_SRC_LFXO,  /**< External 32 kHz crystal. */
 #else
-    NRF_CLOCK_LFCLK_Xtal  = CLOCK_LFCLKSRC_SRC_LFXO,   /**< External 32 kHz crystal. */
+    NRF_CLOCK_LFCLK_XTAL  = CLOCK_LFCLKSRC_SRC_LFXO,   /**< External 32 kHz crystal. */
 #endif
 
 #if defined(CLOCK_LFCLKSRC_SRC_Synth) || defined(__NRFX_DOXYGEN__)
-    NRF_CLOCK_LFCLK_Synth = CLOCK_LFCLKSRC_SRC_Synth,  /**< Internal 32 kHz synthesized from HFCLK system clock. */
+    NRF_CLOCK_LFCLK_SYNTH = CLOCK_LFCLKSRC_SRC_Synth,  /**< Internal 32 kHz synthesized from HFCLK system clock. */
 #elif defined(CLOCK_LFCLKSRC_SRC_LFSYNT)
-    NRF_CLOCK_LFCLK_Synth = CLOCK_LFCLKSRC_SRC_LFSYNT, /**< Internal 32 kHz synthesized from HFCLK system clock. */
+    NRF_CLOCK_LFCLK_SYNTH = CLOCK_LFCLKSRC_SRC_LFSYNT, /**< Internal 32 kHz synthesized from HFCLK system clock. */
 #endif
 
 #if defined(NRF_CLOCK_USE_EXTERNAL_LFCLK_SOURCES) || defined(__NRFX_DOXYGEN__)
     /**
      * External 32 kHz low swing signal. Used only with the LFCLKSRC register.
-     * For the others @ref NRF_CLOCK_LFCLK_Xtal is returned for this setting.
+     * For the others @ref NRF_CLOCK_LFCLK_XTAL is returned for this setting.
      */
-    NRF_CLOCK_LFCLK_Xtal_Low_Swing = (CLOCK_LFCLKSRC_SRC_Xtal |
+    NRF_CLOCK_LFCLK_XTAL_LOW_SWING = (CLOCK_LFCLKSRC_SRC_Xtal |
         (CLOCK_LFCLKSRC_EXTERNAL_Enabled << CLOCK_LFCLKSRC_EXTERNAL_Pos)),
     /**
      * External 32 kHz full swing signal. Used only with the LFCLKSRC register.
-     * For the others @ref NRF_CLOCK_LFCLK_Xtal is returned for this setting.
+     * For the others @ref NRF_CLOCK_LFCLK_XTAL is returned for this setting.
      */
-    NRF_CLOCK_LFCLK_Xtal_Full_Swing = (CLOCK_LFCLKSRC_SRC_Xtal |
+    NRF_CLOCK_LFCLK_XTAL_FULL_SWING = (CLOCK_LFCLKSRC_SRC_Xtal |
         (CLOCK_LFCLKSRC_BYPASS_Enabled   << CLOCK_LFCLKSRC_BYPASS_Pos) |
         (CLOCK_LFCLKSRC_EXTERNAL_Enabled << CLOCK_LFCLKSRC_EXTERNAL_Pos)),
 #endif // defined(NRF_CLOCK_USE_EXTERNAL_LFCLK_SOURCES) || defined(__NRFX_DOXYGEN__)
@@ -151,15 +247,20 @@ typedef enum
  */
 typedef enum
 {
-#if defined(CLOCK_HFCLKSTAT_SRC_RC) || defined(__NRFX_DOXYGEN__)
-    NRF_CLOCK_HFCLK_LOW_ACCURACY  = CLOCK_HFCLKSTAT_SRC_RC,  /**< Internal 16 MHz RC oscillator. */
-#elif defined(CLOCK_HFCLKSTAT_SRC_HFINT)
-    NRF_CLOCK_HFCLK_LOW_ACCURACY  = CLOCK_HFCLKSTAT_SRC_HFINT,  /**< Internal 16 MHz RC oscillator. */
-#endif
 #if defined(CLOCK_HFCLKSTAT_SRC_Xtal) || defined(__NRFX_DOXYGEN__)
-    NRF_CLOCK_HFCLK_HIGH_ACCURACY = CLOCK_HFCLKSTAT_SRC_Xtal /**< External 16 MHz/32 MHz crystal oscillator. */
+    NRF_CLOCK_HFCLK_HIGH_ACCURACY = CLOCK_HFCLKSTAT_SRC_Xtal,  /**< External 16 MHz/32 MHz crystal oscillator. */
+#elif NRF_CLOCK_HAS_XO
+    NRF_CLOCK_HFCLK_HIGH_ACCURACY = CLOCK_XO_STAT_SRC_HFXO,    /**< External 32 MHz crystal oscillator. */
 #else
-    NRF_CLOCK_HFCLK_HIGH_ACCURACY = CLOCK_HFCLKSTAT_SRC_HFXO /**< External 32 MHz crystal oscillator. */
+    NRF_CLOCK_HFCLK_HIGH_ACCURACY = CLOCK_HFCLKSTAT_SRC_HFXO,  /**< External 32 MHz crystal oscillator. */
+#endif
+
+#if defined(CLOCK_HFCLKSTAT_SRC_RC) || defined(__NRFX_DOXYGEN__)
+    NRF_CLOCK_HFCLK_LOW_ACCURACY  = CLOCK_HFCLKSTAT_SRC_RC,    /**< Internal 16 MHz RC oscillator. */
+#elif defined(CLOCK_HFCLKSTAT_SRC_HFINT)
+    NRF_CLOCK_HFCLK_LOW_ACCURACY  = CLOCK_HFCLKSTAT_SRC_HFINT, /**< Internal 16 MHz RC oscillator. */
+#else
+    NRF_CLOCK_HFCLK_LOW_ACCURACY,                              /**< Internal RC oscillator. */
 #endif
 } nrf_clock_hfclk_t;
 
@@ -200,15 +301,19 @@ typedef enum
  */
 typedef enum
 {
-    NRF_CLOCK_START_TASK_NOT_TRIGGERED = CLOCK_LFCLKRUN_STATUS_NotTriggered, /**< Task LFCLKSTART/HFCLKSTART has not been triggered. */
-    NRF_CLOCK_START_TASK_TRIGGERED     = CLOCK_LFCLKRUN_STATUS_Triggered     /**< Task LFCLKSTART/HFCLKSTART has been triggered. */
+    NRF_CLOCK_START_TASK_NOT_TRIGGERED = NRF_CLOCK_LFCLKRUN_STATUS_NotTriggered, /**< Task LFCLKSTART/HFCLKSTART has not been triggered. */
+    NRF_CLOCK_START_TASK_TRIGGERED     = NRF_CLOCK_LFCLKRUN_STATUS_Triggered     /**< Task LFCLKSTART/HFCLKSTART has been triggered. */
 } nrf_clock_start_task_status_t;
 
 /** @brief Interrupts. */
 typedef enum
 {
-    NRF_CLOCK_INT_HF_STARTED_MASK      = CLOCK_INTENSET_HFCLKSTARTED_Msk,      /**< Interrupt on HFCLKSTARTED event. */
-    NRF_CLOCK_INT_LF_STARTED_MASK      = CLOCK_INTENSET_LFCLKSTARTED_Msk,      /**< Interrupt on LFCLKSTARTED event. */
+    NRF_CLOCK_INT_HF_STARTED_MASK      = NRF_CLOCK_INTENSET_HFCLKSTARTED_Msk,  /**< Interrupt on HFCLKSTARTED event. */
+    NRF_CLOCK_INT_LF_STARTED_MASK      = NRF_CLOCK_INTENSET_LFCLKSTARTED_Msk,  /**< Interrupt on LFCLKSTARTED event. */
+
+#if NRF_CLOCK_HAS_PLL
+    NRFX_CLOCK_INT_PLL_STARTED_MASK    = CLOCK_INTENSET_PLLSTARTED_Msk,        /**< Interrupt on PLLSTARTED event. */
+#endif
 #if NRF_CLOCK_HAS_CALIBRATION
     NRF_CLOCK_INT_DONE_MASK            = CLOCK_INTENSET_DONE_Msk,              /**< Interrupt on DONE event. */
 #endif
@@ -236,8 +341,17 @@ typedef enum
  */
 typedef enum
 {
+#if NRF_CLOCK_HAS_XO
+    NRF_CLOCK_TASK_HFCLKSTART      = offsetof(NRF_CLOCK_Type, TASKS_XOSTART),         /**< Start HFCLK clock source. */
+    NRF_CLOCK_TASK_HFCLKSTOP       = offsetof(NRF_CLOCK_Type, TASKS_XOSTOP),          /**< Stop HFCLK clock source. */
+#else
     NRF_CLOCK_TASK_HFCLKSTART      = offsetof(NRF_CLOCK_Type, TASKS_HFCLKSTART),      /**< Start HFCLK clock source. */
     NRF_CLOCK_TASK_HFCLKSTOP       = offsetof(NRF_CLOCK_Type, TASKS_HFCLKSTOP),       /**< Stop HFCLK clock source. */
+#endif
+#if NRF_CLOCK_HAS_PLL
+    NRF_CLOCK_TASK_PLLSTART        = offsetof(NRF_CLOCK_Type, TASKS_PLLSTART),        /**< Start PLL and keep it running, regardless of the automatic clock requests. */
+    NRF_CLOCK_TASK_PLLSTOP         = offsetof(NRF_CLOCK_Type, TASKS_PLLSTOP),         /**< Stop PLL. */
+#endif
     NRF_CLOCK_TASK_LFCLKSTART      = offsetof(NRF_CLOCK_Type, TASKS_LFCLKSTART),      /**< Start LFCLK clock source. */
     NRF_CLOCK_TASK_LFCLKSTOP       = offsetof(NRF_CLOCK_Type, TASKS_LFCLKSTOP),       /**< Stop LFCLK clock source. */
 #if NRF_CLOCK_HAS_CALIBRATION
@@ -260,7 +374,14 @@ typedef enum
 /** @brief Events. */
 typedef enum
 {
+#if NRF_CLOCK_HAS_XO
+    NRF_CLOCK_EVENT_HFCLKSTARTED      = offsetof(NRF_CLOCK_Type, EVENTS_XOSTARTED),         /**< HFCLK oscillator started. */
+#else
     NRF_CLOCK_EVENT_HFCLKSTARTED      = offsetof(NRF_CLOCK_Type, EVENTS_HFCLKSTARTED),      /**< HFCLK oscillator started. */
+#endif
+#if NRF_CLOCK_HAS_PLL
+    NRF_CLOCK_EVENT_PLLSTARTED        = offsetof(NRF_CLOCK_Type, EVENTS_PLLSTARTED),        /**< PLL started. */
+#endif
     NRF_CLOCK_EVENT_LFCLKSTARTED      = offsetof(NRF_CLOCK_Type, EVENTS_LFCLKSTARTED),      /**< LFCLK oscillator started. */
 #if NRF_CLOCK_HAS_CALIBRATION
     NRF_CLOCK_EVENT_DONE              = offsetof(NRF_CLOCK_Type, EVENTS_DONE),              /**< Calibration of LFCLK RC oscillator completed. */
@@ -426,6 +547,7 @@ NRF_STATIC_INLINE nrf_clock_lfclk_t nrf_clock_lf_src_get(NRF_CLOCK_Type const * 
  */
 NRF_STATIC_INLINE nrf_clock_lfclk_t nrf_clock_lf_actv_src_get(NRF_CLOCK_Type const * p_reg);
 
+#if NRF_CLOCK_HAS_LFCLKSRCCOPY
 /**
  * @brief Function for retrieving the clock source for the LFCLK clock when
  *        the task LKCLKSTART is triggered.
@@ -440,6 +562,7 @@ NRF_STATIC_INLINE nrf_clock_lfclk_t nrf_clock_lf_actv_src_get(NRF_CLOCK_Type con
  *                               the HFCLK is running and generating the LFCLK clock.
  */
 NRF_STATIC_INLINE nrf_clock_lfclk_t nrf_clock_lf_srccopy_get(NRF_CLOCK_Type const * p_reg);
+#endif
 
 /**
  * @brief Function for retrieving the state of the LFCLK clock.
@@ -751,11 +874,11 @@ NRF_STATIC_INLINE bool nrf_clock_start_task_check(NRF_CLOCK_Type const * p_reg,
     switch (domain)
     {
         case NRF_CLOCK_DOMAIN_LFCLK:
-            return ((p_reg->LFCLKRUN & CLOCK_LFCLKRUN_STATUS_Msk)
-                    >> CLOCK_LFCLKRUN_STATUS_Pos);
+            return ((p_reg->NRF_LFCLKRUN & NRF_CLOCK_LFCLKRUN_STATUS_Msk)
+                    >> NRF_CLOCK_LFCLKRUN_STATUS_Pos);
         case NRF_CLOCK_DOMAIN_HFCLK:
-            return ((p_reg->HFCLKRUN & CLOCK_HFCLKRUN_STATUS_Msk)
-                    >> CLOCK_HFCLKRUN_STATUS_Pos);
+            return ((p_reg->NRF_HFCLKRUN & NRF_CLOCK_HFCLKRUN_STATUS_Msk)
+                    >> NRF_CLOCK_HFCLKRUN_STATUS_Pos);
 #if NRF_CLOCK_HAS_HFCLK192M
         case NRF_CLOCK_DOMAIN_HFCLK192M:
             return ((p_reg->HFCLK192MRUN & CLOCK_HFCLK192MRUN_STATUS_Msk)
@@ -787,59 +910,55 @@ NRF_STATIC_INLINE bool nrf_clock_is_running(NRF_CLOCK_Type const * p_reg,
                                             nrf_clock_domain_t     domain,
                                             void *                 p_clk_src)
 {
+    bool clock_running;
     switch (domain)
     {
         case NRF_CLOCK_DOMAIN_LFCLK:
+            clock_running = p_reg->NRF_LFCLKSTAT & NRF_CLOCK_LFCLKSTAT_STATE_Msk;
             if (p_clk_src != NULL)
             {
                 (*(nrf_clock_lfclk_t *)p_clk_src) =
-                    (nrf_clock_lfclk_t)((p_reg->LFCLKSTAT & CLOCK_LFCLKSTAT_SRC_Msk)
-                                        >> CLOCK_LFCLKSTAT_SRC_Pos);
-            }
-            if ((p_reg->LFCLKSTAT & CLOCK_LFCLKSTAT_STATE_Msk)
-                >> CLOCK_LFCLKSTAT_STATE_Pos)
-            {
-                return true;
+                    (nrf_clock_lfclk_t)((p_reg->NRF_LFCLKSTAT & NRF_CLOCK_LFCLKSTAT_SRC_Msk)
+                                        >> NRF_CLOCK_LFCLKSTAT_SRC_Pos);
             }
             break;
         case NRF_CLOCK_DOMAIN_HFCLK:
+            clock_running = p_reg->NRF_HFCLKSTAT & NRF_CLOCK_HFCLKSTAT_STATE_Msk;
             if (p_clk_src != NULL)
             {
+#if NRF_CLOCK_HAS_XO
+                /* XO registers do not contain information about low accuracy source being active.
+                 * It has to be derived from HFCLK state. */
+                (*(nrf_clock_hfclk_t *)p_clk_src) = clock_running ? NRF_CLOCK_HFCLK_HIGH_ACCURACY :
+                                                                    NRF_CLOCK_HFCLK_LOW_ACCURACY;
+#else
                 (*(nrf_clock_hfclk_t *)p_clk_src) =
-                    (nrf_clock_hfclk_t)((p_reg->HFCLKSTAT & CLOCK_HFCLKSTAT_SRC_Msk)
-                                        >> CLOCK_HFCLKSTAT_SRC_Pos);
-            }
-            if ((p_reg->HFCLKSTAT & CLOCK_HFCLKSTAT_STATE_Msk)
-                >> CLOCK_HFCLKSTAT_STATE_Pos)
-            {
-                return true;
+                    (nrf_clock_hfclk_t)((p_reg->NRF_HFCLKSTAT & NRF_CLOCK_HFCLKSTAT_SRC_Msk)
+                                        >> NRF_CLOCK_HFCLKSTAT_SRC_Pos);
+#endif
             }
             break;
 #if NRF_CLOCK_HAS_HFCLK192M
         case NRF_CLOCK_DOMAIN_HFCLK192M:
+            clock_running = p_reg->HFCLK192MSTAT & CLOCK_HFCLK192MSTAT_STATE_Msk;
             if (p_clk_src != NULL)
             {
                 (*(nrf_clock_hfclk_t *)p_clk_src) =
                     (nrf_clock_hfclk_t)((p_reg->HFCLK192MSTAT & CLOCK_HFCLK192MSTAT_SRC_Msk)
                                         >> CLOCK_HFCLK192MSTAT_SRC_Pos);
             }
-            if ((p_reg->HFCLK192MSTAT & CLOCK_HFCLK192MSTAT_STATE_Msk)
-                >> CLOCK_HFCLK192MSTAT_STATE_Pos)
-            {
-                return true;
-            }
             break;
 #endif
 #if NRF_CLOCK_HAS_HFCLKAUDIO
         case NRF_CLOCK_DOMAIN_HFCLKAUDIO:
-            return (p_reg->HFCLKAUDIOSTAT & CLOCK_HFCLKAUDIOSTAT_STATE_Msk) ==
-                   CLOCK_HFCLKAUDIOSTAT_STATE_Msk;
+            clock_running = p_reg->HFCLKAUDIOSTAT & CLOCK_HFCLKAUDIOSTAT_STATE_Msk;
+            break;
 #endif
         default:
             NRFX_ASSERT(0);
             return false;
     }
-    return false;
+    return clock_running;
 }
 
 #if defined(__GNUC__)
@@ -848,12 +967,12 @@ NRF_STATIC_INLINE bool nrf_clock_is_running(NRF_CLOCK_Type const * p_reg,
 
 NRF_STATIC_INLINE void nrf_clock_lf_src_set(NRF_CLOCK_Type * p_reg, nrf_clock_lfclk_t source)
 {
-    p_reg->LFCLKSRC = (uint32_t)(source);
+    p_reg->NRF_LFCLKSRC = (uint32_t)(source);
 }
 
 NRF_STATIC_INLINE nrf_clock_lfclk_t nrf_clock_lf_src_get(NRF_CLOCK_Type const * p_reg)
 {
-    return (nrf_clock_lfclk_t)(p_reg->LFCLKSRC);
+    return (nrf_clock_lfclk_t)(p_reg->NRF_LFCLKSRC);
 }
 
 NRF_STATIC_INLINE nrf_clock_lfclk_t nrf_clock_lf_actv_src_get(NRF_CLOCK_Type const * p_reg)
@@ -863,11 +982,13 @@ NRF_STATIC_INLINE nrf_clock_lfclk_t nrf_clock_lf_actv_src_get(NRF_CLOCK_Type con
     return clk_src;
 }
 
+#if NRF_CLOCK_HAS_LFCLKSRCCOPY
 NRF_STATIC_INLINE nrf_clock_lfclk_t nrf_clock_lf_srccopy_get(NRF_CLOCK_Type const * p_reg)
 {
     return (nrf_clock_lfclk_t)((p_reg->LFCLKSRCCOPY & CLOCK_LFCLKSRCCOPY_SRC_Msk)
                                 >> CLOCK_LFCLKSRCCOPY_SRC_Pos);
 }
+#endif
 
 NRF_STATIC_INLINE bool nrf_clock_lf_is_running(NRF_CLOCK_Type const * p_reg)
 {
@@ -892,6 +1013,11 @@ NRF_STATIC_INLINE nrf_clock_hfclk_t nrf_clock_hf_src_get(NRF_CLOCK_Type const * 
 {
 #if NRF_CLOCK_HAS_HFCLKSRC
     return (nrf_clock_hfclk_t)(p_reg->HFCLKSRC);
+#elif NRF_CLOCK_HAS_XO
+    /* XO registers do not contain information about low accuracy source being active.
+     * It has to be derived from HFCLK state. */
+    return (p_reg->NRF_HFCLKSTAT & NRF_CLOCK_HFCLKSTAT_STATE_Msk) ? NRF_CLOCK_HFCLK_HIGH_ACCURACY :
+                                                                    NRF_CLOCK_HFCLK_LOW_ACCURACY;
 #else
     return (nrf_clock_hfclk_t)((p_reg->HFCLKSTAT & CLOCK_HFCLKSTAT_SRC_Msk)
                                 >> CLOCK_HFCLKSTAT_SRC_Pos);
@@ -1072,7 +1198,7 @@ NRF_STATIC_INLINE void nrf_clock_subscribe_set(NRF_CLOCK_Type * p_reg,
                                                uint8_t          channel)
 {
     *((volatile uint32_t *) ((uint8_t *)p_reg+ (uint32_t)task + 0x80uL)) =
-            ((uint32_t)channel | CLOCK_SUBSCRIBE_HFCLKSTART_EN_Msk);
+            ((uint32_t)channel | NRF_SUBSCRIBE_PUBLISH_ENABLE);
 }
 
 NRF_STATIC_INLINE void nrf_clock_subscribe_clear(NRF_CLOCK_Type * p_reg, nrf_clock_task_t task)
@@ -1085,7 +1211,7 @@ NRF_STATIC_INLINE void nrf_clock_publish_set(NRF_CLOCK_Type *  p_reg,
                                              uint8_t           channel)
 {
     *((volatile uint32_t *) ((uint8_t *)p_reg + (uint32_t)event + 0x80uL)) =
-            ((uint32_t)channel | CLOCK_PUBLISH_HFCLKSTARTED_EN_Msk);
+            ((uint32_t)channel | NRF_SUBSCRIBE_PUBLISH_ENABLE);
 }
 
 NRF_STATIC_INLINE void nrf_clock_publish_clear(NRF_CLOCK_Type * p_reg, nrf_clock_event_t event)

--- a/nrfx/hal/nrf_common.h
+++ b/nrfx/hal/nrf_common.h
@@ -42,23 +42,69 @@ extern "C" {
 #define NRFX_EVENT_READBACK_ENABLED 1
 #endif
 
-#if !defined(NRFX_CONFIG_API_VER_2_9)  && \
-    !defined(NRFX_CONFIG_API_VER_2_10) && \
-    !defined(NRFX_CONFIG_API_VER_2_11)
-#define NRFX_CONFIG_API_VER_2_9 1
+#ifndef NRFX_CONFIG_API_VER_MAJOR
+#define NRFX_CONFIG_API_VER_MAJOR 3
+#endif
+
+#ifndef NRFX_CONFIG_API_VER_MINOR
+#define NRFX_CONFIG_API_VER_MINOR 0
+#endif
+
+#ifndef NRFX_CONFIG_API_VER_MICRO
+#define NRFX_CONFIG_API_VER_MICRO 0
+#endif
+
+#if defined(ISA_RISCV)
+#define RISCV_FENCE(p, s) __asm__ __volatile__ ("fence " #p "," #s : : : "memory")
+#endif
+
+#ifndef NRF_SUBSCRIBE_PUBLISH_ENABLE
+#define NRF_SUBSCRIBE_PUBLISH_ENABLE (0x01UL << 31UL)
 #endif
 
 #if defined(NRFX_CLZ)
 #define NRF_CLZ(value) NRFX_CLZ(value)
-#else
+#elif defined(ISA_ARM)
 #define NRF_CLZ(value) __CLZ(value)
+#else
+#define NRF_CLZ(value) __builtin_clz(value)
 #endif
 
 #if defined(NRFX_CTZ)
 #define NRF_CTZ(value) NRFX_CTZ(value)
-#else
+#elif defined(ISA_ARM)
 #define NRF_CTZ(value) __CLZ(__RBIT(value))
+#else
+#define NRF_CTZ(value) __builtin_ctz(value)
 #endif
+
+/** @brief Macro for extracting relative pin number from the absolute pin number. */
+#define NRF_PIN_NUMBER_TO_PIN(pin) ((pin) & 0x1F)
+
+/** @brief Macro for extracting port number from the absolute pin number. */
+#define NRF_PIN_NUMBER_TO_PORT(pin) ((pin) >> 5)
+
+/** @brief Macro for extracting absolute pin number from the relative pin and port numbers. */
+#define NRF_PIN_PORT_TO_PIN_NUMBER(pin, port) (((pin) & 0x1F) | ((port) << 5))
+
+/**
+ * @brief Function for checking if an object is accesible by EasyDMA of given peripheral instance.
+ *
+ * Peripherals that use EasyDMA require buffers to be placed in certain memory regions.
+ *
+ * @param[in] p_reg    Peripheral base pointer.
+ * @param[in] p_object Pointer to an object whose location is to be checked.
+ *
+ * @retval true  The pointed object is located in the memory region accessible by EasyDMA.
+ * @retval false The pointed object is not located in the memory region accessible by EasyDMA.
+ */
+NRF_STATIC_INLINE bool nrf_dma_accessible_check(void const * p_reg, void const * p_object);
+
+NRF_STATIC_INLINE void nrf_barrier_w(void);
+
+NRF_STATIC_INLINE void nrf_barrier_r(void);
+
+NRF_STATIC_INLINE void nrf_barrier_rw(void);
 
 #ifndef NRF_DECLARE_ONLY
 
@@ -68,6 +114,93 @@ NRF_STATIC_INLINE void nrf_event_readback(void * p_event_reg)
     (void)*((volatile uint32_t *)(p_event_reg));
 #else
     (void)p_event_reg;
+#endif
+}
+
+NRF_STATIC_INLINE void nrf_barrier_w(void)
+{
+#if defined(ISA_RISCV)
+    RISCV_FENCE(ow, ow);
+#endif
+}
+
+NRF_STATIC_INLINE void nrf_barrier_r(void)
+{
+#if defined(ISA_RISCV)
+    RISCV_FENCE(ir, ir);
+#endif
+}
+
+NRF_STATIC_INLINE void nrf_barrier_rw(void)
+{
+#if defined(ISA_RISCV)
+    RISCV_FENCE(iorw, iorw);
+#endif
+}
+
+#if defined(ADDRESS_DOMAIN_Msk)
+NRF_STATIC_INLINE uint8_t nrf_address_domain_get(uint32_t addr)
+{
+    return (uint8_t)((addr & ADDRESS_DOMAIN_Msk) >> ADDRESS_DOMAIN_Pos);
+}
+#endif
+
+#if defined(ADDRESS_REGION_Msk)
+NRF_STATIC_INLINE nrf_region_t nrf_address_region_get(uint32_t addr)
+{
+    return (nrf_region_t)((addr & ADDRESS_REGION_Msk) >> ADDRESS_REGION_Pos);
+}
+#endif
+
+#if defined(ADDRESS_SECURITY_Msk)
+NRF_STATIC_INLINE bool nrf_address_security_get(uint32_t addr)
+{
+    return ((addr & ADDRESS_SECURITY_Msk) >> ADDRESS_SECURITY_Pos);
+}
+#endif
+
+#if defined(ADDRESS_BUS_Msk)
+NRF_STATIC_INLINE uint8_t nrf_address_bus_get(uint32_t addr, size_t size)
+{
+    return (uint8_t)((addr & ADDRESS_BUS_Msk & ~(size - 1)) >> ADDRESS_BUS_Pos);
+}
+#endif
+
+#if defined(ADDRESS_BRIDGE_GROUP_Msk)
+NRF_STATIC_INLINE uint8_t nrf_address_bridge_group_get(uint32_t addr)
+{
+    return (uint8_t)((addr & ADDRESS_BRIDGE_GROUP_Msk) >> ADDRESS_BRIDGE_GROUP_Pos);
+}
+#endif
+
+#if defined(ADDRESS_DOMAIN_SPEED_Msk)
+NRF_STATIC_INLINE nrf_domain_speed_t nrf_address_domain_speed_get(uint32_t addr)
+{
+    return (nrf_domain_speed_t)((addr & ADDRESS_DOMAIN_SPEED_Msk) >> ADDRESS_DOMAIN_SPEED_Pos);
+}
+#endif
+
+#if defined(ADDRESS_SLAVE_Msk)
+NRF_STATIC_INLINE uint8_t nrf_address_slave_get(uint32_t addr)
+{
+    return (uint8_t)((addr & ADDRESS_SLAVE_Msk) >> ADDRESS_SLAVE_Pos);
+}
+#endif
+
+#if defined(ADDRESS_PERIPHID_Msk)
+NRF_STATIC_INLINE uint16_t nrf_address_periphid_get(uint32_t addr)
+{
+    return (uint16_t)((addr & ADDRESS_PERIPHID_Msk) >> ADDRESS_PERIPHID_Pos);
+}
+#endif
+
+NRF_STATIC_INLINE bool nrf_dma_accessible_check(void const * p_reg, void const * p_object)
+{
+#if defined(NRF_DMA_ACCESS_EXT)
+    NRF_DMA_ACCESS_EXT
+#else
+    (void)p_reg;
+    return ((((uint32_t)p_object) & 0xE0000000u) == 0x20000000u);
 #endif
 }
 

--- a/nrfx/hal/nrf_comp.h
+++ b/nrfx/hal/nrf_comp.h
@@ -47,7 +47,24 @@ extern "C" {
  * @brief   Hardware access layer (HAL) for managing the Comparator (COMP) peripheral.
  */
 
+#if defined(COMP_ISOURCE_ISOURCE_Msk) || defined (__NRFX_DOXYGEN__)
+/** @brief Symbol indicating whether COMP has ISOURCE register. */
+#define NRF_COMP_HAS_ISOURCE 1
+#else
+#define NRF_COMP_HAS_ISOURCE 0
+#endif
+
+#if defined(COMP_PSEL_PIN_Msk) || defined(__NRFX_DOXYGEN__)
+/** @brief Symbol indicating whether the configuration of analog input using pin number is present. */
+#define NRF_COMP_HAS_AIN_AS_PIN 1
+#else
+#define NRF_COMP_HAS_AIN_AS_PIN 0
+#endif
+
 /** @brief COMP analog pin selection. */
+#if NRF_COMP_HAS_AIN_AS_PIN
+typedef uint32_t nrf_comp_input_t;
+#else
 typedef enum
 {
     NRF_COMP_INPUT_0   = COMP_PSEL_PSEL_AnalogInput0, /*!< AIN0 selected as analog input. */
@@ -73,18 +90,31 @@ typedef enum
     NRF_COMP_VDDH_DIV5 = COMP_PSEL_PSEL_VddhDiv5,     /*!< VDDH/5 selected as analog input. */
 #endif
 } nrf_comp_input_t;
+#endif // NRF_COMP_HAS_AIN_AS_PIN
 
 /** @brief COMP reference selection. */
 typedef enum
 {
-    NRF_COMP_REF_Int1V2 = COMP_REFSEL_REFSEL_Int1V2, /*!< VREF = internal 1.2 V reference (VDD >= 1.7 V). */
-    NRF_COMP_REF_Int1V8 = COMP_REFSEL_REFSEL_Int1V8, /*!< VREF = internal 1.8 V reference (VDD >= VREF + 0.2 V). */
-    NRF_COMP_REF_Int2V4 = COMP_REFSEL_REFSEL_Int2V4, /*!< VREF = internal 2.4 V reference (VDD >= VREF + 0.2 V). */
-    NRF_COMP_REF_VDD = COMP_REFSEL_REFSEL_VDD,       /*!< VREF = VDD. */
-    NRF_COMP_REF_ARef = COMP_REFSEL_REFSEL_ARef      /*!< VREF = AREF (VDD >= VREF >= AREFMIN). */
+    NRF_COMP_REF_INT_1V2   = COMP_REFSEL_REFSEL_Int1V2,    /*!< VREF = internal 1.2 V reference (VDD >= 1.7 V). */
+#if defined(COMP_REFSEL_REFSEL_Int1V8) || defined(__NRFX_DOXYGEN__)
+    NRF_COMP_REF_INT_1V8   = COMP_REFSEL_REFSEL_Int1V8,    /*!< VREF = internal 1.8 V reference (VDD >= VREF + 0.2 V). */
+#endif
+#if defined(COMP_REFSEL_REFSEL_Int2V4) || defined(__NRFX_DOXYGEN__)
+    NRF_COMP_REF_INT_2V4   = COMP_REFSEL_REFSEL_Int2V4,    /*!< VREF = internal 2.4 V reference (VDD >= VREF + 0.2 V). */
+#endif
+#if defined(COMP_REFSEL_REFSEL_AVDDAO1V8) || defined(__NRFX_DOXYGEN__)
+    NRF_COMP_REF_AVDDAO1V8 = COMP_REFSEL_REFSEL_AVDDAO1V8, /*!< VREF = AVDD_AO_1V8. */
+#endif
+#if defined(COMP_REFSEL_REFSEL_VDD) || defined(__NRFX_DOXYGEN__)
+    NRF_COMP_REF_VDD       = COMP_REFSEL_REFSEL_VDD,       /*!< VREF = VDD. */
+#endif
+    NRF_COMP_REF_AREF      = COMP_REFSEL_REFSEL_ARef       /*!< VREF = AREF (VDD >= VREF >= AREFMIN). */
 } nrf_comp_ref_t;
 
 /** @brief COMP external analog reference selection. */
+#if NRF_COMP_HAS_AIN_AS_PIN
+typedef uint32_t nrf_comp_ext_ref_t;
+#else
 typedef enum
 {
     NRF_COMP_EXT_REF_0 = COMP_EXTREFSEL_EXTREFSEL_AnalogReference0, /*!< Use AIN0 as external analog reference. */
@@ -104,6 +134,7 @@ typedef enum
     NRF_COMP_EXT_REF_7 = COMP_EXTREFSEL_EXTREFSEL_AnalogReference7  /*!< Use AIN7 as external analog reference. */
 #endif
 } nrf_comp_ext_ref_t;
+#endif // NRF_COMP_HAS_AIN_AS_PIN
 
 /** @brief COMP THDOWN and THUP values that are used to calculate the threshold voltages VDOWN and VUP. */
 typedef struct
@@ -115,35 +146,54 @@ typedef struct
 /** @brief COMP main operation mode. */
 typedef enum
 {
-    NRF_COMP_MAIN_MODE_SE = COMP_MODE_MAIN_SE,    /*!< Single-ended mode. */
-    NRF_COMP_MAIN_MODE_Diff = COMP_MODE_MAIN_Diff /*!< Differential mode. */
+    NRF_COMP_MAIN_MODE_SE   = COMP_MODE_MAIN_SE,  /*!< Single-ended mode. */
+    NRF_COMP_MAIN_MODE_DIFF = COMP_MODE_MAIN_Diff /*!< Differential mode. */
 } nrf_comp_main_mode_t;
 
 /** @brief COMP speed and power mode. */
 typedef enum
 {
-    NRF_COMP_SP_MODE_Low = COMP_MODE_SP_Low,       /*!< Low power mode. */
-    NRF_COMP_SP_MODE_Normal = COMP_MODE_SP_Normal, /*!< Normal mode. */
-    NRF_COMP_SP_MODE_High = COMP_MODE_SP_High      /*!< High-speed mode. */
+    NRF_COMP_SP_MODE_LOW    = COMP_MODE_SP_Low,    /*!< Low power mode. */
+#if defined (COMP_MODE_SP_Normal) || defined (__NRFX_DOXYGEN__)
+    NRF_COMP_SP_MODE_NORMAL = COMP_MODE_SP_Normal, /*!< Normal mode. */
+#endif
+    NRF_COMP_SP_MODE_HIGH   = COMP_MODE_SP_High    /*!< High-speed mode. */
 } nrf_comp_sp_mode_t;
 
 /** @brief COMP comparator hysteresis. */
 typedef enum
 {
-    NRF_COMP_HYST_NoHyst = COMP_HYST_HYST_NoHyst, /*!< Comparator hysteresis disabled. */
-    NRF_COMP_HYST_50mV = COMP_HYST_HYST_Hyst50mV  /*!< Comparator hysteresis enabled. */
+    NRF_COMP_HYST_NO_HYST = COMP_HYST_HYST_NoHyst,   /*!< Comparator hysteresis disabled. */
+#if defined (COMP_HYST_HYST_Hyst40mV) || defined (__NRFX_DOXYGEN__)
+    NRF_COMP_HYST_40MV    = COMP_HYST_HYST_Hyst40mV, /*!< Comparator hysteresis enabled at 40 mV level. */
+#endif
+#if defined (COMP_HYST_HYST_Hyst50mV) || defined (__NRFX_DOXYGEN__)
+    NRF_COMP_HYST_50MV    = COMP_HYST_HYST_Hyst50mV  /*!< Comparator hysteresis enabled at 50 mV level. */
+#endif
 } nrf_comp_hyst_t;
 
-#if defined (COMP_ISOURCE_ISOURCE_Msk) || defined (__NRFX_DOXYGEN__)
+#if NRF_COMP_HAS_ISOURCE
 /** @brief COMP current source selection on analog input. */
 typedef enum
 {
-    NRF_COMP_ISOURCE_Off = COMP_ISOURCE_ISOURCE_Off,         /*!< Current source disabled. */
-    NRF_COMP_ISOURCE_Ien2uA5 = COMP_ISOURCE_ISOURCE_Ien2mA5, /*!< Current source enabled (+/- 2.5 uA). */
-    NRF_COMP_ISOURCE_Ien5uA = COMP_ISOURCE_ISOURCE_Ien5mA,   /*!< Current source enabled (+/- 5 uA). */
-    NRF_COMP_ISOURCE_Ien10uA = COMP_ISOURCE_ISOURCE_Ien10mA  /*!< Current source enabled (+/- 10 uA). */
-} nrf_isource_t;
+    NRF_COMP_ISOURCE_OFF      = COMP_ISOURCE_ISOURCE_Off,     /*!< Current source disabled. */
+#if defined (COMP_ISOURCE_ISOURCE_Ien2uA5) || defined (__NRFX_DOXYGEN__)
+    NRF_COMP_ISOURCE_IEN_2UA5 = COMP_ISOURCE_ISOURCE_Ien2uA5, /*!< Current source enabled (+/- 2.5 uA). */
+#else
+    NRF_COMP_ISOURCE_IEN_2UA5 = COMP_ISOURCE_ISOURCE_Ien2mA5, /*!< Current source enabled (+/- 2.5 uA). */
 #endif
+#if defined (COMP_ISOURCE_ISOURCE_Ien5uA) || defined (__NRFX_DOXYGEN__)
+    NRF_COMP_ISOURCE_IEN_5UA  = COMP_ISOURCE_ISOURCE_Ien5uA,  /*!< Current source enabled (+/- 5 uA). */
+#else
+    NRF_COMP_ISOURCE_IEN_5UA  = COMP_ISOURCE_ISOURCE_Ien5mA,  /*!< Current source enabled (+/- 5 uA). */
+#endif
+#if defined (COMP_ISOURCE_ISOURCE_Ien10uA) || defined (__NRFX_DOXYGEN__)
+    NRF_COMP_ISOURCE_IEN_10UA = COMP_ISOURCE_ISOURCE_Ien10uA, /*!< Current source enabled (+/- 10 uA). */
+#else
+    NRF_COMP_ISOURCE_IEN_10UA = COMP_ISOURCE_ISOURCE_Ien10mA, /*!< Current source enabled (+/- 10 uA). */
+#endif
+} nrf_isource_t;
+#endif // NRF_COMP_HAS_ISOURCE
 
 /** @brief COMP tasks. */
 typedef enum
@@ -162,13 +212,21 @@ typedef enum
     NRF_COMP_EVENT_CROSS = offsetof(NRF_COMP_Type, EVENTS_CROSS)  /*!< Input voltage crossed the threshold in any direction. */
 } nrf_comp_event_t;
 
+/** @brief COMP interrupts. */
+typedef enum
+{
+    NRF_COMP_INT_READY_MASK = COMP_INTENSET_READY_Msk, /**< Interrupt on READY event. */
+    NRF_COMP_INT_DOWN_MASK  = COMP_INTENSET_DOWN_Msk,  /**< Interrupt on DOWN event. */
+    NRF_COMP_INT_UP_MASK    = COMP_INTENSET_UP_Msk,    /**< Interrupt on UP event. */
+    NRF_COMP_INT_CROSS_MASK = COMP_INTENSET_CROSS_Msk  /**< Interrupt on CROSS event. */
+} nrf_comp_int_mask_t;
+
 /** @brief COMP reference configuration. */
 typedef struct
 {
     nrf_comp_ref_t     reference; /*!< COMP reference selection. */
     nrf_comp_ext_ref_t external;  /*!< COMP external analog reference selection. */
 } nrf_comp_ref_conf_t;
-
 
 /**
  * @brief Function for enabling the COMP peripheral.
@@ -244,7 +302,7 @@ NRF_STATIC_INLINE void nrf_comp_speed_mode_set(NRF_COMP_Type *    p_reg,
  */
 NRF_STATIC_INLINE void nrf_comp_hysteresis_set(NRF_COMP_Type * p_reg, nrf_comp_hyst_t hyst);
 
-#if defined (COMP_ISOURCE_ISOURCE_Msk) || defined (__NRFX_DOXYGEN__)
+#if NRF_COMP_HAS_ISOURCE
 /**
  * @brief Function for setting the current source on the analog input.
  *
@@ -368,7 +426,6 @@ NRF_STATIC_INLINE void nrf_comp_event_clear(NRF_COMP_Type * p_reg, nrf_comp_even
  */
 NRF_STATIC_INLINE bool nrf_comp_event_check(NRF_COMP_Type const * p_reg, nrf_comp_event_t event);
 
-
 #ifndef NRF_DECLARE_ONLY
 
 NRF_STATIC_INLINE void nrf_comp_enable(NRF_COMP_Type * p_reg)
@@ -393,7 +450,14 @@ NRF_STATIC_INLINE void nrf_comp_ref_set(NRF_COMP_Type * p_reg, nrf_comp_ref_t re
 
 NRF_STATIC_INLINE void nrf_comp_ext_ref_set(NRF_COMP_Type * p_reg, nrf_comp_ext_ref_t ext_ref)
 {
-    p_reg->EXTREFSEL = (ext_ref << COMP_EXTREFSEL_EXTREFSEL_Pos);
+#if NRF_COMP_HAS_AIN_AS_PIN
+    p_reg->EXTREFSEL = (NRF_PIN_NUMBER_TO_PORT(ext_ref) << COMP_EXTREFSEL_PORT_Pos) |
+                       (NRF_PIN_NUMBER_TO_PIN(ext_ref) << COMP_EXTREFSEL_PIN_Pos) |
+                       (p_reg->EXTREFSEL & ~(COMP_EXTREFSEL_PORT_Msk | COMP_EXTREFSEL_PIN_Msk));
+#else
+    p_reg->EXTREFSEL = ((uint32_t)ext_ref << COMP_EXTREFSEL_EXTREFSEL_Pos) |
+                        (p_reg->EXTREFSEL & ~COMP_EXTREFSEL_EXTREFSEL_Msk);
+#endif
 }
 
 NRF_STATIC_INLINE void nrf_comp_th_set(NRF_COMP_Type * p_reg, nrf_comp_th_t threshold)
@@ -429,7 +493,13 @@ NRF_STATIC_INLINE void nrf_comp_isource_set(NRF_COMP_Type * p_reg, nrf_isource_t
 
 NRF_STATIC_INLINE void nrf_comp_input_select(NRF_COMP_Type * p_reg, nrf_comp_input_t input)
 {
-    p_reg->PSEL   = ((uint32_t)input << COMP_PSEL_PSEL_Pos);
+#if NRF_COMP_HAS_AIN_AS_PIN
+    p_reg->PSEL = (NRF_PIN_NUMBER_TO_PORT(input) << COMP_PSEL_PORT_Pos) |
+                  (NRF_PIN_NUMBER_TO_PIN(input) << COMP_PSEL_PIN_Pos) |
+                  (p_reg->PSEL & ~(COMP_PSEL_PORT_Msk | COMP_PSEL_PIN_Msk));
+#else
+    p_reg->PSEL = ((uint32_t)input << COMP_PSEL_PSEL_Pos) | (p_reg->PSEL & ~COMP_PSEL_PSEL_Msk);
+#endif
 }
 
 NRF_STATIC_INLINE uint32_t nrf_comp_result_get(NRF_COMP_Type const * p_reg)

--- a/nrfx/hal/nrf_ecb.h
+++ b/nrfx/hal/nrf_ecb.h
@@ -35,6 +35,9 @@
 #define NRF_ECB_H__
 
 #include <nrfx.h>
+#ifdef EASYVDMA_PRESENT
+#include <helpers/nrf_vdma.h>
+#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -47,25 +50,158 @@ extern "C" {
  * @brief   Hardware access layer (HAL) for managing the Advanced Encryption Standard (AES) Electronic Codebook (ECB) peripheral.
  */
 
+#if defined(NRF51) || defined(NRF52832_XXAA) || \
+    defined(ECB_TASKS_STARTECB_TASKS_STARTECB_Msk) || defined(__NRFX_DOXYGEN__)
+/** @brief Presence of the STARTECB task. */
+#define NRF_ECB_HAS_TASK_STARTECB 1
+#else
+#define NRF_ECB_HAS_TASK_STARTECB 0
+#endif
+
+#if defined(ECB_TASKS_START_TASKS_START_Msk) || defined(__NRFX_DOXYGEN__)
+/** @brief Presence of the START task. */
+#define NRF_ECB_HAS_TASK_START 1
+#else
+#define NRF_ECB_HAS_TASK_START 0
+#endif
+
+#if defined(NRF51) || defined(NRF52832_XXAA) || \
+    defined(ECB_TASKS_STOPECB_TASKS_STOPECB_Msk) || defined(__NRFX_DOXYGEN__)
+/** @brief Presence of the STOPECB task. */
+#define NRF_ECB_HAS_TASK_STOPECB 1
+#else
+#define NRF_ECB_HAS_TASK_STOPECB 0
+#endif
+
+#if defined(ECB_TASKS_STOP_TASKS_STOP_Msk) || defined(__NRFX_DOXYGEN__)
+/** @brief Presence of the STOP task. */
+#define NRF_ECB_HAS_TASK_STOP 1
+#else
+#define NRF_ECB_HAS_TASK_STOP 0
+#endif
+
+#if defined(NRF51) || defined(NRF52832_XXAA) || \
+    defined(ECB_EVENTS_ENDECB_EVENTS_ENDECB_Msk) || defined(__NRFX_DOXYGEN__)
+/** @brief Presence of the ENDECB event. */
+#define NRF_ECB_HAS_EVENT_ENDECB 1
+#else
+#define NRF_ECB_HAS_EVENT_ENDECB 0
+#endif
+
+#if defined(ECB_EVENTS_END_EVENTS_END_Msk) || defined(__NRFX_DOXYGEN__)
+/** @brief Presence of the END event. */
+#define NRF_ECB_HAS_EVENT_END 1
+#else
+#define NRF_ECB_HAS_EVENT_END 0
+#endif
+
+#if defined(NRF51) || defined(NRF52832_XXAA) || \
+    defined(ECB_EVENTS_ERRORECB_EVENTS_ERRORECB_Msk) || defined(__NRFX_DOXYGEN__)
+/** @brief Presence of the ERRORECB event. */
+#define NRF_ECB_HAS_EVENT_ERRORECB 1
+#else
+#define NRF_ECB_HAS_EVENT_ERRORECB 0
+#endif
+
+#if defined(ECB_EVENTS_ERROR_EVENTS_ERROR_Msk) || defined(__NRFX_DOXYGEN__)
+/** @brief Presence of the ERROR event. */
+#define NRF_ECB_HAS_EVENT_ERROR 1
+#else
+#define NRF_ECB_HAS_EVENT_ERROR 0
+#endif
+
+#if defined(ECB_KEY_VALUE_VALUE_Msk) || defined(__NRFX_DOXYGEN__)
+/** @brief Presence of the KEY register. */
+#define NRF_ECB_HAS_KEY 1
+#else
+#define NRF_ECB_HAS_KEY 0
+#endif
+
+#if defined(ECB_IN_PTR_PTR_Msk) || defined(__NRFX_DOXYGEN__)
+/** @brief Presence of the IN.PTR register. */
+#define NRF_ECB_HAS_IN_PTR 1
+#else
+#define NRF_ECB_HAS_IN_PTR 0
+#endif
+
+#if defined(ECB_IN_AMOUNT_AMOUNT_Msk) || defined(__NRFX_DOXYGEN__)
+/** @brief Presence of the IN.AMOUNT register. */
+#define NRF_ECB_HAS_IN_AMOUNT 1
+#else
+#define NRF_ECB_HAS_IN_AMOUNT 0
+#endif
+
+#if defined(ECB_OUT_PTR_PTR_Msk) || defined(__NRFX_DOXYGEN__)
+/** @brief Presence of the OUT.PTR register. */
+#define NRF_ECB_HAS_OUT_PTR 1
+#else
+#define NRF_ECB_HAS_OUT_PTR 0
+#endif
+
+#if defined(ECB_OUT_AMOUNT_AMOUNT_Msk) || defined(__NRFX_DOXYGEN__)
+/** @brief Presence of the OUT.AMOUNT register. */
+#define NRF_ECB_HAS_OUT_AMOUNT 1
+#else
+#define NRF_ECB_HAS_OUT_AMOUNT 0
+#endif
+
+#if defined(NRF51) || defined(NRF52832_XXAA) || \
+    defined(ECB_ECBDATAPTR_ECBDATAPTR_Msk) || defined(__NRFX_DOXYGEN__)
+/** @brief Presence of the  ECBDATAPTR register. */
+#define NRF_ECB_HAS_ECBDATAPTR 1
+#else
+#define NRF_ECB_HAS_ECBDATAPTR 0
+#endif
+
 /** @brief ECB tasks. */
 typedef enum
 {
+#if NRF_ECB_HAS_TASK_STARTECB
     NRF_ECB_TASK_STARTECB = offsetof(NRF_ECB_Type, TASKS_STARTECB), /**< Task for starting the ECB block encryption. */
+#endif
+#if NRF_ECB_HAS_TASK_START
+    NRF_ECB_TASK_START    = offsetof(NRF_ECB_Type, TASKS_START),    /**< Task for starting the ECB block encryption. */
+#endif
+#if NRF_ECB_HAS_TASK_STOPECB
     NRF_ECB_TASK_STOPECB  = offsetof(NRF_ECB_Type, TASKS_STOPECB),  /**< Task for stopping the ECB block encryption. */
+#endif
+#if NRF_ECB_HAS_TASK_STOP
+    NRF_ECB_TASK_STOP     = offsetof(NRF_ECB_Type, TASKS_STOP),     /**< Task for stopping the ECB block encryption. */
+#endif
 } nrf_ecb_task_t;
 
 /** @brief ECB events. */
 typedef enum
 {
+#if NRF_ECB_HAS_EVENT_ENDECB
     NRF_ECB_EVENT_ENDECB   = offsetof(NRF_ECB_Type, EVENTS_ENDECB),   /**< ECB block encrypt complete. */
+#endif
+#if NRF_ECB_HAS_EVENT_ERRORECB
     NRF_ECB_EVENT_ERRORECB = offsetof(NRF_ECB_Type, EVENTS_ERRORECB), /**< ECB block encrypt aborted because of a STOPECB task or due to an error. */
+#endif
+#if NRF_ECB_HAS_EVENT_END
+    NRF_ECB_EVENT_END      = offsetof(NRF_ECB_Type, EVENTS_END),      /**< ECB block encrypt complete. */
+#endif
+#if NRF_ECB_HAS_EVENT_ERROR
+    NRF_ECB_EVENT_ERROR    = offsetof(NRF_ECB_Type, EVENTS_ERROR),    /**< ECB block encrypt aborted because of a STOPECB task or due to an error. */
+#endif
 } nrf_ecb_event_t;
 
 /** @brief ECB interrupts. */
 typedef enum
 {
+#if NRF_ECB_HAS_EVENT_ENDECB
     NRF_ECB_INT_ENDECB_MASK   = ECB_INTENSET_ENDECB_Msk,   ///< Interrupt on ENDECB event.
+#endif
+#if NRF_ECB_HAS_EVENT_ERRORECB
     NRF_ECB_INT_ERRORECB_MASK = ECB_INTENSET_ERRORECB_Msk, ///< Interrupt on ERRORECB event.
+#endif
+#if NRF_ECB_HAS_EVENT_END
+    NRF_ECB_INT_END_MASK      = ECB_INTENSET_END_Msk,      ///< Interrupt on END event.
+#endif
+#if NRF_ECB_HAS_EVENT_ERROR
+    NRF_ECB_INT_ERROR_MASK    = ECB_INTENSET_ERROR_Msk,    ///< Interrupt on ERROR event.
+#endif
 } nrf_ecb_int_mask_t;
 
 
@@ -144,6 +280,7 @@ NRF_STATIC_INLINE void nrf_ecb_int_disable(NRF_ECB_Type * p_reg, uint32_t mask);
  */
 NRF_STATIC_INLINE uint32_t nrf_ecb_int_enable_check(NRF_ECB_Type const * p_reg, uint32_t mask);
 
+#if NRF_ECB_HAS_ECBDATAPTR
 /**
  * @brief Function for setting the pointer to the ECB data buffer.
  *
@@ -163,6 +300,91 @@ NRF_STATIC_INLINE void nrf_ecb_data_pointer_set(NRF_ECB_Type * p_reg, void const
  * @return Pointer to the ECB data buffer.
  */
 NRF_STATIC_INLINE void * nrf_ecb_data_pointer_get(NRF_ECB_Type const * p_reg);
+#endif // NRF_ECB_HAS_ECBDATAPTR
+
+#if NRF_ECB_HAS_KEY
+/**
+ * @brief Function for setting the AES key.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ * @param[in] p_key Pointer to the AES 128-bit key value. The key shall be stored
+ *                  in big endian byte order.
+ */
+NRF_STATIC_INLINE void nrf_ecb_key_set(NRF_ECB_Type   * p_reg,
+                                       uint32_t const * p_key);
+#endif // NRF_ECB_HAS_KEY
+
+#if NRF_ECB_HAS_IN_PTR
+/**
+ * @brief Function for setting the pointer to a job list containing unencrypted
+ *        ECB data structure in Encryption mode or encrypted ECB data structure
+ *        in Decryption mode.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ * @param[in] p_job Pointer to a job list.
+ */
+NRF_STATIC_INLINE void nrf_ecb_in_ptr_set(NRF_ECB_Type *         p_reg,
+                                          nrf_vdma_job_t const * p_job);
+
+/**
+ * @brief Function for getting the pointer to job list containing unencrypted
+ *        ECB data structure in Encryption mode or encrypted ECB data structure
+ *        in Decryption mode.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ *
+ * @return Pointer to a job list.
+ */
+NRF_STATIC_INLINE nrf_vdma_job_t * nrf_ecb_in_ptr_get(NRF_ECB_Type const * p_reg);
+#endif // NRF_ECB_HAS_IN_PTR
+
+#if NRF_ECB_HAS_IN_AMOUNT
+/**
+ * @brief Function for getting number of bytes read from the input data,
+ *        not including the job list structure.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ *
+ * @return Number of bytes read from the input data.
+ */
+NRF_STATIC_INLINE uint32_t nrf_ecb_in_amount_get(NRF_ECB_Type const * p_reg);
+#endif // NRF_ECB_HAS_IN_AMOUNT
+
+#if NRF_ECB_HAS_OUT_PTR
+/**
+ * @brief Function for setting the pointer to a job list containing encrypted
+ *        ECB data structure in Encryption mode or decrypted ECB data structure
+ *        in Decryption mode.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ * @param[in] p_job Pointer to a job list.
+ */
+NRF_STATIC_INLINE void nrf_ecb_out_ptr_set(NRF_ECB_Type *         p_reg,
+                                           nrf_vdma_job_t const * p_job);
+
+/**
+ * @brief Function for getting the pointer to a job list containing encrypted
+ *        ECB data structure in Encryption mode or decrypted ECB data structure
+ *        in Decryption mode.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ *
+ * @return Pointer to the job list.
+ */
+NRF_STATIC_INLINE nrf_vdma_job_t * nrf_ecb_out_ptr_get(NRF_ECB_Type const * p_reg);
+#endif // NRF_ECB_HAS_OUT_PTR
+
+#if NRF_ECB_HAS_OUT_AMOUNT
+/**
+ * @brief Function for getting number of bytes available in the output data,
+ *        not including the job list structure.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ *
+ * @return Number of bytes available in the output data.
+ */
+NRF_STATIC_INLINE uint32_t nrf_ecb_out_amount_get(NRF_ECB_Type const * p_reg);
+#endif // NRF_ECB_HAS_OUT_AMOUNT
 
 #if defined(DPPI_PRESENT) || defined(__NRFX_DOXYGEN__)
 /**
@@ -255,6 +477,7 @@ NRF_STATIC_INLINE uint32_t nrf_ecb_int_enable_check(NRF_ECB_Type const * p_reg, 
     return p_reg->INTENSET & mask;
 }
 
+#if NRF_ECB_HAS_ECBDATAPTR
 NRF_STATIC_INLINE void nrf_ecb_data_pointer_set(NRF_ECB_Type * p_reg, void const * p_buffer)
 {
     p_reg->ECBDATAPTR = (uint32_t)p_buffer;
@@ -264,6 +487,58 @@ NRF_STATIC_INLINE void * nrf_ecb_data_pointer_get(NRF_ECB_Type const * p_reg)
 {
     return (void *)(p_reg->ECBDATAPTR);
 }
+#endif // NRF_ECB_HAS_ECBDATAPTR
+
+#if NRF_ECB_HAS_KEY
+NRF_STATIC_INLINE void nrf_ecb_key_set(NRF_ECB_Type   * p_reg,
+                                       uint32_t const * p_key)
+{
+    for (uint8_t i = 0; i < ECB_KEY_VALUE_MaxCount; i++)
+    {
+        p_reg->KEY.VALUE[i] = p_key[i];
+    }
+}
+#endif // NRF_ECB_HAS_KEY
+
+#if NRF_ECB_HAS_IN_PTR
+NRF_STATIC_INLINE void nrf_ecb_in_ptr_set(NRF_ECB_Type *         p_reg,
+                                          nrf_vdma_job_t const * p_job)
+{
+    p_reg->IN.PTR = (uint32_t)p_job;
+}
+
+NRF_STATIC_INLINE nrf_vdma_job_t * nrf_ecb_in_ptr_get(NRF_ECB_Type const * p_reg)
+{
+    return (nrf_vdma_job_t *)(p_reg->IN.PTR);
+}
+#endif // NRF_ECB_HAS_IN_PTR
+
+#if NRF_ECB_HAS_IN_AMOUNT
+NRF_STATIC_INLINE uint32_t nrf_ecb_in_amount_get(NRF_ECB_Type const * p_reg)
+{
+    return p_reg->IN.AMOUNT;
+}
+#endif // NRF_ECB_HAS_IN_AMOUNT
+
+#if NRF_ECB_HAS_OUT_PTR
+NRF_STATIC_INLINE void nrf_ecb_out_ptr_set(NRF_ECB_Type *         p_reg,
+                                           nrf_vdma_job_t const * p_job)
+{
+    p_reg->OUT.PTR = (uint32_t)p_job;
+}
+
+NRF_STATIC_INLINE nrf_vdma_job_t * nrf_ecb_out_ptr_get(NRF_ECB_Type const * p_reg)
+{
+    return (nrf_vdma_job_t *)(p_reg->OUT.PTR);
+}
+#endif // NRF_ECB_HAS_OUT_PTR
+
+#if NRF_ECB_HAS_OUT_AMOUNT
+NRF_STATIC_INLINE uint32_t nrf_ecb_out_amount_get(NRF_ECB_Type const * p_reg)
+{
+    return p_reg->OUT.AMOUNT;
+}
+#endif // NRF_ECB_HAS_OUT_AMOUNT
 
 #if defined(DPPI_PRESENT)
 NRF_STATIC_INLINE void nrf_ecb_subscribe_set(NRF_ECB_Type * p_reg,
@@ -271,7 +546,7 @@ NRF_STATIC_INLINE void nrf_ecb_subscribe_set(NRF_ECB_Type * p_reg,
                                              uint8_t        channel)
 {
     *((volatile uint32_t *) ((uint8_t *) p_reg + (uint32_t) task + 0x80uL)) =
-            ((uint32_t)channel | ECB_SUBSCRIBE_STARTECB_EN_Msk);
+            ((uint32_t)channel | NRF_SUBSCRIBE_PUBLISH_ENABLE);
 }
 
 NRF_STATIC_INLINE void nrf_ecb_subscribe_clear(NRF_ECB_Type * p_reg,
@@ -285,7 +560,7 @@ NRF_STATIC_INLINE void nrf_ecb_publish_set(NRF_ECB_Type *  p_reg,
                                            uint8_t         channel)
 {
     *((volatile uint32_t *) ((uint8_t *) p_reg + (uint32_t) event + 0x80uL)) =
-            ((uint32_t)channel | ECB_PUBLISH_ENDECB_EN_Msk);
+            ((uint32_t)channel | NRF_SUBSCRIBE_PUBLISH_ENABLE);
 }
 
 NRF_STATIC_INLINE void nrf_ecb_publish_clear(NRF_ECB_Type *  p_reg,

--- a/nrfx/hal/nrf_egu.h
+++ b/nrfx/hal/nrf_egu.h
@@ -40,6 +40,18 @@
 extern "C" {
 #endif
 
+/*
+ * Macro for generating if statement code blocks that allow extracting
+ * the number of channels associated with the specific EGU instance.
+ */
+#define NRF_INTERNAL_EGU_CHAN_NUM_EXTRACT(chan_num, p_reg)                                      \
+    if (0) {}                                                                                   \
+    NRFX_FOREACH_PRESENT(EGU, NRF_INTERNAL_ELSE_IF_EXTRACT_1, (), (), chan_num, _CH_NUM, p_reg) \
+    else                                                                                        \
+    {                                                                                           \
+        chan_num = 0;                                                                           \
+    }
+
 /**
 * @defgroup nrf_egu_hal EGU HAL
 * @{
@@ -282,29 +294,10 @@ NRF_STATIC_INLINE void nrf_egu_publish_clear(NRF_EGU_Type *  p_reg,
 
 NRF_STATIC_INLINE uint32_t nrf_egu_channel_count(NRF_EGU_Type const * p_reg)
 {
-    if (p_reg == NRF_EGU0){
-        return EGU0_CH_NUM;
-    }
-#if EGU_COUNT > 1
-    if (p_reg == NRF_EGU1){
-        return EGU1_CH_NUM;
-    }
-#endif
-#if EGU_COUNT > 2
-    if (p_reg == NRF_EGU2){
-        return EGU2_CH_NUM;
-    }
-    if (p_reg == NRF_EGU3){
-        return EGU3_CH_NUM;
-    }
-    if (p_reg == NRF_EGU4){
-        return EGU4_CH_NUM;
-    }
-    if (p_reg == NRF_EGU5){
-        return EGU5_CH_NUM;
-    }
-#endif
-    return 0;
+    uint8_t chan_num = 0;
+    NRF_INTERNAL_EGU_CHAN_NUM_EXTRACT(chan_num, p_reg);
+
+    return chan_num;
 }
 
 NRF_STATIC_INLINE void nrf_egu_task_trigger(NRF_EGU_Type * p_reg, nrf_egu_task_t egu_task)
@@ -378,13 +371,15 @@ NRF_STATIC_INLINE void nrf_egu_subscribe_set(NRF_EGU_Type * p_reg,
                                              nrf_egu_task_t task,
                                              uint8_t        channel)
 {
+    NRFX_ASSERT(p_reg);
     *((volatile uint32_t *) ((uint8_t *) p_reg + (uint32_t) task + 0x80uL)) =
-            ((uint32_t)channel | EGU_SUBSCRIBE_TRIGGER_EN_Msk);
+            ((uint32_t)channel | NRF_SUBSCRIBE_PUBLISH_ENABLE);
 }
 
 NRF_STATIC_INLINE void nrf_egu_subscribe_clear(NRF_EGU_Type * p_reg,
                                                nrf_egu_task_t task)
 {
+    NRFX_ASSERT(p_reg);
     *((volatile uint32_t *) ((uint8_t *) p_reg + (uint32_t) task + 0x80uL)) = 0;
 }
 
@@ -392,13 +387,15 @@ NRF_STATIC_INLINE void nrf_egu_publish_set(NRF_EGU_Type *  p_reg,
                                            nrf_egu_event_t event,
                                            uint8_t         channel)
 {
+    NRFX_ASSERT(p_reg);
     *((volatile uint32_t *) ((uint8_t *) p_reg + (uint32_t) event + 0x80uL)) =
-            ((uint32_t)channel | EGU_PUBLISH_TRIGGERED_EN_Msk);
+            ((uint32_t)channel | NRF_SUBSCRIBE_PUBLISH_ENABLE);
 }
 
 NRF_STATIC_INLINE void nrf_egu_publish_clear(NRF_EGU_Type *  p_reg,
                                              nrf_egu_event_t event)
 {
+    NRFX_ASSERT(p_reg);
     *((volatile uint32_t *) ((uint8_t *) p_reg + (uint32_t) event + 0x80uL)) = 0;
 }
 #endif // defined(DPPI_PRESENT)

--- a/nrfx/hal/nrf_ficr.h
+++ b/nrfx/hal/nrf_ficr.h
@@ -43,7 +43,7 @@ extern "C" {
 /**
  * @defgroup nrf_ficr_hal FICR HAL
  * @{
- * @ingroup nrf_ficr
+ * @ingroup nrf_icr
  * @brief   Hardware access layer (HAL) for getting data from
  *          the Factory Information Configuration Registers (FICR).
  */

--- a/nrfx/hal/nrf_ipc.h
+++ b/nrfx/hal/nrf_ipc.h
@@ -416,7 +416,7 @@ NRF_STATIC_INLINE void nrf_ipc_subscribe_set(NRF_IPC_Type * p_reg,
                                              uint8_t        channel)
 {
     *((volatile uint32_t *) ((uint8_t *) p_reg + (uint32_t) task + 0x80uL)) =
-            ((uint32_t)channel | IPC_SUBSCRIBE_SEND_EN_Msk);
+            ((uint32_t)channel | NRF_SUBSCRIBE_PUBLISH_ENABLE);
 }
 
 NRF_STATIC_INLINE void nrf_ipc_subscribe_clear(NRF_IPC_Type * p_reg, nrf_ipc_task_t task)
@@ -429,7 +429,7 @@ NRF_STATIC_INLINE void nrf_ipc_publish_set(NRF_IPC_Type *  p_reg,
                                            uint8_t         channel)
 {
     *((volatile uint32_t *) ((uint8_t *) p_reg + (uint32_t) event + 0x80uL)) =
-            ((uint32_t)channel | IPC_PUBLISH_RECEIVE_EN_Msk);
+            ((uint32_t)channel | NRF_SUBSCRIBE_PUBLISH_ENABLE);
 }
 
 NRF_STATIC_INLINE void nrf_ipc_publish_clear(NRF_IPC_Type *  p_reg, nrf_ipc_event_t event)

--- a/nrfx/hal/nrf_kmu.h
+++ b/nrfx/hal/nrf_kmu.h
@@ -47,20 +47,112 @@ extern "C" {
  * @brief   Hardware access layer for managing the Key Management Unit (KMU) peripheral.
  */
 
+#if defined(KMU_INTEN_KEYSLOT_ERROR_Msk) || defined(__NRFX_DOXYGEN__)
+/** @brief Symbol indicating whether INTEN register is available. */
+#define NRF_KMU_HAS_INTEN 1
+#else
+#define NRF_KMU_HAS_INTEN 0
+#endif
+
+#if defined(KMU_TASKS_PROVISION_TASKS_PROVISION_Msk) || defined(__NRFX_DOXYGEN__)
+/** @brief Symbol indicating whether KMU has PROVISION registers. */
+#define NRF_KMU_HAS_PROVISION 1
+#else
+#define NRF_KMU_HAS_PROVISION 0
+#endif
+
+#if defined(KMU_TASKS_REVOKE_TASKS_REVOKE_Msk) || defined(__NRFX_DOXYGEN__)
+/** @brief Symbol indicating whether KMU has REVOKE registers. */
+#define NRF_KMU_HAS_REVOKE 1
+#else
+#define NRF_KMU_HAS_REVOKE 0
+#endif
+
+#if defined(KMU_TASKS_READMETADATA_TASKS_READMETADATA_Msk) || defined(__NRFX_DOXYGEN__)
+/** @brief Symbol indicating whether KMU has READMETADATA registers. */
+#define NRF_KMU_HAS_READ_METADATA 1
+#else
+#define NRF_KMU_HAS_READ_METADATA 0
+#endif
+
+#if defined(KMU_TASKS_PUSHBLOCK_TASKS_PUSHBLOCK_Msk) || defined(__NRFX_DOXYGEN__)
+/** @brief Symbol indicating whether KMU has PUSHBLOCK registers. */
+#define NRF_KMU_HAS_PUSH_BLOCK 1
+#else
+#define NRF_KMU_HAS_PUSH_BLOCK 0
+#endif
+
+#if defined(KMU_SRC_SRC_Msk) || defined(__NRFX_DOXYGEN__)
+/** @brief Symbol indicating whether KMU has SRC registers. */
+#define NRF_KMU_HAS_SRC 1
+#else
+#define NRF_KMU_HAS_SRC 0
+#endif
+
+#if defined(KMU_METADATA_METADATA_Msk) || defined(__NRFX_DOXYGEN__)
+/** @brief Symbol indicating whether KMU has METADATA registers. */
+#define NRF_KMU_HAS_METADATA 1
+#else
+#define NRF_KMU_HAS_METADATA 0
+#endif
+
 /** @brief KMU tasks. */
 typedef enum
 {
-    NRF_KMU_TASK_PUSH_KEYSLOT = offsetof(NRF_KMU_Type, TASKS_PUSH_KEYSLOT), ///< Push a key slot over secure APB.
+#if NRF_KMU_HAS_PROVISION
+    NRF_KMU_TASK_PROVISION_KEYSLOT = offsetof(NRF_KMU_Type, TASKS_PROVISION),    ///< Provision key slot.
+#endif
+#if defined(KMU_TASKS_PUSH_KEYSLOT_TASKS_PUSH_KEYSLOT_Msk) || defined(__NRFX_DOXYGEN__)
+    NRF_KMU_TASK_PUSH_KEYSLOT      = offsetof(NRF_KMU_Type, TASKS_PUSH_KEYSLOT), ///< Push a key slot over secure APB.
+#else
+    NRF_KMU_TASK_PUSH_KEYSLOT      = offsetof(NRF_KMU_Type, TASKS_PUSH),         ///< Push key slot.
+#endif
+#if NRF_KMU_HAS_REVOKE
+    NRF_KMU_TASK_REVOKE_KEYSLOT    = offsetof(NRF_KMU_Type, TASKS_PROVISION),    ///< Revoke key slot.
+#endif
+#if NRF_KMU_HAS_READ_METADATA
+    NRF_KMU_TASK_READ_METADATA     = offsetof(NRF_KMU_Type, TASKS_READMETADATA), ///< Read key slot metedata into METADATA register.
+#endif
+#if NRF_KMU_HAS_PUSH_BLOCK
+    NRF_KMU_TASK_PUSH_BLOCK        = offsetof(NRF_KMU_Type, TASKS_PUSHBLOCK),    ///< Block the PUSH operation of key slot, preventing the key slot being PUSH until next reset.
+#endif
 } nrf_kmu_task_t;
 
 /** @brief KMU events. */
 typedef enum
 {
-    NRF_KMU_EVENT_KEYSLOT_PUSHED  = offsetof(NRF_KMU_Type, EVENTS_KEYSLOT_PUSHED),  ///< Key successfully pushed over secure APB.
-    NRF_KMU_EVENT_KEYSLOT_REVOKED = offsetof(NRF_KMU_Type, EVENTS_KEYSLOT_REVOKED), ///< Key has been revoked and cannot be tasked for selection.
-    NRF_KMU_EVENT_KEYSLOT_ERROR   = offsetof(NRF_KMU_Type, EVENTS_KEYSLOT_ERROR)    ///< No key slot selected or no destination address defined or error during push mechanism.
+#if NRF_KMU_HAS_PROVISION
+    NRF_KMU_EVENT_EVENTS_PROVISIONED          = offsetof(NRF_KMU_Type, EVENTS_PROVISIONED),     ///< Key slot successfully provisioned.
+#endif
+
+#if defined(KMU_EVENTS_KEYSLOT_PUSHED_EVENTS_KEYSLOT_PUSHED_Msk) || defined(__NRFX_DOXYGEN__)
+    NRF_KMU_EVENT_KEYSLOT_PUSHED              = offsetof(NRF_KMU_Type, EVENTS_KEYSLOT_PUSHED),  ///< Key successfully pushed over secure APB.
+#else
+    NRF_KMU_EVENT_KEYSLOT_PUSHED              = offsetof(NRF_KMU_Type, EVENTS_PUSHED),          ///< Key successfully pushed over secure APB.
+#endif
+
+#if defined(KMU_EVENTS_KEYSLOT_REVOKED_EVENTS_KEYSLOT_REVOKED_Msk) || defined(__NRFX_DOXYGEN__)
+    NRF_KMU_EVENT_KEYSLOT_REVOKED             = offsetof(NRF_KMU_Type, EVENTS_KEYSLOT_REVOKED), ///< Key has been revoked and cannot be tasked for selection.
+#else
+    NRF_KMU_EVENT_KEYSLOT_REVOKED             = offsetof(NRF_KMU_Type, EVENTS_REVOKED),         ///< Key has been revoked and cannot be tasked for selection.
+#endif
+
+#if defined(KMU_EVENTS_KEYSLOT_ERROR_EVENTS_KEYSLOT_ERROR_Msk) || defined(__NRFX_DOXYGEN__)
+    NRF_KMU_EVENT_KEYSLOT_ERROR               = offsetof(NRF_KMU_Type, EVENTS_KEYSLOT_ERROR),   ///< No key slot selected or no destination address defined or error during push mechanism.
+#else
+    NRF_KMU_EVENT_KEYSLOT_ERROR               = offsetof(NRF_KMU_Type, EVENTS_ERROR),           ///< No key slot selected or no destination address defined or error during push mechanism.
+#endif
+
+#if NRF_KMU_HAS_READ_METADATA
+    NRF_KMU_EVENT_EVENTS_EVENTS_METADATA_READ = offsetof(NRF_KMU_Type, EVENTS_METADATAREAD),    ///< Key slot metedata has been read into METADATA register.
+#endif
+
+#if NRF_KMU_HAS_PUSH_BLOCK
+    NRF_KMU_EVENT_EVENTS_EVENTS_PUSHBLOCKED   = offsetof(NRF_KMU_Type, EVENTS_PUSHBLOCKED),     ///< The PUSHBLOCK operation was succesful.
+#endif
 } nrf_kmu_event_t;
 
+#if NRF_KMU_HAS_INTEN
 /** @brief KMU interrupts. */
 typedef enum
 {
@@ -68,14 +160,22 @@ typedef enum
     NRF_KMU_INT_REVOKED_MASK = KMU_INTEN_KEYSLOT_REVOKED_Msk, ///< Interrupt on KEYSLOT_REVOKED event.
     NRF_KMU_INT_ERROR_MASK   = KMU_INTEN_KEYSLOT_ERROR_Msk    ///< Interrupt on KEYSLOT_ERROR event.
 } nrf_kmu_int_mask_t;
+#endif
 
 /** @brief KMU operation status. */
 typedef enum
 {
+#if defined(KMU_STATUS_BLOCKED_Msk) || defined(__NRFX_DOXYGEN__)
     NRF_KMU_STATUS_BLOCKED_MASK  = KMU_STATUS_BLOCKED_Msk,  ///< Access violation detected and blocked.
-    NRF_KMU_STATUS_SELECTED_MASK = KMU_STATUS_SELECTED_Msk, ///< Key slot ID successfully selected by KMU
+#endif
+#if defined(KMU_STATUS_SELECTED_Msk) || defined(__NRFX_DOXYGEN__)
+    NRF_KMU_STATUS_SELECTED_MASK = KMU_STATUS_SELECTED_Msk, ///< Key slot ID successfully selected by KMU.
+#endif
+#if defined(KMU_STATUS_STATUS_Msk) || defined(__NRFX_DOXYGEN__)
+    NRF_KMU_STATUS_READY         = KMU_STATUS_STATUS_Ready, ///< KMU is ready for a new operation.
+    NRF_KMU_STATUS_BUSY          = KMU_STATUS_STATUS_Busy,  ///< KMU is busy, an operation is in progress.
+#endif
 } nrf_kmu_status_t;
-
 
 /**
  * @brief Function for activating a specific KMU task.
@@ -126,6 +226,7 @@ NRF_STATIC_INLINE bool nrf_kmu_event_check(NRF_KMU_Type const * p_reg, nrf_kmu_e
 NRF_STATIC_INLINE uint32_t nrf_kmu_event_address_get(NRF_KMU_Type const * p_reg,
                                                      nrf_kmu_event_t      event);
 
+#if NRF_KMU_HAS_INTEN
 /**
  * @brief Function for enabling specified interrupts.
  *
@@ -162,15 +263,16 @@ NRF_STATIC_INLINE uint32_t nrf_kmu_int_enable_check(NRF_KMU_Type const * p_reg, 
  * @return Bitmask with pending interrupts bits.
  */
 NRF_STATIC_INLINE uint32_t nrf_kmu_intpend_get(NRF_KMU_Type const * p_reg);
+#endif // NRF_KMU_HAS_INTEN
 
 /**
  * @brief Function for getting status bits of the KMU operation.
  *
- * Function returns bitmask. Please use @ref nrf_kmu_status_t to check operations status.
+ * Please use @ref nrf_kmu_status_t to check operations status.
  *
  * @param[in] p_reg Pointer to the structure of registers of the peripheral.
  *
- * @return Bitmask with operation status bits.
+ * @return Operation status.
  */
 NRF_STATIC_INLINE uint32_t nrf_kmu_status_get(NRF_KMU_Type const * p_reg);
 
@@ -192,6 +294,43 @@ NRF_STATIC_INLINE void nrf_kmu_keyslot_set(NRF_KMU_Type * p_reg, uint8_t keyslot
  */
 NRF_STATIC_INLINE uint8_t nrf_kmu_keyslot_get(NRF_KMU_Type const * p_reg);
 
+#if NRF_KMU_HAS_SRC
+/**
+ * @brief Function for setting the source address for provisioning.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ * @param[in] src   Source address to be set.
+ */
+NRF_STATIC_INLINE void nrf_kmu_src_set(NRF_KMU_Type * p_reg, uint32_t src);
+
+/**
+ * @brief Function for getting the source address for provisioning.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ *
+ * @return Source address.
+ */
+NRF_STATIC_INLINE uint32_t nrf_kmu_src_get(NRF_KMU_Type const * p_reg);
+#endif // NRF_KMU_HAS_SRC
+
+#if NRF_KMU_HAS_METADATA
+/**
+ * @brief Function for setting the key slot metadata.
+ *
+ * @param[in] p_reg   Pointer to the structure of registers of the peripheral.
+ * @param[in] metdata Key slot metadata.
+ */
+NRF_STATIC_INLINE void nrf_kmu_metadata_set(NRF_KMU_Type * p_reg, uint32_t metdata);
+
+/**
+ * @brief Function for getting the key slot metadata.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ *
+ * @return Key slot metadata.
+ */
+NRF_STATIC_INLINE uint32_t nrf_kmu_metadata_get(NRF_KMU_Type const * p_reg);
+#endif // NRF_KMU_HAS_METADATA
 
 #ifndef NRF_DECLARE_ONLY
 
@@ -223,6 +362,7 @@ NRF_STATIC_INLINE uint32_t nrf_kmu_event_address_get(NRF_KMU_Type const * p_reg,
     return ((uint32_t)p_reg + (uint32_t)event);
 }
 
+#if NRF_KMU_HAS_INTEN
 NRF_STATIC_INLINE void nrf_kmu_int_enable(NRF_KMU_Type * p_reg, uint32_t mask)
 {
     p_reg->INTENSET = mask;
@@ -242,6 +382,7 @@ NRF_STATIC_INLINE uint32_t nrf_kmu_intpend_get(NRF_KMU_Type const * p_reg)
 {
     return p_reg->INTPEND;
 }
+#endif // NRF_KMU_HAS_INTEN
 
 NRF_STATIC_INLINE uint32_t nrf_kmu_status_get(NRF_KMU_Type const * p_reg)
 {
@@ -250,13 +391,49 @@ NRF_STATIC_INLINE uint32_t nrf_kmu_status_get(NRF_KMU_Type const * p_reg)
 
 NRF_STATIC_INLINE void nrf_kmu_keyslot_set(NRF_KMU_Type * p_reg, uint8_t keyslot_id)
 {
-    p_reg->SELECTKEYSLOT = (uint32_t) keyslot_id;
+#if defined(KMU_SELECTKEYSLOT_ID_Msk)
+    p_reg->SELECTKEYSLOT = (uint32_t)keyslot_id;
+#elif defined(KMU_KEYSLOT_ID_Msk)
+    p_reg->KEYSLOT = (uint32_t)keyslot_id;
+#else
+    #error "Unsupported"
+#endif
 }
 
 NRF_STATIC_INLINE uint8_t nrf_kmu_keyslot_get(NRF_KMU_Type const * p_reg)
 {
-    return (uint8_t) p_reg->SELECTKEYSLOT;
+#if defined(KMU_SELECTKEYSLOT_ID_Msk)
+    return (uint8_t)p_reg->SELECTKEYSLOT;
+#elif defined(KMU_KEYSLOT_ID_Msk)
+    return (uint8_t)p_reg->KEYSLOT;
+#else
+    #error "Unsupported"
+#endif
 }
+
+#if NRF_KMU_HAS_SRC
+NRF_STATIC_INLINE void nrf_kmu_src_set(NRF_KMU_Type * p_reg, uint32_t src)
+{
+    p_reg->SRC = src;
+}
+
+NRF_STATIC_INLINE uint32_t nrf_kmu_src_get(NRF_KMU_Type const * p_reg)
+{
+    return p_reg->SRC;
+}
+#endif // NRF_KMU_HAS_SRC
+
+#if NRF_KMU_HAS_METADATA
+NRF_STATIC_INLINE void nrf_kmu_metadata_set(NRF_KMU_Type * p_reg, uint32_t metdata)
+{
+    p_reg->METADATA = metdata;
+}
+
+NRF_STATIC_INLINE uint32_t nrf_kmu_metadata_get(NRF_KMU_Type const * p_reg)
+{
+    return p_reg->METADATA;
+}
+#endif // NRF_KMU_HAS_METADATA
 
 #endif // NRF_DECLARE_ONLY
 

--- a/nrfx/hal/nrf_lpcomp.h
+++ b/nrfx/hal/nrf_lpcomp.h
@@ -47,41 +47,53 @@ extern "C" {
  * @brief   Hardware access layer for managing the Low Power Comparator (LPCOMP) peripheral.
  */
 
+#if defined(LPCOMP_PSEL_PIN_Msk) || defined(__NRFX_DOXYGEN__)
+/** @brief Symbol indicating whether the configuration of analog input using pin number is present. */
+#define NRF_LPCOMP_HAS_AIN_AS_PIN 1
+#else
+#define NRF_LPCOMP_HAS_AIN_AS_PIN 0
+#endif
+
 /** @brief LPCOMP reference selection. */
 typedef enum
 {
 #if (LPCOMP_REFSEL_RESOLUTION == 8) || defined(__NRFX_DOXYGEN__)
-    NRF_LPCOMP_REF_SUPPLY_1_8   = LPCOMP_REFSEL_REFSEL_SupplyOneEighthPrescaling,    /**< Use supply with a 1/8 prescaler as reference. */
-    NRF_LPCOMP_REF_SUPPLY_2_8   = LPCOMP_REFSEL_REFSEL_SupplyTwoEighthsPrescaling,   /**< Use supply with a 2/8 prescaler as reference. */
-    NRF_LPCOMP_REF_SUPPLY_3_8   = LPCOMP_REFSEL_REFSEL_SupplyThreeEighthsPrescaling, /**< Use supply with a 3/8 prescaler as reference. */
-    NRF_LPCOMP_REF_SUPPLY_4_8   = LPCOMP_REFSEL_REFSEL_SupplyFourEighthsPrescaling,  /**< Use supply with a 4/8 prescaler as reference. */
-    NRF_LPCOMP_REF_SUPPLY_5_8   = LPCOMP_REFSEL_REFSEL_SupplyFiveEighthsPrescaling,  /**< Use supply with a 5/8 prescaler as reference. */
-    NRF_LPCOMP_REF_SUPPLY_6_8   = LPCOMP_REFSEL_REFSEL_SupplySixEighthsPrescaling,   /**< Use supply with a 6/8 prescaler as reference. */
-    NRF_LPCOMP_REF_SUPPLY_7_8   = LPCOMP_REFSEL_REFSEL_SupplySevenEighthsPrescaling, /**< Use supply with a 7/8 prescaler as reference. */
+    NRF_LPCOMP_REF_SUPPLY_1_8   = LPCOMP_REFSEL_REFSEL_SupplyOneEighthPrescaling,      /**< Use supply with a 1/8 prescaler as reference. */
+    NRF_LPCOMP_REF_SUPPLY_2_8   = LPCOMP_REFSEL_REFSEL_SupplyTwoEighthsPrescaling,     /**< Use supply with a 2/8 prescaler as reference. */
+    NRF_LPCOMP_REF_SUPPLY_3_8   = LPCOMP_REFSEL_REFSEL_SupplyThreeEighthsPrescaling,   /**< Use supply with a 3/8 prescaler as reference. */
+    NRF_LPCOMP_REF_SUPPLY_4_8   = LPCOMP_REFSEL_REFSEL_SupplyFourEighthsPrescaling,    /**< Use supply with a 4/8 prescaler as reference. */
+    NRF_LPCOMP_REF_SUPPLY_5_8   = LPCOMP_REFSEL_REFSEL_SupplyFiveEighthsPrescaling,    /**< Use supply with a 5/8 prescaler as reference. */
+    NRF_LPCOMP_REF_SUPPLY_6_8   = LPCOMP_REFSEL_REFSEL_SupplySixEighthsPrescaling,     /**< Use supply with a 6/8 prescaler as reference. */
+    NRF_LPCOMP_REF_SUPPLY_7_8   = LPCOMP_REFSEL_REFSEL_SupplySevenEighthsPrescaling,   /**< Use supply with a 7/8 prescaler as reference. */
 #elif (LPCOMP_REFSEL_RESOLUTION == 16) || defined(__NRFX_DOXYGEN__)
-    NRF_LPCOMP_REF_SUPPLY_1_8   = LPCOMP_REFSEL_REFSEL_Ref1_8Vdd,   /**< Use supply with a 1/8 prescaler as reference. */
-    NRF_LPCOMP_REF_SUPPLY_2_8   = LPCOMP_REFSEL_REFSEL_Ref2_8Vdd,   /**< Use supply with a 2/8 prescaler as reference. */
-    NRF_LPCOMP_REF_SUPPLY_3_8   = LPCOMP_REFSEL_REFSEL_Ref3_8Vdd,   /**< Use supply with a 3/8 prescaler as reference. */
-    NRF_LPCOMP_REF_SUPPLY_4_8   = LPCOMP_REFSEL_REFSEL_Ref4_8Vdd,   /**< Use supply with a 4/8 prescaler as reference. */
-    NRF_LPCOMP_REF_SUPPLY_5_8   = LPCOMP_REFSEL_REFSEL_Ref5_8Vdd,   /**< Use supply with a 5/8 prescaler as reference. */
-    NRF_LPCOMP_REF_SUPPLY_6_8   = LPCOMP_REFSEL_REFSEL_Ref6_8Vdd,   /**< Use supply with a 6/8 prescaler as reference. */
-    NRF_LPCOMP_REF_SUPPLY_7_8   = LPCOMP_REFSEL_REFSEL_Ref7_8Vdd,   /**< Use supply with a 7/8 prescaler as reference. */
-    NRF_LPCOMP_REF_SUPPLY_1_16  = LPCOMP_REFSEL_REFSEL_Ref1_16Vdd,  /**< Use supply with a 1/16 prescaler as reference. */
-    NRF_LPCOMP_REF_SUPPLY_3_16  = LPCOMP_REFSEL_REFSEL_Ref3_16Vdd,  /**< Use supply with a 3/16 prescaler as reference. */
-    NRF_LPCOMP_REF_SUPPLY_5_16  = LPCOMP_REFSEL_REFSEL_Ref5_16Vdd,  /**< Use supply with a 5/16 prescaler as reference. */
-    NRF_LPCOMP_REF_SUPPLY_7_16  = LPCOMP_REFSEL_REFSEL_Ref7_16Vdd,  /**< Use supply with a 7/16 prescaler as reference. */
-    NRF_LPCOMP_REF_SUPPLY_9_16  = LPCOMP_REFSEL_REFSEL_Ref9_16Vdd,  /**< Use supply with a 9/16 prescaler as reference. */
-    NRF_LPCOMP_REF_SUPPLY_11_16 = LPCOMP_REFSEL_REFSEL_Ref11_16Vdd, /**< Use supply with a 11/16 prescaler as reference. */
-    NRF_LPCOMP_REF_SUPPLY_13_16 = LPCOMP_REFSEL_REFSEL_Ref13_16Vdd, /**< Use supply with a 13/16 prescaler as reference. */
-    NRF_LPCOMP_REF_SUPPLY_15_16 = LPCOMP_REFSEL_REFSEL_Ref15_16Vdd, /**< Use supply with a 15/16 prescaler as reference. */
+    NRF_LPCOMP_REF_SUPPLY_1_8   = LPCOMP_REFSEL_REFSEL_Ref1_8Vdd,                      /**< Use supply with a 1/8 prescaler as reference. */
+    NRF_LPCOMP_REF_SUPPLY_2_8   = LPCOMP_REFSEL_REFSEL_Ref2_8Vdd,                      /**< Use supply with a 2/8 prescaler as reference. */
+    NRF_LPCOMP_REF_SUPPLY_3_8   = LPCOMP_REFSEL_REFSEL_Ref3_8Vdd,                      /**< Use supply with a 3/8 prescaler as reference. */
+    NRF_LPCOMP_REF_SUPPLY_4_8   = LPCOMP_REFSEL_REFSEL_Ref4_8Vdd,                      /**< Use supply with a 4/8 prescaler as reference. */
+    NRF_LPCOMP_REF_SUPPLY_5_8   = LPCOMP_REFSEL_REFSEL_Ref5_8Vdd,                      /**< Use supply with a 5/8 prescaler as reference. */
+    NRF_LPCOMP_REF_SUPPLY_6_8   = LPCOMP_REFSEL_REFSEL_Ref6_8Vdd,                      /**< Use supply with a 6/8 prescaler as reference. */
+    NRF_LPCOMP_REF_SUPPLY_7_8   = LPCOMP_REFSEL_REFSEL_Ref7_8Vdd,                      /**< Use supply with a 7/8 prescaler as reference. */
+    NRF_LPCOMP_REF_SUPPLY_1_16  = LPCOMP_REFSEL_REFSEL_Ref1_16Vdd,                     /**< Use supply with a 1/16 prescaler as reference. */
+    NRF_LPCOMP_REF_SUPPLY_3_16  = LPCOMP_REFSEL_REFSEL_Ref3_16Vdd,                     /**< Use supply with a 3/16 prescaler as reference. */
+    NRF_LPCOMP_REF_SUPPLY_5_16  = LPCOMP_REFSEL_REFSEL_Ref5_16Vdd,                     /**< Use supply with a 5/16 prescaler as reference. */
+    NRF_LPCOMP_REF_SUPPLY_7_16  = LPCOMP_REFSEL_REFSEL_Ref7_16Vdd,                     /**< Use supply with a 7/16 prescaler as reference. */
+    NRF_LPCOMP_REF_SUPPLY_9_16  = LPCOMP_REFSEL_REFSEL_Ref9_16Vdd,                     /**< Use supply with a 9/16 prescaler as reference. */
+    NRF_LPCOMP_REF_SUPPLY_11_16 = LPCOMP_REFSEL_REFSEL_Ref11_16Vdd,                    /**< Use supply with a 11/16 prescaler as reference. */
+    NRF_LPCOMP_REF_SUPPLY_13_16 = LPCOMP_REFSEL_REFSEL_Ref13_16Vdd,                    /**< Use supply with a 13/16 prescaler as reference. */
+    NRF_LPCOMP_REF_SUPPLY_15_16 = LPCOMP_REFSEL_REFSEL_Ref15_16Vdd,                    /**< Use supply with a 15/16 prescaler as reference. */
 #endif
+#if !NRF_LPCOMP_HAS_AIN_AS_PIN
     NRF_LPCOMP_REF_EXT_REF0     = LPCOMP_REFSEL_REFSEL_ARef |
                                   (LPCOMP_EXTREFSEL_EXTREFSEL_AnalogReference0 << 16), /**< External reference 0. */
     NRF_LPCOMP_REF_EXT_REF1     = LPCOMP_REFSEL_REFSEL_ARef |
                                   (LPCOMP_EXTREFSEL_EXTREFSEL_AnalogReference1 << 16), /**< External reference 1. */
+#endif
 } nrf_lpcomp_ref_t;
 
 /** @brief LPCOMP input selection. */
+#if NRF_LPCOMP_HAS_AIN_AS_PIN
+typedef uint32_t nrf_lpcomp_input_t;
+#else
 typedef enum
 {
     NRF_LPCOMP_INPUT_0 = LPCOMP_PSEL_PSEL_AnalogInput0, /**< Input 0. */
@@ -93,6 +105,7 @@ typedef enum
     NRF_LPCOMP_INPUT_6 = LPCOMP_PSEL_PSEL_AnalogInput6, /**< Input 6. */
     NRF_LPCOMP_INPUT_7 = LPCOMP_PSEL_PSEL_AnalogInput7  /**< Input 7. */
 } nrf_lpcomp_input_t;
+#endif
 
 /** @brief LPCOMP detection type selection. */
 typedef enum
@@ -319,11 +332,9 @@ NRF_STATIC_INLINE bool nrf_lpcomp_event_check(NRF_LPCOMP_Type const * p_reg,
 NRF_STATIC_INLINE void nrf_lpcomp_configure(NRF_LPCOMP_Type *           p_reg,
                                             nrf_lpcomp_config_t const * p_config)
 {
-    p_reg->TASKS_STOP = 1;
-    p_reg->ENABLE     = LPCOMP_ENABLE_ENABLE_Disabled << LPCOMP_ENABLE_ENABLE_Pos;
-    p_reg->REFSEL     =
-        (p_config->reference << LPCOMP_REFSEL_REFSEL_Pos) & LPCOMP_REFSEL_REFSEL_Msk;
+    p_reg->REFSEL = (p_config->reference << LPCOMP_REFSEL_REFSEL_Pos) & LPCOMP_REFSEL_REFSEL_Msk;
 
+#if !NRF_LPCOMP_HAS_AIN_AS_PIN
     //If external source is choosen extract analog reference index.
     if ((p_config->reference & LPCOMP_REFSEL_REFSEL_ARef)==LPCOMP_REFSEL_REFSEL_ARef)
     {
@@ -331,34 +342,29 @@ NRF_STATIC_INLINE void nrf_lpcomp_configure(NRF_LPCOMP_Type *           p_reg,
         p_reg->EXTREFSEL = (extref << LPCOMP_EXTREFSEL_EXTREFSEL_Pos) &
                            LPCOMP_EXTREFSEL_EXTREFSEL_Msk;
     }
+#endif
 
     p_reg->ANADETECT = (p_config->detection << LPCOMP_ANADETECT_ANADETECT_Pos) &
                        LPCOMP_ANADETECT_ANADETECT_Msk;
 #ifdef LPCOMP_FEATURE_HYST_PRESENT
     p_reg->HYST      = ((p_config->hyst) << LPCOMP_HYST_HYST_Pos) & LPCOMP_HYST_HYST_Msk;
 #endif //LPCOMP_FEATURE_HYST_PRESENT
-    p_reg->SHORTS    = 0;
-    p_reg->INTENCLR  = LPCOMP_INTENCLR_CROSS_Msk | LPCOMP_INTENCLR_UP_Msk |
-                       LPCOMP_INTENCLR_DOWN_Msk | LPCOMP_INTENCLR_READY_Msk;
 }
 
 NRF_STATIC_INLINE void nrf_lpcomp_input_select(NRF_LPCOMP_Type * p_reg, nrf_lpcomp_input_t input)
 {
-    uint32_t lpcomp_enable_state = p_reg->ENABLE;
-
-    p_reg->ENABLE = LPCOMP_ENABLE_ENABLE_Disabled << LPCOMP_ENABLE_ENABLE_Pos;
-    p_reg->PSEL   = ((uint32_t)input << LPCOMP_PSEL_PSEL_Pos) |
-                    (p_reg->PSEL & ~LPCOMP_PSEL_PSEL_Msk);
-    p_reg->ENABLE = lpcomp_enable_state;
+#if NRF_LPCOMP_HAS_AIN_AS_PIN
+    p_reg->PSEL = (NRF_PIN_NUMBER_TO_PORT(input) << LPCOMP_PSEL_PORT_Pos) |
+                  (NRF_PIN_NUMBER_TO_PIN(input) << LPCOMP_PSEL_PIN_Pos) |
+                  (p_reg->PSEL & ~(LPCOMP_PSEL_PORT_Msk | LPCOMP_PSEL_PIN_Msk));
+#else
+    p_reg->PSEL = ((uint32_t)input << LPCOMP_PSEL_PSEL_Pos) | (p_reg->PSEL & ~LPCOMP_PSEL_PSEL_Msk);
+#endif
 }
 
 NRF_STATIC_INLINE void nrf_lpcomp_enable(NRF_LPCOMP_Type * p_reg)
 {
     p_reg->ENABLE = LPCOMP_ENABLE_ENABLE_Enabled << LPCOMP_ENABLE_ENABLE_Pos;
-    p_reg->EVENTS_READY = 0;
-    p_reg->EVENTS_DOWN  = 0;
-    p_reg->EVENTS_UP    = 0;
-    p_reg->EVENTS_CROSS = 0;
 }
 
 NRF_STATIC_INLINE void nrf_lpcomp_disable(NRF_LPCOMP_Type * p_reg)

--- a/nrfx/hal/nrf_oscillators.h
+++ b/nrfx/hal/nrf_oscillators.h
@@ -54,6 +54,9 @@ typedef enum
     NRF_OSCILLATORS_LFXO_CAP_6PF      = OSCILLATORS_XOSC32KI_INTCAP_INTCAP_C6PF,     ///< Use 6 pF internal capacitors.
     NRF_OSCILLATORS_LFXO_CAP_7PF      = OSCILLATORS_XOSC32KI_INTCAP_INTCAP_C7PF,     ///< Use 7 pF internal capacitors.
     NRF_OSCILLATORS_LFXO_CAP_9PF      = OSCILLATORS_XOSC32KI_INTCAP_INTCAP_C9PF,     ///< Use 9 pF internal capacitors.
+#if defined(OSCILLATORS_XOSC32KI_INTCAP_INTCAP_C11PF) || defined(__NRFX_DOXYGEN__)
+    NRF_OSCILLATORS_LFXO_CAP_11PF     = OSCILLATORS_XOSC32KI_INTCAP_INTCAP_C11PF,    ///< Use 11 pF internal capacitors.
+#endif
 } nrf_oscillators_lfxo_cap_t;
 
 /**

--- a/nrfx/hal/nrf_power.h
+++ b/nrfx/hal/nrf_power.h
@@ -111,6 +111,13 @@ extern "C" {
 #define NRF_POWER_HAS_MAINREGSTATUS 0
 #endif
 
+#if (!defined(POWER_GPREGRET2_GPREGRET_Msk) && !defined(NRF51)) || defined(__NRFX_DOXYGEN__)
+/** @brief Symbol indicating whether GPREGRET register is treated as an array. */
+#define NRF_POWER_HAS_GPREGRET_ARRAY 1
+#else
+#define NRF_POWER_HAS_GPREGRET_ARRAY 0
+#endif
+
 /** @brief POWER tasks. */
 typedef enum
 {
@@ -930,7 +937,7 @@ NRF_STATIC_INLINE void nrf_power_subscribe_set(NRF_POWER_Type * p_reg,
                                                uint8_t          channel)
 {
     *((volatile uint32_t *) ((uint8_t *) p_reg + (uint32_t) task + 0x80uL)) =
-            ((uint32_t)channel | POWER_SUBSCRIBE_CONSTLAT_EN_Msk);
+            ((uint32_t)channel | NRF_SUBSCRIBE_PUBLISH_ENABLE);
 }
 
 NRF_STATIC_INLINE void nrf_power_subscribe_clear(NRF_POWER_Type * p_reg, nrf_power_task_t task)
@@ -943,7 +950,7 @@ NRF_STATIC_INLINE void nrf_power_publish_set(NRF_POWER_Type *  p_reg,
                                              uint8_t           channel)
 {
     *((volatile uint32_t *) ((uint8_t *) p_reg + (uint32_t) event + 0x80uL)) =
-            ((uint32_t)channel | POWER_PUBLISH_SLEEPENTER_EN_Msk);
+            ((uint32_t)channel | NRF_SUBSCRIBE_PUBLISH_ENABLE);
 }
 
 NRF_STATIC_INLINE void nrf_power_publish_clear(NRF_POWER_Type * p_reg, nrf_power_event_t event)
@@ -1073,14 +1080,14 @@ NRF_STATIC_INLINE uint8_t nrf_power_gpregret_get(NRF_POWER_Type const * p_reg)
     {
         p_gpregret = &((volatile uint32_t *)&p_reg->GPREGRET)[0];
     }
-    return *p_gpregret;
+    return (uint8_t)*p_gpregret;
 }
 
 NRF_STATIC_INLINE void nrf_power_gpregret_ext_set(NRF_POWER_Type * p_reg,
                                                   uint8_t          reg_num,
                                                   uint8_t          val)
 {
-#if defined(NRF91_SERIES) || defined(NRF5340_XXAA_APPLICATION) || defined(NRF5340_XXAA_NETWORK)
+#if NRF_POWER_HAS_GPREGRET_ARRAY
     p_reg->GPREGRET[reg_num] = val;
 #else
     NRFX_ASSERT(reg_num < 1);
@@ -1090,11 +1097,11 @@ NRF_STATIC_INLINE void nrf_power_gpregret_ext_set(NRF_POWER_Type * p_reg,
 
 NRF_STATIC_INLINE uint8_t nrf_power_gpregret_ext_get(NRF_POWER_Type const * p_reg, uint8_t reg_num)
 {
-#if defined(NRF91_SERIES) || defined(NRF5340_XXAA_APPLICATION) || defined(NRF5340_XXAA_NETWORK)
+#if NRF_POWER_HAS_GPREGRET_ARRAY
     return p_reg->GPREGRET[reg_num];
 #else
     NRFX_ASSERT(reg_num < 1);
-    return p_reg->GPREGRET;
+    return (uint8_t)p_reg->GPREGRET;
 #endif
 }
 
@@ -1106,7 +1113,7 @@ NRF_STATIC_INLINE void nrf_power_gpregret2_set(NRF_POWER_Type * p_reg, uint8_t v
 
 NRF_STATIC_INLINE uint8_t nrf_power_gpregret2_get(NRF_POWER_Type const * p_reg)
 {
-    return p_reg->GPREGRET2;
+    return (uint8_t)p_reg->GPREGRET2;
 }
 #endif
 

--- a/nrfx/hal/nrf_qdec.h
+++ b/nrfx/hal/nrf_qdec.h
@@ -39,6 +39,10 @@
 extern "C" {
 #endif
 
+#if !defined(NRF_QDEC0) && defined(NRF_QDEC)
+#define NRF_QDEC0 NRF_QDEC
+#endif
+
 /**
  * @defgroup nrf_qdec_hal QDEC HAL
  * @{
@@ -47,18 +51,52 @@ extern "C" {
  */
 
 /**
- * @brief This value can be provided as a parameter for the @ref nrf_qdec_pio_assign
+ * @brief This value can be provided as a parameter for the @ref nrf_qdec_pins_set
  *        function call to specify that a LED signal shall not be use by the QDEC and
  *        connected to a physical pin.
  */
-#define NRF_QDEC_LED_NOT_CONNECTED  0xFFFFFFFF
+#define NRF_QDEC_PIN_NOT_CONNECTED 0xFFFFFFFF
+
+#if defined(QDEC_TASKS_RDCLRACC_TASKS_RDCLRACC_Msk) || defined(__NRFX_DOXYGEN__)
+/** @brief Presence of the RDCLRACC task. */
+#define NRF_QDEC_HAS_TASK_RDCLRACC 1
+#else
+#define NRF_QDEC_HAS_TASK_RDCLRACC 0
+#endif
+
+#if defined(QDEC_TASKS_RDCLRDBL_TASKS_RDCLRDBL_Msk) || defined(__NRFX_DOXYGEN__)
+/** @brief Presence of the RDCLRDBL task. */
+#define NRF_QDEC_HAS_RDCLRDBL 1
+#else
+#define NRF_QDEC_HAS_RDCLRDBL 0
+#endif
+
+#if defined(QDEC_EVENTS_DBLRDY_EVENTS_DBLRDY_Msk) || defined(__NRFX_DOXYGEN__)
+/** @brief Presence of the DBLRDY event. */
+#define NRF_QDEC_HAS_EVENT_DBLRDY 1
+#else
+#define NRF_QDEC_HAS_EVENT_DBLRDY 0
+#endif
+
+#if defined(QDEC_EVENTS_STOPPED_EVENTS_STOPPED_Msk) || defined(__NRFX_DOXYGEN__)
+/** @brief Presence of the STOPPED event. */
+#define NRF_QDEC_HAS_EVENT_STOPPED 1
+#else
+#define NRF_QDEC_HAS_EVENT_STOPPED 0
+#endif
 
 /** @brief QDEC tasks. */
 typedef enum
 {
-    NRF_QDEC_TASK_START      = offsetof(NRF_QDEC_Type, TASKS_START),     /**< Starting the quadrature decoder. */
-    NRF_QDEC_TASK_STOP       = offsetof(NRF_QDEC_Type, TASKS_STOP),      /**< Stopping the quadrature decoder. */
-    NRF_QDEC_TASK_READCLRACC = offsetof(NRF_QDEC_Type, TASKS_READCLRACC) /**< Reading and clearing ACC and ACCDBL registers. */
+    NRF_QDEC_TASK_START      = offsetof(NRF_QDEC_Type, TASKS_START),      /**< Starting the quadrature decoder. */
+    NRF_QDEC_TASK_STOP       = offsetof(NRF_QDEC_Type, TASKS_STOP),       /**< Stopping the quadrature decoder. */
+    NRF_QDEC_TASK_READCLRACC = offsetof(NRF_QDEC_Type, TASKS_READCLRACC), /**< Reading and clearing ACC and ACCDBL registers. */
+#if NRF_QDEC_HAS_TASK_RDCLRACC
+    NRF_QDEC_TASK_RDCLRACC   = offsetof(NRF_QDEC_Type, TASKS_RDCLRACC),   /**< Reading and clearing ACC register. */
+#endif
+#if NRF_QDEC_HAS_TASK_RDCLRDBL
+    NRF_QDEC_TASK_RDCLRDBL   = offsetof(NRF_QDEC_Type, TASKS_RDCLRDBL)    /**< Reading and clearing ACCDBL register. */
+#endif
 } nrf_qdec_task_t;
 
 /** @brief QDEC events. */
@@ -66,7 +104,13 @@ typedef enum
 {
     NRF_QDEC_EVENT_SAMPLERDY = offsetof(NRF_QDEC_Type, EVENTS_SAMPLERDY), /**< Event generated for every new sample.  */
     NRF_QDEC_EVENT_REPORTRDY = offsetof(NRF_QDEC_Type, EVENTS_REPORTRDY), /**< Event generated for every new report.  */
-    NRF_QDEC_EVENT_ACCOF     = offsetof(NRF_QDEC_Type, EVENTS_ACCOF)      /**< Event generated for every accumulator overflow. */
+    NRF_QDEC_EVENT_ACCOF     = offsetof(NRF_QDEC_Type, EVENTS_ACCOF),     /**< Event generated for every accumulator overflow. */
+#if NRF_QDEC_HAS_EVENT_DBLRDY
+    NRF_QDEC_EVENT_DBLRDY    = offsetof(NRF_QDEC_Type, EVENTS_DBLRDY),    /**< Event generated for every double displacement(s) detected. */
+#endif
+#if NRF_QDEC_HAS_EVENT_STOPPED
+    NRF_QDEC_EVENT_STOPPED   = offsetof(NRF_QDEC_Type, EVENTS_STOPPED)    /**< Event generated for every QDEC stop. */
+#endif
 } nrf_qdec_event_t;
 
 /** @brief QDEC shortcuts. */
@@ -108,14 +152,14 @@ typedef enum
 /** @brief Available sampling periods. */
 typedef enum
 {
-    NRF_QDEC_SAMPLEPER_128us   = QDEC_SAMPLEPER_SAMPLEPER_128us,  /**< QDEC sampling period 128 microseconds.  */
-    NRF_QDEC_SAMPLEPER_256us   = QDEC_SAMPLEPER_SAMPLEPER_256us,  /**< QDEC sampling period 256 microseconds.  */
-    NRF_QDEC_SAMPLEPER_512us   = QDEC_SAMPLEPER_SAMPLEPER_512us,  /**< QDEC sampling period 512 microseconds.  */
-    NRF_QDEC_SAMPLEPER_1024us  = QDEC_SAMPLEPER_SAMPLEPER_1024us, /**< QDEC sampling period 1024 microseconds.  */
-    NRF_QDEC_SAMPLEPER_2048us  = QDEC_SAMPLEPER_SAMPLEPER_2048us, /**< QDEC sampling period 2048 microseconds.  */
-    NRF_QDEC_SAMPLEPER_4096us  = QDEC_SAMPLEPER_SAMPLEPER_4096us, /**< QDEC sampling period 4096 microseconds.  */
-    NRF_QDEC_SAMPLEPER_8192us  = QDEC_SAMPLEPER_SAMPLEPER_8192us, /**< QDEC sampling period 8192 microseconds.  */
-    NRF_QDEC_SAMPLEPER_16384us = QDEC_SAMPLEPER_SAMPLEPER_16384us /**< QDEC sampling period 16384 microseconds.  */
+    NRF_QDEC_SAMPLEPER_128US   = QDEC_SAMPLEPER_SAMPLEPER_128us,  /**< QDEC sampling period 128 microseconds.  */
+    NRF_QDEC_SAMPLEPER_256US   = QDEC_SAMPLEPER_SAMPLEPER_256us,  /**< QDEC sampling period 256 microseconds.  */
+    NRF_QDEC_SAMPLEPER_512US   = QDEC_SAMPLEPER_SAMPLEPER_512us,  /**< QDEC sampling period 512 microseconds.  */
+    NRF_QDEC_SAMPLEPER_1024US  = QDEC_SAMPLEPER_SAMPLEPER_1024us, /**< QDEC sampling period 1024 microseconds.  */
+    NRF_QDEC_SAMPLEPER_2048US  = QDEC_SAMPLEPER_SAMPLEPER_2048us, /**< QDEC sampling period 2048 microseconds.  */
+    NRF_QDEC_SAMPLEPER_4096US  = QDEC_SAMPLEPER_SAMPLEPER_4096us, /**< QDEC sampling period 4096 microseconds.  */
+    NRF_QDEC_SAMPLEPER_8192US  = QDEC_SAMPLEPER_SAMPLEPER_8192us, /**< QDEC sampling period 8192 microseconds.  */
+    NRF_QDEC_SAMPLEPER_16384US = QDEC_SAMPLEPER_SAMPLEPER_16384us /**< QDEC sampling period 16384 microseconds.  */
 } nrf_qdec_sampleper_t;
 
 /** @brief Available report periods. */
@@ -132,7 +176,6 @@ typedef enum
     NRF_QDEC_REPORTPER_200      = QDEC_REPORTPER_REPORTPER_200Smpl,                                  /**< QDEC report period 200 samples. */
     NRF_QDEC_REPORTPER_240      = QDEC_REPORTPER_REPORTPER_240Smpl,                                  /**< QDEC report period 240 samples. */
     NRF_QDEC_REPORTPER_280      = QDEC_REPORTPER_REPORTPER_280Smpl,                                  /**< QDEC report period 280 samples. */
-    NRF_QDEC_REPORTPER_DISABLED = (QDEC_REPORTPER_REPORTPER_Msk >> QDEC_REPORTPER_REPORTPER_Pos) + 1 /**< QDEC reporting disabled. Deprecated. */
 } nrf_qdec_reportper_t;
 
 /**
@@ -220,21 +263,6 @@ NRF_STATIC_INLINE void nrf_qdec_pins_set(NRF_QDEC_Type * p_reg,
                                          uint32_t        phase_a_pin,
                                          uint32_t        phase_b_pin,
                                          uint32_t        led_pin);
-
-/**
- * @brief Function for assigning QDEC pins.
- *
- * @note This function is deprecated. Use @ref nrf_qdec_pins_set instead.
- *
- * @param[in] p_reg   Pointer to the structure of registers of the peripheral.
- * @param[in] psela   Pin number.
- * @param[in] pselb   Pin number.
- * @param[in] pselled Pin number.
- */
-NRF_STATIC_INLINE void nrf_qdec_pio_assign(NRF_QDEC_Type * p_reg,
-                                           uint32_t        psela,
-                                           uint32_t        pselb,
-                                           uint32_t        pselled);
 
 /**
  * @brief Function for getting the Phase A pin selection.
@@ -434,7 +462,7 @@ NRF_STATIC_INLINE void nrf_qdec_reportper_set(NRF_QDEC_Type *      p_reg,
  *
  * @return The report period.
  */
-NRF_STATIC_INLINE uint32_t nrf_qdec_reportper_get(NRF_QDEC_Type const * p_reg);
+NRF_STATIC_INLINE nrf_qdec_reportper_t nrf_qdec_reportper_get(NRF_QDEC_Type const * p_reg);
 
 /**
  * @brief Function for retrieving the value of QDEC SAMPLEPER register.
@@ -443,7 +471,7 @@ NRF_STATIC_INLINE uint32_t nrf_qdec_reportper_get(NRF_QDEC_Type const * p_reg);
  *
  * @return Number of samples per report.
  */
-NRF_STATIC_INLINE uint32_t nrf_qdec_reportper_to_value(uint32_t reportper);
+NRF_STATIC_INLINE uint32_t nrf_qdec_reportper_to_value(nrf_qdec_reportper_t reportper);
 
 /**
  * @brief Function for setting the active level for the LED.
@@ -532,14 +560,6 @@ NRF_STATIC_INLINE void nrf_qdec_pins_set(NRF_QDEC_Type * p_reg,
 #else
     p_reg->PSELLED = led_pin;
 #endif
-}
-
-NRF_STATIC_INLINE void nrf_qdec_pio_assign(NRF_QDEC_Type * p_reg,
-                                           uint32_t        psela,
-                                           uint32_t        pselb,
-                                           uint32_t        pselled)
-{
-    nrf_qdec_pins_set(p_reg, psela, pselb, pselled);
 }
 
 NRF_STATIC_INLINE uint32_t nrf_qdec_phase_a_pin_get(NRF_QDEC_Type const * p_reg)
@@ -664,12 +684,12 @@ NRF_STATIC_INLINE void nrf_qdec_reportper_set(NRF_QDEC_Type *      p_reg,
     p_reg->REPORTPER = reportper;
 }
 
-NRF_STATIC_INLINE uint32_t nrf_qdec_reportper_get(NRF_QDEC_Type const * p_reg)
+NRF_STATIC_INLINE nrf_qdec_reportper_t nrf_qdec_reportper_get(NRF_QDEC_Type const * p_reg)
 {
-    return p_reg->REPORTPER;
+    return (nrf_qdec_reportper_t)(p_reg->REPORTPER);
 }
 
-NRF_STATIC_INLINE uint32_t nrf_qdec_reportper_to_value(uint32_t reportper)
+NRF_STATIC_INLINE uint32_t nrf_qdec_reportper_to_value(nrf_qdec_reportper_t reportper)
 {
     return (reportper == NRF_QDEC_REPORTPER_10) ? 10 : reportper * 40;
 }

--- a/nrfx/hal/nrf_qspi.h
+++ b/nrfx/hal/nrf_qspi.h
@@ -226,16 +226,16 @@ typedef enum
 /** @brief Pin configuration. */
 typedef struct
 {
-    uint8_t sck_pin; /**< SCK pin number. */
-    uint8_t csn_pin; /**< Chip select pin number. */
-    uint8_t io0_pin; /**< IO0/MOSI pin number. */
-    uint8_t io1_pin; /**< IO1/MISO pin number. */
-    uint8_t io2_pin; /**< IO2 pin number (optional).
-                      *   Set to @ref NRF_QSPI_PIN_NOT_CONNECTED if this signal is not needed.
-                      */
-    uint8_t io3_pin; /**< IO3 pin number (optional).
-                      *   Set to @ref NRF_QSPI_PIN_NOT_CONNECTED if this signal is not needed.
-                      */
+    uint32_t sck_pin; /**< SCK pin number. */
+    uint32_t csn_pin; /**< Chip select pin number. */
+    uint32_t io0_pin; /**< IO0/MOSI pin number. */
+    uint32_t io1_pin; /**< IO1/MISO pin number. */
+    uint32_t io2_pin; /**< IO2 pin number (optional).
+                       *   Set to @ref NRF_QSPI_PIN_NOT_CONNECTED if this signal is not needed.
+                       */
+    uint32_t io3_pin; /**< IO3 pin number (optional).
+                       *   Set to @ref NRF_QSPI_PIN_NOT_CONNECTED if this signal is not needed.
+                       */
 } nrf_qspi_pins_t;
 
 /** @brief Custom instruction configuration. */

--- a/nrfx/hal/nrf_radio.h
+++ b/nrfx/hal/nrf_radio.h
@@ -47,6 +47,12 @@ extern "C" {
  * @brief   Hardware access layer for managing the RADIO peripheral.
  */
 
+#if defined(DPPI_PRESENT) || defined(__NRFX_DOXYGEN__)
+/** @brief Symbol specifying offset between address of TASK/EVENT register and address of associated SUBSCRIBE/PUBLISH register. */
+#define NRF_RADIO_DPPI_OFFSET \
+    (NRFX_OFFSETOF(NRF_RADIO_Type, SUBSCRIBE_TXEN) - NRFX_OFFSETOF(NRF_RADIO_Type, TASKS_TXEN))
+#endif // defined(DPPI_PRESENT) || defined(__NRFX_DOXYGEN__)
+
 /** @brief RADIO tasks. */
 typedef enum
 {
@@ -56,7 +62,11 @@ typedef enum
     NRF_RADIO_TASK_STOP      = offsetof(NRF_RADIO_Type, TASKS_STOP),      /**< Stop RADIO. */
     NRF_RADIO_TASK_DISABLE   = offsetof(NRF_RADIO_Type, TASKS_DISABLE),   /**< Disable RADIO. */
     NRF_RADIO_TASK_RSSISTART = offsetof(NRF_RADIO_Type, TASKS_RSSISTART), /**< Start the RSSI and take one single sample of the receive signal strength. */
+#if defined(RADIO_TASKS_RSSISTOP_TASKS_RSSISTOP_Msk) || \
+    defined(RADIO_SHORTS_DISABLED_RSSISTOP_Msk) || \
+    defined(__NRFX_DOXYGEN__)
     NRF_RADIO_TASK_RSSISTOP  = offsetof(NRF_RADIO_Type, TASKS_RSSISTOP),  /**< Stop the RSSI measurement. */
+#endif
     NRF_RADIO_TASK_BCSTART   = offsetof(NRF_RADIO_Type, TASKS_BCSTART),   /**< Start the bit counter. */
     NRF_RADIO_TASK_BCSTOP    = offsetof(NRF_RADIO_Type, TASKS_BCSTOP),    /**< Stop the bit counter. */
 #if defined(RADIO_TASKS_EDSTART_TASKS_EDSTART_Msk) || defined(__NRFX_DOXYGEN__)
@@ -83,55 +93,89 @@ typedef enum
     NRF_RADIO_EVENT_DISABLED   = offsetof(NRF_RADIO_Type, EVENTS_DISABLED),   /**< RADIO has been disabled. */
     NRF_RADIO_EVENT_DEVMATCH   = offsetof(NRF_RADIO_Type, EVENTS_DEVMATCH),   /**< A device address match occurred on the last received packet. */
     NRF_RADIO_EVENT_DEVMISS    = offsetof(NRF_RADIO_Type, EVENTS_DEVMISS),    /**< No device address match occurred on the last received packet. */
+#if defined(RADIO_INTENSET_RSSIEND_Msk) ||   \
+    defined(RADIO_INTENSET00_RSSIEND_Msk) || \
+    defined(__NRFX_DOXYGEN__)
     NRF_RADIO_EVENT_RSSIEND    = offsetof(NRF_RADIO_Type, EVENTS_RSSIEND),    /**< Sampling of receive signal strength complete. */
+#endif
     NRF_RADIO_EVENT_BCMATCH    = offsetof(NRF_RADIO_Type, EVENTS_BCMATCH),    /**< Bit counter reached bit count value. */
-#if defined(RADIO_INTENSET_CRCOK_Msk) || defined(__NRFX_DOXYGEN__)
+#if defined(RADIO_INTENSET_CRCOK_Msk) ||   \
+    defined(RADIO_INTENSET00_CRCOK_Msk) || \
+    defined(__NRFX_DOXYGEN__)
     NRF_RADIO_EVENT_CRCOK      = offsetof(NRF_RADIO_Type, EVENTS_CRCOK),      /**< Packet received with correct CRC. */
 #endif
-#if defined(RADIO_INTENSET_CRCERROR_Msk) || defined(__NRFX_DOXYGEN__)
+#if defined(RADIO_INTENSET_CRCERROR_Msk) ||   \
+    defined(RADIO_INTENSET00_CRCERROR_Msk) || \
+    defined(__NRFX_DOXYGEN__)
     NRF_RADIO_EVENT_CRCERROR   = offsetof(NRF_RADIO_Type, EVENTS_CRCERROR),   /**< Packet received with incorrect CRC. */
 #endif
-#if defined(RADIO_INTENSET_FRAMESTART_Msk) || defined(__NRFX_DOXYGEN__)
+#if defined(RADIO_INTENSET_FRAMESTART_Msk) ||   \
+    defined(RADIO_INTENSET00_FRAMESTART_Msk) || \
+    defined(__NRFX_DOXYGEN__)
     NRF_RADIO_EVENT_FRAMESTART = offsetof(NRF_RADIO_Type, EVENTS_FRAMESTART), /**< IEEE 802.15.4 length field received. */
 #endif
-#if defined(RADIO_INTENSET_EDEND_Msk) || defined(__NRFX_DOXYGEN__)
+#if defined(RADIO_INTENSET_EDEND_Msk) ||   \
+    defined(RADIO_INTENSET00_EDEND_Msk) || \
+    defined(__NRFX_DOXYGEN__)
     NRF_RADIO_EVENT_EDEND      = offsetof(NRF_RADIO_Type, EVENTS_EDEND),      /**< Energy Detection procedure ended. */
 #endif
-#if defined(RADIO_INTENSET_EDSTOPPED_Msk) || defined(__NRFX_DOXYGEN__)
+#if defined(RADIO_INTENSET_EDSTOPPED_Msk) ||   \
+    defined(RADIO_INTENSET00_EDSTOPPED_Msk) || \
+    defined(__NRFX_DOXYGEN__)
     NRF_RADIO_EVENT_EDSTOPPED  = offsetof(NRF_RADIO_Type, EVENTS_EDSTOPPED),  /**< The sampling of Energy Detection has stopped. */
 #endif
-#if defined(RADIO_INTENSET_CCAIDLE_Msk) || defined(__NRFX_DOXYGEN__)
+#if defined(RADIO_INTENSET_CCAIDLE_Msk) ||   \
+    defined(RADIO_INTENSET00_CCAIDLE_Msk) || \
+    defined(__NRFX_DOXYGEN__)
     NRF_RADIO_EVENT_CCAIDLE    = offsetof(NRF_RADIO_Type, EVENTS_CCAIDLE),    /**< Wireless medium in idle - clear to send. */
 #endif
-#if defined(RADIO_INTENSET_CCABUSY_Msk) || defined(__NRFX_DOXYGEN__)
+#if defined(RADIO_INTENSET_CCABUSY_Msk) ||   \
+    defined(RADIO_INTENSET00_CCABUSY_Msk) || \
+    defined(__NRFX_DOXYGEN__)
     NRF_RADIO_EVENT_CCABUSY    = offsetof(NRF_RADIO_Type, EVENTS_CCABUSY),    /**< Wireless medium busy - do not send. */
 #endif
-#if defined(RADIO_INTENSET_CCASTOPPED_Msk) || defined(__NRFX_DOXYGEN__)
+#if defined(RADIO_INTENSET_CCASTOPPED_Msk) ||   \
+    defined(RADIO_INTENSET00_CCASTOPPED_Msk) || \
+    defined(__NRFX_DOXYGEN__)
     NRF_RADIO_EVENT_CCASTOPPED = offsetof(NRF_RADIO_Type, EVENTS_CCASTOPPED), /**< The CCA has stopped. */
 #endif
-#if defined(RADIO_INTENSET_RATEBOOST_Msk) || defined(__NRFX_DOXYGEN__)
+#if defined(RADIO_INTENSET_RATEBOOST_Msk) ||   \
+    defined(RADIO_INTENSET00_RATEBOOST_Msk) || \
+    defined(__NRFX_DOXYGEN__)
     NRF_RADIO_EVENT_RATEBOOST  = offsetof(NRF_RADIO_Type, EVENTS_RATEBOOST),  /**< Ble_LR CI field received, receive mode is changed from Ble_LR125Kbit to Ble_LR500Kbit. */
 #endif
-#if defined(RADIO_INTENSET_TXREADY_Msk) || defined(__NRFX_DOXYGEN__)
+#if defined(RADIO_INTENSET_TXREADY_Msk) ||   \
+    defined(RADIO_INTENSET00_TXREADY_Msk) || \
+    defined(__NRFX_DOXYGEN__)
     NRF_RADIO_EVENT_TXREADY    = offsetof(NRF_RADIO_Type, EVENTS_TXREADY),    /**< RADIO has ramped up and is ready to be started TX path. */
 #endif
-#if defined(RADIO_INTENSET_RXREADY_Msk) || defined(__NRFX_DOXYGEN__)
+#if defined(RADIO_INTENSET_RXREADY_Msk) ||   \
+    defined(RADIO_INTENSET00_RXREADY_Msk) || \
+    defined(__NRFX_DOXYGEN__)
     NRF_RADIO_EVENT_RXREADY    = offsetof(NRF_RADIO_Type, EVENTS_RXREADY),    /**< RADIO has ramped up and is ready to be started RX path. */
 #endif
-#if defined(RADIO_INTENSET_MHRMATCH_Msk) || defined(__NRFX_DOXYGEN__)
+#if defined(RADIO_INTENSET_MHRMATCH_Msk) ||   \
+    defined(RADIO_INTENSET00_MHRMATCH_Msk) || \
+    defined(__NRFX_DOXYGEN__)
     NRF_RADIO_EVENT_MHRMATCH   = offsetof(NRF_RADIO_Type, EVENTS_MHRMATCH),   /**< MAC Header match found. */
 #endif
-#if defined(RADIO_INTENSET_PHYEND_Msk) || defined(__NRFX_DOXYGEN__)
+#if defined(RADIO_INTENSET_PHYEND_Msk) ||   \
+    defined(RADIO_INTENSET00_PHYEND_Msk) || \
+    defined(__NRFX_DOXYGEN__)
     NRF_RADIO_EVENT_PHYEND     = offsetof(NRF_RADIO_Type, EVENTS_PHYEND),     /**< Generated in Ble_LR125Kbit, Ble_LR500Kbit
                                                                                    and BleIeee802154_250Kbit modes when last
                                                                                    bit is sent on the air. */
 #endif
-#if defined(RADIO_INTENSET_SYNC_Msk) || defined(__NRFX_DOXYGEN__)
+#if defined(RADIO_INTENSET_SYNC_Msk) ||   \
+    defined(RADIO_INTENSET00_SYNC_Msk) || \
+    defined(__NRFX_DOXYGEN__)
     NRF_RADIO_EVENT_SYNC       = offsetof(NRF_RADIO_Type, EVENTS_SYNC),       /**< Generated in Ble_LR125Kbit, Ble_LR500Kbit
                                                                                    and BleIeee802154_250Kbit modes when possible
                                                                                    preamble has been received. */
 #endif
-#if defined(RADIO_INTENSET_CTEPRESENT_Msk) || defined(__NRFX_DOXYGEN__)
+#if defined(RADIO_INTENSET_CTEPRESENT_Msk) ||   \
+    defined(RADIO_INTENSET00_CTEPRESENT_Msk) || \
+    defined(__NRFX_DOXYGEN__)
     NRF_RADIO_EVENT_CTEPRESENT = offsetof(NRF_RADIO_Type, EVENTS_CTEPRESENT)  /**< CTE is present. */
 #endif
 } nrf_radio_event_t;
@@ -139,59 +183,125 @@ typedef enum
 /** @brief RADIO interrupts. */
 typedef enum
 {
-    NRF_RADIO_INT_READY_MASK      = RADIO_INTENSET_READY_Msk,      /**< Interrupt on READY event.  */
-    NRF_RADIO_INT_ADDRESS_MASK    = RADIO_INTENSET_ADDRESS_Msk,    /**< Interrupt on ADDRESS event. */
-    NRF_RADIO_INT_PAYLOAD_MASK    = RADIO_INTENSET_PAYLOAD_Msk,    /**< Interrupt on PAYLOAD event. */
-    NRF_RADIO_INT_END_MASK        = RADIO_INTENSET_END_Msk,        /**< Interrupt on END event. */
-    NRF_RADIO_INT_DISABLED_MASK   = RADIO_INTENSET_DISABLED_Msk,   /**< Interrupt on DISABLED event. */
-    NRF_RADIO_INT_DEVMATCH_MASK   = RADIO_INTENSET_DEVMATCH_Msk,   /**< Interrupt on DEVMATCH event. */
-    NRF_RADIO_INT_DEVMISS_MASK    = RADIO_INTENSET_DEVMISS_Msk,    /**< Interrupt on DEVMISS event. */
-    NRF_RADIO_INT_RSSIEND_MASK    = RADIO_INTENSET_RSSIEND_Msk,    /**< Interrupt on RSSIEND event. */
-    NRF_RADIO_INT_BCMATCH_MASK    = RADIO_INTENSET_BCMATCH_Msk,    /**< Interrupt on BCMATCH event. */
+#if defined(RADIO_INTENSET_READY_Msk) || defined(__NRFX_DOXYGEN__)
+    NRF_RADIO_INT_READY_MASK      = RADIO_INTENSET_READY_Msk,        /**< Interrupt on READY event.  */
+#elif defined(RADIO_INTENSET00_READY_Msk)
+    NRF_RADIO_INT_READY_MASK      = RADIO_INTENSET00_READY_Msk,      /**< Interrupt on READY event.  */
+#endif
+#if defined(RADIO_INTENSET_ADDRESS_Msk) || defined(__NRFX_DOXYGEN__)
+    NRF_RADIO_INT_ADDRESS_MASK    = RADIO_INTENSET_ADDRESS_Msk,      /**< Interrupt on ADDRESS event. */
+#elif defined(RADIO_INTENSET00_ADDRESS_Msk)
+    NRF_RADIO_INT_ADDRESS_MASK    = RADIO_INTENSET00_ADDRESS_Msk,    /**< Interrupt on ADDRESS event. */
+#endif
+#if defined(RADIO_INTENSET_PAYLOAD_Msk) || defined(__NRFX_DOXYGEN__)
+    NRF_RADIO_INT_PAYLOAD_MASK    = RADIO_INTENSET_PAYLOAD_Msk,      /**< Interrupt on PAYLOAD event. */
+#elif defined(RADIO_INTENSET00_PAYLOAD_Msk)
+    NRF_RADIO_INT_PAYLOAD_MASK    = RADIO_INTENSET00_PAYLOAD_Msk,    /**< Interrupt on PAYLOAD event. */
+#endif
+#if defined(RADIO_INTENSET_END_Msk) || defined(__NRFX_DOXYGEN__)
+    NRF_RADIO_INT_END_MASK        = RADIO_INTENSET_END_Msk,          /**< Interrupt on END event. */
+#elif defined(RADIO_INTENSET00_END_Msk)
+    NRF_RADIO_INT_END_MASK        = RADIO_INTENSET00_END_Msk,        /**< Interrupt on END event. */
+#endif
+#if defined(RADIO_INTENSET_DISABLED_Msk) || defined(__NRFX_DOXYGEN__)
+    NRF_RADIO_INT_DISABLED_MASK   = RADIO_INTENSET_DISABLED_Msk,     /**< Interrupt on DISABLED event. */
+#elif defined(RADIO_INTENSET00_DISABLED_Msk)
+    NRF_RADIO_INT_DISABLED_MASK   = RADIO_INTENSET00_DISABLED_Msk,   /**< Interrupt on DISABLED event. */
+#endif
+#if defined(RADIO_INTENSET_DEVMATCH_Msk) || defined(__NRFX_DOXYGEN__)
+    NRF_RADIO_INT_DEVMATCH_MASK   = RADIO_INTENSET_DEVMATCH_Msk,     /**< Interrupt on DEVMATCH event. */
+#elif defined(RADIO_INTENSET00_DEVMATCH_Msk)
+    NRF_RADIO_INT_DEVMATCH_MASK   = RADIO_INTENSET00_DEVMATCH_Msk,   /**< Interrupt on DEVMATCH event. */
+#endif
+#if defined(RADIO_INTENSET_DEVMISS_Msk) || defined(__NRFX_DOXYGEN__)
+    NRF_RADIO_INT_DEVMISS_MASK    = RADIO_INTENSET_DEVMISS_Msk,      /**< Interrupt on DEVMISS event. */
+#elif defined(RADIO_INTENSET00_DEVMISS_Msk)
+    NRF_RADIO_INT_DEVMISS_MASK    = RADIO_INTENSET00_DEVMISS_Msk,    /**< Interrupt on DEVMISS event. */
+#endif
+#if defined(RADIO_INTENSET_RSSIEND_Msk) || defined(__NRFX_DOXYGEN__)
+    NRF_RADIO_INT_RSSIEND_MASK    = RADIO_INTENSET_RSSIEND_Msk,      /**< Interrupt on RSSIEND event. */
+#elif defined(RADIO_INTENSET00_RSSIEND_Msk)
+    NRF_RADIO_INT_RSSIEND_MASK    = RADIO_INTENSET00_RSSIEND_Msk,    /**< Interrupt on RSSIEND event. */
+#endif
+#if defined(RADIO_INTENSET_BCMATCH_Msk) || defined(__NRFX_DOXYGEN__)
+    NRF_RADIO_INT_BCMATCH_MASK    = RADIO_INTENSET_BCMATCH_Msk,      /**< Interrupt on BCMATCH event. */
+#elif defined(RADIO_INTENSET00_BCMATCH_Msk)
+    NRF_RADIO_INT_BCMATCH_MASK    = RADIO_INTENSET00_BCMATCH_Msk,    /**< Interrupt on BCMATCH event. */
+#endif
 #if defined(RADIO_INTENSET_CRCOK_Msk) || defined(__NRFX_DOXYGEN__)
-    NRF_RADIO_INT_CRCOK_MASK      = RADIO_INTENSET_CRCOK_Msk,      /**< Interrupt on CRCOK event. */
+    NRF_RADIO_INT_CRCOK_MASK      = RADIO_INTENSET_CRCOK_Msk,        /**< Interrupt on CRCOK event. */
+#elif defined(RADIO_INTENSET00_CRCOK_Msk)
+    NRF_RADIO_INT_CRCOK_MASK      = RADIO_INTENSET00_CRCOK_Msk,      /**< Interrupt on CRCOK event. */
 #endif
 #if defined(RADIO_INTENSET_CRCERROR_Msk) || defined(__NRFX_DOXYGEN__)
-    NRF_RADIO_INT_CRCERROR_MASK   = RADIO_INTENSET_CRCERROR_Msk,   /**< Interrupt on CRCERROR event. */
+    NRF_RADIO_INT_CRCERROR_MASK   = RADIO_INTENSET_CRCERROR_Msk,     /**< Interrupt on CRCERROR event. */
+#elif defined(RADIO_INTENSET00_CRCERROR_Msk)
+    NRF_RADIO_INT_CRCERROR_MASK   = RADIO_INTENSET00_CRCERROR_Msk,   /**< Interrupt on CRCERROR event. */
 #endif
 #if defined(RADIO_INTENSET_FRAMESTART_Msk) || defined(__NRFX_DOXYGEN__)
-    NRF_RADIO_INT_FRAMESTART_MASK = RADIO_INTENSET_FRAMESTART_Msk, /**< Interrupt on FRAMESTART event. */
+    NRF_RADIO_INT_FRAMESTART_MASK = RADIO_INTENSET_FRAMESTART_Msk,   /**< Interrupt on FRAMESTART event. */
+#elif defined(RADIO_INTENSET00_FRAMESTART_Msk)
+    NRF_RADIO_INT_FRAMESTART_MASK = RADIO_INTENSET00_FRAMESTART_Msk, /**< Interrupt on FRAMESTART event. */
 #endif
 #if defined(RADIO_INTENSET_EDEND_Msk) || defined(__NRFX_DOXYGEN__)
-    NRF_RADIO_INT_EDEND_MASK      = RADIO_INTENSET_EDEND_Msk,      /**< Interrupt on EDEND event. */
+    NRF_RADIO_INT_EDEND_MASK      = RADIO_INTENSET_EDEND_Msk,        /**< Interrupt on EDEND event. */
+#elif defined(RADIO_INTENSET00_EDEND_Msk)
+    NRF_RADIO_INT_EDEND_MASK      = RADIO_INTENSET00_EDEND_Msk,      /**< Interrupt on EDEND event. */
 #endif
 #if defined(RADIO_INTENSET_EDSTOPPED_Msk) || defined(__NRFX_DOXYGEN__)
-    NRF_RADIO_INT_EDSTOPPED_MASK  = RADIO_INTENSET_EDSTOPPED_Msk,  /**< Interrupt on EDSTOPPED event. */
+    NRF_RADIO_INT_EDSTOPPED_MASK  = RADIO_INTENSET_EDSTOPPED_Msk,    /**< Interrupt on EDSTOPPED event. */
+#elif defined(RADIO_INTENSET00_EDSTOPPED_Msk)
+    NRF_RADIO_INT_EDSTOPPED_MASK  = RADIO_INTENSET00_EDSTOPPED_Msk,  /**< Interrupt on EDSTOPPED event. */
 #endif
 #if defined(RADIO_INTENSET_CCAIDLE_Msk) || defined(__NRFX_DOXYGEN__)
-    NRF_RADIO_INT_CCAIDLE_MASK    = RADIO_INTENSET_CCAIDLE_Msk,    /**< Interrupt on CCAIDLE event. */
+    NRF_RADIO_INT_CCAIDLE_MASK    = RADIO_INTENSET_CCAIDLE_Msk,      /**< Interrupt on CCAIDLE event. */
+#elif defined(RADIO_INTENSET00_CCAIDLE_Msk)
+    NRF_RADIO_INT_CCAIDLE_MASK    = RADIO_INTENSET00_CCAIDLE_Msk,    /**< Interrupt on CCAIDLE event. */
 #endif
 #if defined(RADIO_INTENSET_CCABUSY_Msk) || defined(__NRFX_DOXYGEN__)
-    NRF_RADIO_INT_CCABUSY_MASK    = RADIO_INTENSET_CCABUSY_Msk,    /**< Interrupt on CCABUSY event. */
+    NRF_RADIO_INT_CCABUSY_MASK    = RADIO_INTENSET_CCABUSY_Msk,      /**< Interrupt on CCABUSY event. */
+#elif defined(RADIO_INTENSET00_CCABUSY_Msk)
+    NRF_RADIO_INT_CCABUSY_MASK    = RADIO_INTENSET00_CCABUSY_Msk,    /**< Interrupt on CCABUSY event. */
 #endif
 #if defined(RADIO_INTENSET_CCASTOPPED_Msk) || defined(__NRFX_DOXYGEN__)
-    NRF_RADIO_INT_CCASTOPPED_MASK = RADIO_INTENSET_CCASTOPPED_Msk, /**< Interrupt on CCASTOPPED event. */
+    NRF_RADIO_INT_CCASTOPPED_MASK = RADIO_INTENSET_CCASTOPPED_Msk,   /**< Interrupt on CCASTOPPED event. */
+#elif defined(RADIO_INTENSET00_CCASTOPPED_Msk)
+    NRF_RADIO_INT_CCASTOPPED_MASK = RADIO_INTENSET00_CCASTOPPED_Msk, /**< Interrupt on CCASTOPPED event. */
 #endif
 #if defined(RADIO_INTENSET_RATEBOOST_Msk) || defined(__NRFX_DOXYGEN__)
-    NRF_RADIO_INT_RATEBOOST_MASK  = RADIO_INTENSET_RATEBOOST_Msk,  /**< Interrupt on RATEBOOST event. */
+    NRF_RADIO_INT_RATEBOOST_MASK  = RADIO_INTENSET_RATEBOOST_Msk,    /**< Interrupt on RATEBOOST event. */
+#elif defined(RADIO_INTENSET00_RATEBOOST_Msk)
+    NRF_RADIO_INT_RATEBOOST_MASK  = RADIO_INTENSET00_RATEBOOST_Msk,  /**< Interrupt on RATEBOOST event. */
 #endif
 #if defined(RADIO_INTENSET_TXREADY_Msk) || defined(__NRFX_DOXYGEN__)
-    NRF_RADIO_INT_TXREADY_MASK    = RADIO_INTENSET_TXREADY_Msk,    /**< Interrupt on TXREADY event. */
+    NRF_RADIO_INT_TXREADY_MASK    = RADIO_INTENSET_TXREADY_Msk,      /**< Interrupt on TXREADY event. */
+#elif defined(RADIO_INTENSET00_TXREADY_Msk)
+    NRF_RADIO_INT_TXREADY_MASK    = RADIO_INTENSET00_TXREADY_Msk,    /**< Interrupt on TXREADY event. */
 #endif
 #if defined(RADIO_INTENSET_RXREADY_Msk) || defined(__NRFX_DOXYGEN__)
-    NRF_RADIO_INT_RXREADY_MASK    = RADIO_INTENSET_RXREADY_Msk,    /**< Interrupt on RXREADY event. */
+    NRF_RADIO_INT_RXREADY_MASK    = RADIO_INTENSET_RXREADY_Msk,      /**< Interrupt on RXREADY event. */
+#elif defined(RADIO_INTENSET00_RXREADY_Msk)
+    NRF_RADIO_INT_RXREADY_MASK    = RADIO_INTENSET00_RXREADY_Msk,    /**< Interrupt on RXREADY event. */
 #endif
 #if defined(RADIO_INTENSET_MHRMATCH_Msk) || defined(__NRFX_DOXYGEN__)
-    NRF_RADIO_INT_MHRMATCH_MASK   = RADIO_INTENSET_MHRMATCH_Msk,   /**< Interrupt on MHRMATCH event. */
+    NRF_RADIO_INT_MHRMATCH_MASK   = RADIO_INTENSET_MHRMATCH_Msk,     /**< Interrupt on MHRMATCH event. */
+#elif defined(RADIO_INTENSET00_MHRMATCH_Msk)
+    NRF_RADIO_INT_MHRMATCH_MASK   = RADIO_INTENSET00_MHRMATCH_Msk,   /**< Interrupt on MHRMATCH event. */
 #endif
 #if defined(RADIO_INTENSET_PHYEND_Msk) || defined(__NRFX_DOXYGEN__)
-    NRF_RADIO_INT_PHYEND_MASK     = RADIO_INTENSET_PHYEND_Msk,     /**< Interrupt on PHYEND event. */
+    NRF_RADIO_INT_PHYEND_MASK     = RADIO_INTENSET_PHYEND_Msk,       /**< Interrupt on PHYEND event. */
+#elif defined(RADIO_INTENSET00_PHYEND_Msk)
+    NRF_RADIO_INT_PHYEND_MASK     = RADIO_INTENSET00_PHYEND_Msk,     /**< Interrupt on PHYEND event. */
 #endif
 #if defined(RADIO_INTENSET_SYNC_Msk) || defined(__NRFX_DOXYGEN__)
-    NRF_RADIO_INT_SYNC_MASK       = RADIO_INTENSET_SYNC_Msk,       /**< Interrupt on SYNC event. */
+    NRF_RADIO_INT_SYNC_MASK       = RADIO_INTENSET_SYNC_Msk,         /**< Interrupt on SYNC event. */
+#elif defined(RADIO_INTENSET00_SYNC_Msk)
+    NRF_RADIO_INT_SYNC_MASK       = RADIO_INTENSET00_SYNC_Msk,       /**< Interrupt on SYNC event. */
 #endif
 #if defined(RADIO_INTENSET_CTEPRESENT_Msk) || defined(__NRFX_DOXYGEN__)
-    NRF_RADIO_INT_CTEPRESENT_MASK = RADIO_INTENSET_CTEPRESENT_Msk  /**< Interrupt on CTEPRESENT event. */
+    NRF_RADIO_INT_CTEPRESENT_MASK = RADIO_INTENSET_CTEPRESENT_Msk    /**< Interrupt on CTEPRESENT event. */
+#elif defined(RADIO_INTENSET00_CTEPRESENT_Msk)
+    NRF_RADIO_INT_CTEPRESENT_MASK = RADIO_INTENSET00_CTEPRESENT_Msk  /**< Interrupt on CTEPRESENT event. */
 #endif
 } nrf_radio_int_mask_t;
 
@@ -205,7 +315,9 @@ typedef enum
     NRF_RADIO_SHORT_ADDRESS_RSSISTART_MASK  = RADIO_SHORTS_ADDRESS_RSSISTART_Msk,  /**< Shortcut between ADDRESS event and RSSISTART task. */
     NRF_RADIO_SHORT_END_START_MASK          = RADIO_SHORTS_END_START_Msk,          /**< Shortcut between END event and START task. */
     NRF_RADIO_SHORT_ADDRESS_BCSTART_MASK    = RADIO_SHORTS_ADDRESS_BCSTART_Msk,    /**< Shortcut between ADDRESS event and BCSTART task. */
+#if defined(RADIO_SHORTS_DISABLED_RSSISTOP_Msk) || defined(__NRFX_DOXYGEN__)
     NRF_RADIO_SHORT_DISABLED_RSSISTOP_MASK  = RADIO_SHORTS_DISABLED_RSSISTOP_Msk,  /**< Shortcut between DISABLED event and RSSISTOP task. */
+#endif
 #if defined(RADIO_SHORTS_RXREADY_CCASTART_Msk) || defined(__NRFX_DOXYGEN__)
     NRF_RADIO_SHORT_RXREADY_CCASTART_MASK   = RADIO_SHORTS_RXREADY_CCASTART_Msk,   /**< Shortcut between RXREADY event and CCASTART task. */
 #endif
@@ -270,6 +382,12 @@ typedef enum
 /** @brief Types of RADIO TX power. */
 typedef enum
 {
+#if defined(RADIO_TXPOWER_TXPOWER_Pos10dBm) || defined(__NRFX_DOXYGEN__)
+    NRF_RADIO_TXPOWER_POS10DBM = RADIO_TXPOWER_TXPOWER_Pos10dBm, /**< 10 dBm. */
+#endif
+#if defined(RADIO_TXPOWER_TXPOWER_Pos9dBm) || defined(__NRFX_DOXYGEN__)
+    NRF_RADIO_TXPOWER_POS9DBM  = RADIO_TXPOWER_TXPOWER_Pos9dBm,  /**< 9 dBm. */
+#endif
 #if defined(RADIO_TXPOWER_TXPOWER_Pos8dBm) || defined(__NRFX_DOXYGEN__)
     NRF_RADIO_TXPOWER_POS8DBM  = RADIO_TXPOWER_TXPOWER_Pos8dBm,  /**< 8 dBm. */
 #endif
@@ -290,6 +408,9 @@ typedef enum
 #endif
 #if defined(RADIO_TXPOWER_TXPOWER_Pos2dBm) || defined(__NRFX_DOXYGEN__)
     NRF_RADIO_TXPOWER_POS2DBM  = RADIO_TXPOWER_TXPOWER_Pos2dBm,  /**< 2 dBm. */
+#endif
+#if defined(RADIO_TXPOWER_TXPOWER_Pos1dBm) || defined(__NRFX_DOXYGEN__)
+    NRF_RADIO_TXPOWER_POS1DBM  = RADIO_TXPOWER_TXPOWER_Pos1dBm,  /**< 1 dBm. */
 #endif
     NRF_RADIO_TXPOWER_0DBM     = RADIO_TXPOWER_TXPOWER_0dBm,     /**< 0 dBm. */
 #if defined(RADIO_TXPOWER_TXPOWER_Neg1dBm) || defined(__NRFX_DOXYGEN__)
@@ -319,6 +440,9 @@ typedef enum
 #if defined(RADIO_TXPOWER_TXPOWER_Neg40dBm) || defined(__NRFX_DOXYGEN__)
     NRF_RADIO_TXPOWER_NEG40DBM = RADIO_TXPOWER_TXPOWER_Neg40dBm, /**< -40 dBm. */
 #endif
+#if defined(RADIO_TXPOWER_TXPOWER_Neg70dBm) || defined(__NRFX_DOXYGEN__)
+    NRF_RADIO_TXPOWER_NEG70DBM = RADIO_TXPOWER_TXPOWER_Neg70dBm, /**< -70 dBm. */
+#endif
 } nrf_radio_txpower_t;
 
 /** @brief Types of RADIO modes (data rate and modulation). */
@@ -328,6 +452,12 @@ typedef enum
     NRF_RADIO_MODE_NRF_2MBIT          = RADIO_MODE_MODE_Nrf_2Mbit,          /**< 2Mbit/s Nordic proprietary radio mode. */
 #if defined(RADIO_MODE_MODE_Nrf_250Kbit) || defined(__NRFX_DOXYGEN__)
     NRF_RADIO_MODE_NRF_250KBIT        = RADIO_MODE_MODE_Nrf_250Kbit,        /**< 250Kbit/s Nordic proprietary radio mode. */
+#endif
+#if defined(RADIO_MODE_MODE_Nrf_4Mbit0_5) || defined(__NRFX_DOXYGEN__)
+    NRF_RADIO_MODE_NRF_4MBIT_H_0_5    = RADIO_MODE_MODE_Nrf_4Mbit0_5,       /*!< 4Mbit/s Nordic proprietary radio mode (BT=0.5/h=0.5). */
+#endif
+#if defined(RADIO_MODE_MODE_Nrf_4Mbit0_25) || defined(__NRFX_DOXYGEN__)
+    NRF_RADIO_MODE_NRF_4MBIT_H_0_25   = RADIO_MODE_MODE_Nrf_4Mbit0_25,      /*!< 4Mbit/s Nordic proprietary radio mode (BT=0.5/h=0.25). */
 #endif
     NRF_RADIO_MODE_BLE_1MBIT          = RADIO_MODE_MODE_Ble_1Mbit,          /**< 1 Mbit/s Bluetooth Low Energy. */
 #if defined(RADIO_MODE_MODE_Ble_2Mbit) || defined(__NRFX_DOXYGEN__)
@@ -503,6 +633,9 @@ typedef struct
     nrf_radio_dfectrl_sample_spacing_t spacing_ref;    /**< Interval between samples in the reference period. */
     nrf_radio_dfectrl_sample_type_t    sample_type;    /**< Indicates whether to sample I/Q or magnitude/phase. */
     nrf_radio_dfectrl_sample_spacing_t sample_spacing; /**< Interval between samples in the switching period. */
+#if defined(RADIO_DFECTRL1_REPEATPATTERN_Msk)
+    uint8_t                            repeat_pattern; /**< Number of times antenna pattern should be repeated. */
+#endif
     uint8_t                            gain_steps;     /**< Number of gain steps lowering the total gain at the start of CTE . */
     int16_t                            switch_offset;  /**< Signed value offset after the end of the CRC before starting switching expressed in 16 Mhz cycles. */
     int16_t                            sample_offset;  /**< Signed value offset before starting sampling expressed in 16 Mhz cycles
@@ -1154,6 +1287,26 @@ NRF_STATIC_INLINE bool nrf_radio_modecnf0_ru_get(NRF_RADIO_Type const * p_reg);
 NRF_STATIC_INLINE uint8_t nrf_radio_modecnf0_dtx_get(NRF_RADIO_Type const * p_reg);
 #endif // defined(RADIO_MODECNF0_RU_Msk) || defined(__NRFX_DOXYGEN__)
 
+#if defined(RADIO_MODECNF0_RU_Msk) || defined(RADIO_TIMING_RU_Msk) || defined(__NRFX_DOXYGEN__)
+/**
+ * @brief Function for enabling or disabling fast ramp-up setting.
+ *
+ * @param[in] p_reg  Pointer to the structure of registers of the peripheral.
+ * @param[in] enable True if fast ramp-up is to be enabled, false otherwise.
+ */
+NRF_STATIC_INLINE void nrf_radio_fast_ramp_up_enable_set(NRF_RADIO_Type * p_reg, bool enable);
+
+/**
+ * @brief Function for checking fast ramp-up time configuration.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ *
+ * @return true  If the ramp-up time is set to fast.
+ * @return false If the ramp-up time is set to default compatible with 180nm radio.
+ */
+NRF_STATIC_INLINE bool nrf_radio_fast_ramp_up_check(NRF_RADIO_Type const * p_reg);
+#endif
+
 #if defined(RADIO_SFD_SFD_Msk) || defined(__NRFX_DOXYGEN__)
 /**
  * @brief Function for setting IEEE 802.15.4 start of frame delimiter.
@@ -1173,7 +1326,7 @@ NRF_STATIC_INLINE void nrf_radio_sfd_set(NRF_RADIO_Type * p_reg, uint8_t sfd);
 NRF_STATIC_INLINE uint8_t nrf_radio_sfd_get(NRF_RADIO_Type const * p_reg);
 #endif // defined(RADIO_SFD_SFD_Msk) || defined(__NRFX_DOXYGEN__)
 
-#if defined(RADIO_EDCNT_EDCNT_Msk) || defined(__NRFX_DOXYGEN__)
+#if defined(RADIO_EDCNT_EDCNT_Msk) || defined(RADIO_EDCTRL_EDCNT_Msk) || defined(__NRFX_DOXYGEN__)
 /**
  * @brief Function for setting number of iterations to perform ED scan.
  *
@@ -1181,7 +1334,17 @@ NRF_STATIC_INLINE uint8_t nrf_radio_sfd_get(NRF_RADIO_Type const * p_reg);
  * @param[in] ed_loop_count Number of iterations during ED procedure.
  */
 NRF_STATIC_INLINE void nrf_radio_ed_loop_count_set(NRF_RADIO_Type * p_reg, uint32_t ed_loop_count);
-#endif // defined(RADIO_EDCNT_EDCNT_Msk) || defined(__NRFX_DOXYGEN__)
+#endif // defined(RADIO_EDCNT_EDCNT_Msk) || defined(RADIO_EDCTRL_EDCNT_Msk) || defined(__NRFX_DOXYGEN__)
+
+#if defined(RADIO_EDCTRL_EDPERIOD_Msk) || defined(__NRFX_DOXYGEN__)
+/**
+ * @brief Function for setting the period of a ED/CCA iteration.
+ *
+ * @param[in] p_reg     Pointer to the structure of registers of the peripheral.
+ * @param[in] ed_period Duration of a single ED/CCA iteration.
+ */
+NRF_STATIC_INLINE void nrf_radio_ed_cca_period_set(NRF_RADIO_Type * p_reg, uint8_t ed_period);
+#endif // defined(RADIO_EDCTRL_EDPERIOD_Msk) || defined(__NRFX_DOXYGEN__)
 
 #if defined(RADIO_EDSAMPLE_EDLVL_Msk) || defined(__NRFX_DOXYGEN__)
 /**
@@ -1213,6 +1376,7 @@ NRF_STATIC_INLINE void nrf_radio_cca_configure(NRF_RADIO_Type *     p_reg,
                                                uint8_t              cca_corr_cnt);
 #endif // defined(RADIO_CCACTRL_CCAMODE_Msk) || defined(__NRFX_DOXYGEN__)
 
+#if defined(RADIO_POWER_POWER_Msk) || defined(__NRFX_DOXYGEN__)
 /**
  * @brief Function for setting power mode of the radio peripheral.
  *
@@ -1220,6 +1384,7 @@ NRF_STATIC_INLINE void nrf_radio_cca_configure(NRF_RADIO_Type *     p_reg,
  * @param[in] radio_power If radio should be powered on.
  */
 NRF_STATIC_INLINE void nrf_radio_power_set(NRF_RADIO_Type * p_reg, bool radio_power);
+#endif // defined(RADIO_POWER_POWER_Msk) || defined(__NRFX_DOXYGEN__)
 
 #if defined(RADIO_CTESTATUS_CTETIME_Msk) || defined(__NRFX_DOXYGEN__)
 /**
@@ -1381,6 +1546,19 @@ NRF_STATIC_INLINE void nrf_radio_dfe_buffer_set(NRF_RADIO_Type * p_reg,
  * @retval Amount of samples.
  */
 NRF_STATIC_INLINE uint32_t nrf_radio_dfe_amount_get(NRF_RADIO_Type const * p_reg);
+
+#if defined(RADIO_DFEPACKET_CURRENTAMOUNT_AMOUNT_Msk)
+/**
+ * @brief Function for getting the number of bytes transferred in the current transaction.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ *
+ * @return Number of bytes.
+ */
+NRF_STATIC_INLINE uint32_t nrf_radio_dfe_current_amount_get(NRF_RADIO_Type const * p_reg);
+
+#endif
+
 #endif
 
 #ifndef NRF_DECLARE_ONLY
@@ -1435,17 +1613,29 @@ NRF_STATIC_INLINE uint32_t nrf_radio_shorts_get(NRF_RADIO_Type const * p_reg)
 
 NRF_STATIC_INLINE void nrf_radio_int_enable(NRF_RADIO_Type * p_reg, uint32_t mask)
 {
+#if defined(RADIO_INTENSET_READY_Msk)
     p_reg->INTENSET = mask;
+#elif defined(RADIO_INTENSET00_READY_Msk)
+    p_reg->INTENSET00 = mask;
+#endif
 }
 
 NRF_STATIC_INLINE void nrf_radio_int_disable(NRF_RADIO_Type * p_reg, uint32_t mask)
 {
+#if defined(RADIO_INTENCLR_READY_Msk)
     p_reg->INTENCLR = mask;
+#elif defined(RADIO_INTENCLR00_READY_Msk)
+    p_reg->INTENCLR00 = mask;
+#endif
 }
 
 NRF_STATIC_INLINE uint32_t nrf_radio_int_enable_check(NRF_RADIO_Type const * p_reg, uint32_t mask)
 {
+#if defined(RADIO_INTENSET_READY_Msk)
     return p_reg->INTENSET & mask;
+#elif defined(RADIO_INTENSET00_READY_Msk)
+    return p_reg->INTENSET00 & mask;
+#endif
 }
 
 #if defined(DPPI_PRESENT)
@@ -1453,28 +1643,28 @@ NRF_STATIC_INLINE void nrf_radio_subscribe_set(NRF_RADIO_Type * p_reg,
                                                nrf_radio_task_t task,
                                                uint8_t          channel)
 {
-    *((volatile uint32_t *) ((uint8_t *) p_reg + (uint32_t) task + 0x80uL)) =
-            ((uint32_t)channel | RADIO_SUBSCRIBE_TXEN_EN_Msk);
+    *((volatile uint32_t *) ((uint8_t *) p_reg + (uint32_t) task + NRF_RADIO_DPPI_OFFSET)) =
+            ((uint32_t)channel | NRF_SUBSCRIBE_PUBLISH_ENABLE);
 }
 
 NRF_STATIC_INLINE void nrf_radio_subscribe_clear(NRF_RADIO_Type * p_reg,
                                                  nrf_radio_task_t task)
 {
-    *((volatile uint32_t *) ((uint8_t *) p_reg + (uint32_t) task + 0x80uL)) = 0;
+    *((volatile uint32_t *) ((uint8_t *) p_reg + (uint32_t) task + NRF_RADIO_DPPI_OFFSET)) = 0;
 }
 
 NRF_STATIC_INLINE void nrf_radio_publish_set(NRF_RADIO_Type *  p_reg,
                                              nrf_radio_event_t event,
                                              uint8_t           channel)
 {
-    *((volatile uint32_t *) ((uint8_t *) p_reg + (uint32_t) event + 0x80uL)) =
-            ((uint32_t)channel | RADIO_PUBLISH_READY_EN_Msk);
+    *((volatile uint32_t *) ((uint8_t *) p_reg + (uint32_t) event + NRF_RADIO_DPPI_OFFSET)) =
+            ((uint32_t)channel | NRF_SUBSCRIBE_PUBLISH_ENABLE);
 }
 
 NRF_STATIC_INLINE void nrf_radio_publish_clear(NRF_RADIO_Type *  p_reg,
                                                nrf_radio_event_t event)
 {
-    *((volatile uint32_t *) ((uint8_t *) p_reg + (uint32_t) event + 0x80uL)) = 0;
+    *((volatile uint32_t *) ((uint8_t *) p_reg + (uint32_t) event + NRF_RADIO_DPPI_OFFSET)) = 0;
 }
 #endif // defined(DPPI_PRESENT)
 
@@ -1533,13 +1723,11 @@ NRF_STATIC_INLINE void nrf_radio_frequency_set(NRF_RADIO_Type * p_reg, uint16_t 
     uint32_t delta;
     if (radio_frequency < 2400)
     {
-        delta = ((uint32_t)(radio_frequency - 2360)) |
-                (RADIO_FREQUENCY_MAP_Low << RADIO_FREQUENCY_MAP_Pos);
+        delta = (uint32_t)(radio_frequency - 2360) | RADIO_FREQUENCY_MAP_Msk;
     }
     else
     {
-        delta = ((uint32_t)(radio_frequency - 2400)) |
-                (RADIO_FREQUENCY_MAP_Default << RADIO_FREQUENCY_MAP_Pos);
+        delta = (uint32_t)(radio_frequency - 2400);
     }
 
     p_reg->FREQUENCY = delta;
@@ -1554,8 +1742,7 @@ NRF_STATIC_INLINE uint16_t nrf_radio_frequency_get(NRF_RADIO_Type const * p_reg)
     uint32_t freq;
 
 #if defined(RADIO_FREQUENCY_MAP_Msk)
-    if (((p_reg->FREQUENCY & RADIO_FREQUENCY_MAP_Msk) >> RADIO_FREQUENCY_MAP_Pos) ==
-        RADIO_FREQUENCY_MAP_Low)
+    if ((p_reg->FREQUENCY & RADIO_FREQUENCY_MAP_Msk) == RADIO_FREQUENCY_MAP_Msk)
     {
         freq = 2360;
     }
@@ -1566,7 +1753,7 @@ NRF_STATIC_INLINE uint16_t nrf_radio_frequency_get(NRF_RADIO_Type const * p_reg)
     }
     freq += p_reg->FREQUENCY & RADIO_FREQUENCY_FREQUENCY_Msk;
 
-    return freq;
+    return (uint16_t)freq;
 }
 
 NRF_STATIC_INLINE void nrf_radio_txpower_set(NRF_RADIO_Type * p_reg, nrf_radio_txpower_t tx_power)
@@ -1785,26 +1972,26 @@ NRF_STATIC_INLINE void nrf_radio_dacnf_set(NRF_RADIO_Type * p_reg, uint8_t ena, 
 
 NRF_STATIC_INLINE uint8_t nrf_radio_dacnf_ena_get(NRF_RADIO_Type const * p_reg)
 {
-    return (p_reg->DACNF & (RADIO_DACNF_ENA0_Msk |
-                            RADIO_DACNF_ENA1_Msk |
-                            RADIO_DACNF_ENA2_Msk |
-                            RADIO_DACNF_ENA3_Msk |
-                            RADIO_DACNF_ENA4_Msk |
-                            RADIO_DACNF_ENA5_Msk |
-                            RADIO_DACNF_ENA6_Msk |
-                            RADIO_DACNF_ENA7_Msk)) >> RADIO_DACNF_ENA0_Pos;
+    return (uint8_t)((p_reg->DACNF & (RADIO_DACNF_ENA0_Msk |
+                                      RADIO_DACNF_ENA1_Msk |
+                                      RADIO_DACNF_ENA2_Msk |
+                                      RADIO_DACNF_ENA3_Msk |
+                                      RADIO_DACNF_ENA4_Msk |
+                                      RADIO_DACNF_ENA5_Msk |
+                                      RADIO_DACNF_ENA6_Msk |
+                                      RADIO_DACNF_ENA7_Msk)) >> RADIO_DACNF_ENA0_Pos);
 }
 
 NRF_STATIC_INLINE uint8_t nrf_radio_dacnf_txadd_get(NRF_RADIO_Type const * p_reg)
 {
-    return (p_reg->DACNF & (RADIO_DACNF_TXADD0_Msk |
-                            RADIO_DACNF_TXADD1_Msk |
-                            RADIO_DACNF_TXADD2_Msk |
-                            RADIO_DACNF_TXADD3_Msk |
-                            RADIO_DACNF_TXADD4_Msk |
-                            RADIO_DACNF_TXADD5_Msk |
-                            RADIO_DACNF_TXADD6_Msk |
-                            RADIO_DACNF_TXADD7_Msk)) >> RADIO_DACNF_TXADD0_Pos;
+    return (uint8_t)((p_reg->DACNF & (RADIO_DACNF_TXADD0_Msk |
+                                      RADIO_DACNF_TXADD1_Msk |
+                                      RADIO_DACNF_TXADD2_Msk |
+                                      RADIO_DACNF_TXADD3_Msk |
+                                      RADIO_DACNF_TXADD4_Msk |
+                                      RADIO_DACNF_TXADD5_Msk |
+                                      RADIO_DACNF_TXADD6_Msk |
+                                      RADIO_DACNF_TXADD7_Msk)) >> RADIO_DACNF_TXADD0_Pos);
 }
 
 #if defined(RADIO_INTENSET_MHRMATCH_Msk)
@@ -1853,6 +2040,30 @@ NRF_STATIC_INLINE uint8_t nrf_radio_modecnf0_dtx_get(NRF_RADIO_Type const * p_re
 }
 #endif // defined(RADIO_MODECNF0_RU_Msk)
 
+#if defined(RADIO_MODECNF0_RU_Msk) || defined(RADIO_TIMING_RU_Msk)
+NRF_STATIC_INLINE void nrf_radio_fast_ramp_up_enable_set(NRF_RADIO_Type * p_reg, bool enable)
+{
+#if defined(RADIO_TIMING_RU_Msk)
+    p_reg->TIMING = (enable ? RADIO_TIMING_RU_Fast : RADIO_TIMING_RU_Default) <<
+                    RADIO_TIMING_RU_Pos;
+#elif defined(RADIO_MODECNF0_RU_Msk)
+    p_reg->MODECNF0 = ((p_reg->MODECNF0 & (~RADIO_MODECNF0_RU_Msk)) |
+                       (enable ? RADIO_MODECNF0_RU_Fast : RADIO_MODECNF0_RU_Default) <<
+                       RADIO_MODECNF0_RU_Pos);
+#endif
+}
+
+NRF_STATIC_INLINE bool nrf_radio_fast_ramp_up_check(NRF_RADIO_Type const * p_reg)
+{
+#if defined(RADIO_TIMING_RU_Msk)
+    return ((p_reg->TIMING & RADIO_TIMING_RU_Msk) >> RADIO_TIMING_RU_Pos) == RADIO_TIMING_RU_Fast;
+#elif defined(RADIO_MODECNF0_RU_Msk)
+    return ((p_reg->MODECNF0 & RADIO_MODECNF0_RU_Msk) >> RADIO_MODECNF0_RU_Pos) ==
+           RADIO_MODECNF0_RU_Fast;
+#endif
+}
+#endif
+
 #if defined(RADIO_SFD_SFD_Msk)
 NRF_STATIC_INLINE void nrf_radio_sfd_set(NRF_RADIO_Type * p_reg, uint8_t sfd)
 {
@@ -1865,10 +2076,23 @@ NRF_STATIC_INLINE uint8_t nrf_radio_sfd_get(NRF_RADIO_Type const * p_reg)
 }
 #endif // defined(RADIO_SFD_SFD_Msk)
 
-#if defined(RADIO_EDCNT_EDCNT_Msk)
+#if defined(RADIO_EDCNT_EDCNT_Msk) || defined(RADIO_EDCTRL_EDCNT_Msk)
 NRF_STATIC_INLINE void nrf_radio_ed_loop_count_set(NRF_RADIO_Type * p_reg, uint32_t ed_loop_count)
 {
+#if defined(RADIO_EDCNT_EDCNT_Msk)
     p_reg->EDCNT = (ed_loop_count & RADIO_EDCNT_EDCNT_Msk);
+#elif defined(RADIO_EDCTRL_EDCNT_Msk)
+    p_reg->EDCTRL = ((p_reg->EDCTRL & ~RADIO_EDCTRL_EDCNT_Msk) |
+                     ((ed_loop_count << RADIO_EDCTRL_EDCNT_Pos) & RADIO_EDCTRL_EDCNT_Msk));
+#endif
+}
+#endif
+
+#if defined(RADIO_EDCTRL_EDPERIOD_Msk)
+NRF_STATIC_INLINE void nrf_radio_ed_cca_period_set(NRF_RADIO_Type * p_reg, uint8_t ed_period)
+{
+    p_reg->EDCTRL = ((p_reg->EDCTRL & ~RADIO_EDCTRL_EDPERIOD_Msk) |
+                     ((ed_period << RADIO_EDCTRL_EDPERIOD_Pos) & RADIO_EDCTRL_EDPERIOD_Msk));
 }
 #endif
 
@@ -1893,11 +2117,13 @@ NRF_STATIC_INLINE void nrf_radio_cca_configure(NRF_RADIO_Type *     p_reg,
 }
 #endif
 
+#if defined(RADIO_POWER_POWER_Msk)
 NRF_STATIC_INLINE void nrf_radio_power_set(NRF_RADIO_Type * p_reg, bool radio_power)
 {
     p_reg->POWER = (radio_power ? RADIO_POWER_POWER_Enabled : RADIO_POWER_POWER_Disabled)
                    << RADIO_POWER_POWER_Pos;
 }
+#endif
 
 #if defined(RADIO_CTESTATUS_CTETIME_Msk)
 NRF_STATIC_INLINE uint32_t nrf_radio_cte_time_get(NRF_RADIO_Type const * p_reg)
@@ -1970,6 +2196,10 @@ NRF_STATIC_INLINE void nrf_radio_dfectrl_configure(NRF_RADIO_Type *             
                        ((uint32_t)p_config->spacing_ref << RADIO_DFECTRL1_TSAMPLESPACINGREF_Pos) |
                        ((uint32_t)p_config->sample_type << RADIO_DFECTRL1_SAMPLETYPE_Pos) |
                        ((uint32_t)p_config->sample_spacing << RADIO_DFECTRL1_TSAMPLESPACING_Pos) |
+#if defined(RADIO_DFECTRL1_REPEATPATTERN_Msk)
+                       (((uint32_t)p_config->repeat_pattern << RADIO_DFECTRL1_REPEATPATTERN_Pos) &
+                            RADIO_DFECTRL1_REPEATPATTERN_Msk) |
+#endif
                        (((uint32_t)p_config->gain_steps << RADIO_DFECTRL1_AGCBACKOFFGAIN_Pos) &
                             RADIO_DFECTRL1_AGCBACKOFFGAIN_Msk));
 
@@ -2010,8 +2240,7 @@ NRF_STATIC_INLINE uint32_t nrf_radio_dfe_pattern_cnt_get(NRF_RADIO_Type const * 
 
 NRF_STATIC_INLINE void nrf_radio_dfe_pattern_clear(NRF_RADIO_Type * p_reg)
 {
-    p_reg->CLEARPATTERN = RADIO_CLEARPATTERN_CLEARPATTERN_Clear <<
-                          RADIO_CLEARPATTERN_CLEARPATTERN_Pos;
+    p_reg->CLEARPATTERN = RADIO_CLEARPATTERN_CLEARPATTERN_Msk;
 }
 #endif
 
@@ -2021,13 +2250,25 @@ NRF_STATIC_INLINE void nrf_radio_dfe_buffer_set(NRF_RADIO_Type * p_reg,
                                                 size_t           length)
 {
     p_reg->DFEPACKET.PTR    = (uint32_t)p_buffer;
+#if defined(RADIO_DFEPACKET_MAX_MAX_Msk)
+    p_reg->DFEPACKET.MAX    = length;
+#else
     p_reg->DFEPACKET.MAXCNT = length;
+#endif
 }
 
 NRF_STATIC_INLINE uint32_t nrf_radio_dfe_amount_get(NRF_RADIO_Type const * p_reg)
 {
     return p_reg->DFEPACKET.AMOUNT;
 }
+
+#if defined(RADIO_DFEPACKET_CURRENTAMOUNT_AMOUNT_Msk)
+NRF_STATIC_INLINE uint32_t nrf_radio_dfe_current_amount_get(NRF_RADIO_Type const * p_reg)
+{
+    return p_reg->DFEPACKET.CURRENTAMOUNT;
+}
+#endif
+
 #endif
 
 #endif // NRF_DECLARE_ONLY

--- a/nrfx/hal/nrf_reset.h
+++ b/nrfx/hal/nrf_reset.h
@@ -65,25 +65,55 @@ extern "C" {
 /** @brief Reset reason bit masks. */
 typedef enum
 {
-    NRF_RESET_RESETREAS_RESETPIN_MASK  = RESET_RESETREAS_RESETPIN_Msk,  ///< Bit mask of RESETPIN field.
-    NRF_RESET_RESETREAS_DOG0_MASK      = RESET_RESETREAS_DOG0_Msk,      ///< Bit mask of DOG0 field.
-    NRF_RESET_RESETREAS_CTRLAP_MASK    = RESET_RESETREAS_CTRLAP_Msk,    ///< Bit mask of CTRLAP field.
-    NRF_RESET_RESETREAS_SREQ_MASK      = RESET_RESETREAS_SREQ_Msk,      ///< Bit mask of SREQ field.
-    NRF_RESET_RESETREAS_LOCKUP_MASK    = RESET_RESETREAS_LOCKUP_Msk,    ///< Bit mask of LOCKUP field.
-    NRF_RESET_RESETREAS_OFF_MASK       = RESET_RESETREAS_OFF_Msk,       ///< Bit mask of OFF field.
-    NRF_RESET_RESETREAS_LPCOMP_MASK    = RESET_RESETREAS_LPCOMP_Msk,    ///< Bit mask of LPCOMP field.
-    NRF_RESET_RESETREAS_DIF_MASK       = RESET_RESETREAS_DIF_Msk,       ///< Bit mask of DIF field.
-#if NRF_RESET_HAS_NETWORK
-    NRF_RESET_RESETREAS_LSREQ_MASK     = RESET_RESETREAS_LSREQ_Msk,     ///< Bit mask of LSREQ field.
-    NRF_RESET_RESETREAS_LLOCKUP_MASK   = RESET_RESETREAS_LLOCKUP_Msk,   ///< Bit mask of LLOCKUP field.
-    NRF_RESET_RESETREAS_LDOG_MASK      = RESET_RESETREAS_LDOG_Msk,      ///< Bit mask of LDOG field.
-    NRF_RESET_RESETREAS_MFORCEOFF_MASK = RESET_RESETREAS_MFORCEOFF_Msk, ///< Bit mask of MFORCEOFF field.
+    NRF_RESET_RESETREAS_RESETPIN_MASK   = RESET_RESETREAS_RESETPIN_Msk,   ///< Bit mask of RESETPIN field.
+    NRF_RESET_RESETREAS_DOG0_MASK       = RESET_RESETREAS_DOG0_Msk,       ///< Bit mask of DOG0 field.
+    NRF_RESET_RESETREAS_SREQ_MASK       = RESET_RESETREAS_SREQ_Msk,       ///< Bit mask of SREQ field.
+    NRF_RESET_RESETREAS_LOCKUP_MASK     = RESET_RESETREAS_LOCKUP_Msk,     ///< Bit mask of LOCKUP field.
+    NRF_RESET_RESETREAS_OFF_MASK        = RESET_RESETREAS_OFF_Msk,        ///< Bit mask of OFF field.
+    NRF_RESET_RESETREAS_DIF_MASK        = RESET_RESETREAS_DIF_Msk,        ///< Bit mask of DIF field.
+    NRF_RESET_RESETREAS_NFC_MASK        = RESET_RESETREAS_NFC_Msk,        ///< Bit mask of NFC field.
+    NRF_RESET_RESETREAS_DOG1_MASK       = RESET_RESETREAS_DOG1_Msk,       ///< Bit mask of DOG1 field.
+#if defined(RESET_RESETREAS_CTRLAPSOFT_Msk) || defined(__NRFX_DOXYGEN__)
+    NRF_RESET_RESETREAS_CTRLAPSOFT_MASK = RESET_RESETREAS_CTRLAPSOFT_Msk, ///< Bit mask of CTRLAPSOFT field.
 #endif
-    NRF_RESET_RESETREAS_NFC_MASK       = RESET_RESETREAS_NFC_Msk,       ///< Bit mask of NFC field.
-    NRF_RESET_RESETREAS_DOG1_MASK      = RESET_RESETREAS_DOG1_Msk,      ///< Bit mask of DOG1 field.
-    NRF_RESET_RESETREAS_VBUS_MASK      = RESET_RESETREAS_VBUS_Msk,      ///< Bit mask of VBUS field.
+#if defined(RESET_RESETREAS_CTRLAPHARD_Msk) || defined(__NRFX_DOXYGEN__)
+    NRF_RESET_RESETREAS_CTRLAPHARD_MASK = RESET_RESETREAS_CTRLAPHARD_Msk, ///< Bit mask of CTRLAPHARD field.
+#endif
+#if defined(RESET_RESETREAS_CTRLAPPIN_Msk) || defined(__NRFX_DOXYGEN__)
+    NRF_RESET_RESETREAS_CTRLAPPIN_MASK  = RESET_RESETREAS_CTRLAPPIN_Msk,  ///< Bit mask of CTRLAPPIN field.
+#endif
+#if defined(RESET_RESETREAS_CTRLAP_Msk) || defined(__NRFX_DOXYGEN__)
+    NRF_RESET_RESETREAS_CTRLAP_MASK     = RESET_RESETREAS_CTRLAP_Msk,     ///< Bit mask of CTRLAP field.
+#endif
+#if defined(RESET_RESETREAS_LPCOMP_Msk) || defined(__NRFX_DOXYGEN__)
+    NRF_RESET_RESETREAS_LPCOMP_MASK     = RESET_RESETREAS_LPCOMP_Msk,     ///< Bit mask of LPCOMP field.
+#endif
 #if NRF_RESET_HAS_NETWORK
-    NRF_RESET_RESETREAS_LCTRLAP_MASK   = RESET_RESETREAS_LCTRLAP_Msk,   ///< Bit mask of LCTRLAP field.
+    NRF_RESET_RESETREAS_LSREQ_MASK      = RESET_RESETREAS_LSREQ_Msk,      ///< Bit mask of LSREQ field.
+#endif
+#if defined(RESET_RESETREAS_LLOCKUP_Msk) || defined(__NRFX_DOXYGEN__)
+    NRF_RESET_RESETREAS_LLOCKUP_MASK    = RESET_RESETREAS_LLOCKUP_Msk,    ///< Bit mask of LLOCKUP field.
+#endif
+#if defined(RESET_RESETREAS_LDOG_Msk) || defined(__NRFX_DOXYGEN__)
+    NRF_RESET_RESETREAS_LDOG_MASK       = RESET_RESETREAS_LDOG_Msk,       ///< Bit mask of LDOG field.
+#endif
+#if defined(RESET_RESETREAS_MFORCEOFF_Msk) || defined(__NRFX_DOXYGEN__)
+    NRF_RESET_RESETREAS_MFORCEOFF_MASK  = RESET_RESETREAS_MFORCEOFF_Msk,  ///< Bit mask of MFORCEOFF field.
+#endif
+#if defined(RESET_RESETREAS_GRTC_Msk) || defined(__NRFX_DOXYGEN__)
+    NRF_RESET_RESETREAS_GRTC_MASK       = RESET_RESETREAS_GRTC_Msk,       ///< Bit mask of GRTC field.
+#endif
+#if defined(RESET_RESETREAS_VBUS_Msk) || defined(__NRFX_DOXYGEN__)
+    NRF_RESET_RESETREAS_VBUS_MASK       = RESET_RESETREAS_VBUS_Msk,       ///< Bit mask of VBUS field.
+#endif
+#if NRF_RESET_HAS_NETWORK
+    NRF_RESET_RESETREAS_LCTRLAP_MASK    = RESET_RESETREAS_LCTRLAP_Msk,    ///< Bit mask of LCTRLAP field.
+#endif
+#if defined(RESET_RESETREAS_VMON_Msk) || defined(__NRFX_DOXYGEN__)
+    NRF_RESET_RESETREAS_VMON_MASK       = RESET_RESETREAS_VMON_Msk,       ///< Bit mask of VMON field.
+#endif
+#if defined(NRF_RESET_RESETREAS_EXT)
+    NRF_RESET_RESETREAS_EXT
 #endif
 } nrf_reset_resetreas_mask_t;
 

--- a/nrfx/hal/nrf_rng.h
+++ b/nrfx/hal/nrf_rng.h
@@ -314,7 +314,7 @@ NRF_STATIC_INLINE void nrf_rng_subscribe_set(NRF_RNG_Type * p_reg,
                                              uint8_t        channel)
 {
     *((volatile uint32_t *) ((uint8_t *) p_reg + (uint32_t) task + 0x80uL)) =
-            ((uint32_t)channel | RNG_SUBSCRIBE_START_EN_Msk);
+            ((uint32_t)channel | NRF_SUBSCRIBE_PUBLISH_ENABLE);
 }
 
 NRF_STATIC_INLINE void nrf_rng_subscribe_clear(NRF_RNG_Type * p_reg,
@@ -328,7 +328,7 @@ NRF_STATIC_INLINE void nrf_rng_publish_set(NRF_RNG_Type *  p_reg,
                                            uint8_t         channel)
 {
     *((volatile uint32_t *) ((uint8_t *) p_reg + (uint32_t) event + 0x80uL)) =
-            ((uint32_t)channel | RNG_PUBLISH_VALRDY_EN_Msk);
+            ((uint32_t)channel | NRF_SUBSCRIBE_PUBLISH_ENABLE);
 }
 
 NRF_STATIC_INLINE void nrf_rng_publish_clear(NRF_RNG_Type *  p_reg,

--- a/nrfx/hal/nrf_saadc.h
+++ b/nrfx/hal/nrf_saadc.h
@@ -47,6 +47,75 @@ extern "C" {
  * @brief   Hardware access layer for managing the SAADC peripheral.
  */
 
+/** @brief Symbol specifying the offset of interrupt bitmask for limits of all channels. */
+#define NRF_SAADC_LIMITS_INT_OFFSET \
+    NRFX_MIN(SAADC_INTENSET_CH0LIMITH_Pos, SAADC_INTENSET_CH0LIMITL_Pos)
+
+/** @brief Symbol specifying the interrupt bitmask for limits of all channels. */
+#define NRF_SAADC_ALL_CHANNELS_LIMITS_INT_MASK \
+    ((uint32_t)(((1 << SAADC_CH_NUM) - 1) << NRF_SAADC_LIMITS_INT_OFFSET))
+
+#if defined(SAADC_CH_CONFIG_TACQ_3us) || defined(__NRFX_DOXYGEN__)
+/** @brief Symbol indicating whether the configuration of acquisition time using predefined values is present. */
+#define NRF_SAADC_HAS_ACQTIME_ENUM 1
+#else
+#define NRF_SAADC_HAS_ACQTIME_ENUM 0
+#endif
+
+#if defined(SAADC_CH_CONFIG_TCONV_Msk) || defined(__NRFX_DOXYGEN__)
+/** @brief Symbol indicating whether the configuration of conversion time is present. */
+#define NRF_SAADC_HAS_CONVTIME 1
+#else
+#define NRF_SAADC_HAS_CONVTIME 0
+#endif
+
+#if defined(SAADC_TRIM_LINCALCOEFF_VAL_Msk) || defined(__NRFX_DOXYGEN__)
+/** @brief Symbol indicating whether the configuration of linearity calibration coefficients is present. */
+#define NRF_SAADC_HAS_LIN_CAL 1
+#else
+#define NRF_SAADC_HAS_LIN_CAL 0
+#endif
+
+#if defined(SAADC_CH_PSELP_PIN_Msk) || defined(__NRFX_DOXYGEN__)
+/** @brief Symbol indicating whether configuration of analog input using pin number is present. */
+#define NRF_SAADC_HAS_AIN_AS_PIN 1
+#else
+#define NRF_SAADC_HAS_AIN_AS_PIN 0
+#endif
+
+#if defined(SAADC_DMA_PTR_PTR_Msk) || defined(__NRFX_DOXYGEN__)
+/** @brief Symbol indicating whether dedicated DMA register is present. */
+#define NRF_SAADC_HAS_DMA_REG 1
+#else
+#define NRF_SAADC_HAS_DMA_REG 0
+#endif
+
+#if (defined(SAADC_TASKS_DMA_START_START_Msk) && defined(SAADC_EVENTS_DMA_END_END_Msk)) || \
+    defined(__NRFX_DOXYGEN__)
+/** @brief Symbol indicating whether SAADC DMA tasks and events are present. */
+#define NRF_SAADC_HAS_DMA_TASKS_EVENTS 1
+#else
+#define NRF_SAADC_HAS_DMA_TASKS_EVENTS 0
+#endif
+
+#if !NRF_SAADC_HAS_ACQTIME_ENUM
+/** @brief Maximum value of acquire time. */
+#define NRF_SAADC_ACQTIME_MAX SAADC_CH_CONFIG_TACQ_Max
+#endif
+
+#if NRF_SAADC_HAS_CONVTIME
+/** @brief Symbol specifying maximum value of conversion time. */
+#define NRF_SAADC_CONVTIME_MAX SAADC_CH_CONFIG_TCONV_Max
+#endif
+
+#if NRF_SAADC_HAS_LIN_CAL
+/** @brief Symbol specifying maximum count of linearity calibration coefficients. */
+#define NRF_SAADC_LIN_CAL_MAX_COUNT SAADC_TRIM_LINCALCOEFF_MaxCount
+
+/** @brief Symbol specifying maximum value of linearity calibration coefficient. */
+#define NRF_SAADC_LIN_CAL_MAX SAADC_TRIM_LINCALCOEFF_VAL_Max
+#endif
+
 /** @brief Resolution of the analog-to-digital converter. */
 typedef enum
 {
@@ -56,23 +125,51 @@ typedef enum
     NRF_SAADC_RESOLUTION_14BIT = SAADC_RESOLUTION_VAL_14bit  ///< 14 bit resolution.
 } nrf_saadc_resolution_t;
 
+#if NRF_SAADC_HAS_AIN_AS_PIN
+/** @brief Analog input type. */
+typedef uint32_t nrf_saadc_input_t;
+
+/** @brief Symbol specifying disconnected analog input. */
+#define NRF_SAADC_INPUT_DISABLED ((nrf_saadc_input_t)0)
+#else
 /** @brief Input selection for the analog-to-digital converter. */
 typedef enum
 {
-    NRF_SAADC_INPUT_DISABLED = SAADC_CH_PSELP_PSELP_NC,           ///< Not connected.
-    NRF_SAADC_INPUT_AIN0     = SAADC_CH_PSELP_PSELP_AnalogInput0, ///< Analog input 0 (AIN0).
-    NRF_SAADC_INPUT_AIN1     = SAADC_CH_PSELP_PSELP_AnalogInput1, ///< Analog input 1 (AIN1).
-    NRF_SAADC_INPUT_AIN2     = SAADC_CH_PSELP_PSELP_AnalogInput2, ///< Analog input 2 (AIN2).
-    NRF_SAADC_INPUT_AIN3     = SAADC_CH_PSELP_PSELP_AnalogInput3, ///< Analog input 3 (AIN3).
-    NRF_SAADC_INPUT_AIN4     = SAADC_CH_PSELP_PSELP_AnalogInput4, ///< Analog input 4 (AIN4).
-    NRF_SAADC_INPUT_AIN5     = SAADC_CH_PSELP_PSELP_AnalogInput5, ///< Analog input 5 (AIN5).
-    NRF_SAADC_INPUT_AIN6     = SAADC_CH_PSELP_PSELP_AnalogInput6, ///< Analog input 6 (AIN6).
-    NRF_SAADC_INPUT_AIN7     = SAADC_CH_PSELP_PSELP_AnalogInput7, ///< Analog input 7 (AIN7).
-    NRF_SAADC_INPUT_VDD      = SAADC_CH_PSELP_PSELP_VDD,          ///< VDD as input.
+    NRF_SAADC_INPUT_DISABLED = SAADC_CH_PSELP_PSELP_NC,            ///< Not connected.
+    NRF_SAADC_INPUT_AIN0     = SAADC_CH_PSELP_PSELP_AnalogInput0,  ///< Analog input 0 (AIN0).
+    NRF_SAADC_INPUT_AIN1     = SAADC_CH_PSELP_PSELP_AnalogInput1,  ///< Analog input 1 (AIN1).
+    NRF_SAADC_INPUT_AIN2     = SAADC_CH_PSELP_PSELP_AnalogInput2,  ///< Analog input 2 (AIN2).
+    NRF_SAADC_INPUT_AIN3     = SAADC_CH_PSELP_PSELP_AnalogInput3,  ///< Analog input 3 (AIN3).
+    NRF_SAADC_INPUT_AIN4     = SAADC_CH_PSELP_PSELP_AnalogInput4,  ///< Analog input 4 (AIN4).
+    NRF_SAADC_INPUT_AIN5     = SAADC_CH_PSELP_PSELP_AnalogInput5,  ///< Analog input 5 (AIN5).
+    NRF_SAADC_INPUT_AIN6     = SAADC_CH_PSELP_PSELP_AnalogInput6,  ///< Analog input 6 (AIN6).
+    NRF_SAADC_INPUT_AIN7     = SAADC_CH_PSELP_PSELP_AnalogInput7,  ///< Analog input 7 (AIN7).
+#if defined(SAADC_CH_PSELP_PSELP_VDD) || defined(__NRFX_DOXYGEN__)
+    NRF_SAADC_INPUT_VDD      = SAADC_CH_PSELP_PSELP_VDD,           ///< VDD as input.
+#endif
 #if defined(SAADC_CH_PSELP_PSELP_VDDHDIV5) || defined(__NRFX_DOXYGEN__)
-    NRF_SAADC_INPUT_VDDHDIV5 = SAADC_CH_PSELP_PSELP_VDDHDIV5      ///< VDDH/5 as input.
+    NRF_SAADC_INPUT_VDDHDIV5 = SAADC_CH_PSELP_PSELP_VDDHDIV5       ///< VDDH/5 as input.
+#endif
+#if defined(SAADC_CH_PSELP_PSELP_AnalogInput8) || defined(__NRFX_DOXYGEN__)
+    NRF_SAADC_INPUT_AIN8     = SAADC_CH_PSELP_PSELP_AnalogInput8,  ///< Analog input 8 (AIN8).
+#endif
+#if defined(SAADC_CH_PSELP_PSELP_AnalogInput9) || defined(__NRFX_DOXYGEN__)
+    NRF_SAADC_INPUT_AIN9     = SAADC_CH_PSELP_PSELP_AnalogInput9,  ///< Analog input 9 (AIN9).
+#endif
+#if defined(SAADC_CH_PSELP_PSELP_AnalogInput10) || defined(__NRFX_DOXYGEN__)
+    NRF_SAADC_INPUT_AIN10    = SAADC_CH_PSELP_PSELP_AnalogInput10, ///< Analog input 10 (AIN10).
+#endif
+#if defined(SAADC_CH_PSELP_PSELP_AnalogInput11) || defined(__NRFX_DOXYGEN__)
+    NRF_SAADC_INPUT_AIN11    = SAADC_CH_PSELP_PSELP_AnalogInput11, ///< Analog input 11 (AIN11).
+#endif
+#if defined(SAADC_CH_PSELP_PSELP_AnalogInput12) || defined(__NRFX_DOXYGEN__)
+    NRF_SAADC_INPUT_AIN12    = SAADC_CH_PSELP_PSELP_AnalogInput12, ///< Analog input 12 (AIN12).
+#endif
+#if defined(SAADC_CH_PSELP_PSELP_AnalogInput13) || defined(__NRFX_DOXYGEN__)
+    NRF_SAADC_INPUT_AIN13    = SAADC_CH_PSELP_PSELP_AnalogInput13, ///< Analog input 13 (AIN13).
 #endif
 } nrf_saadc_input_t;
+#endif
 
 /** @brief Analog-to-digital converter oversampling mode. */
 typedef enum
@@ -91,20 +188,38 @@ typedef enum
 /** @brief Analog-to-digital converter channel resistor control. */
 typedef enum
 {
-    NRF_SAADC_RESISTOR_DISABLED = SAADC_CH_CONFIG_RESP_Bypass,   ///< Bypass resistor ladder.
-    NRF_SAADC_RESISTOR_PULLDOWN = SAADC_CH_CONFIG_RESP_Pulldown, ///< Pull-down to GND.
-    NRF_SAADC_RESISTOR_PULLUP   = SAADC_CH_CONFIG_RESP_Pullup,   ///< Pull-up to VDD.
-    NRF_SAADC_RESISTOR_VDD1_2   = SAADC_CH_CONFIG_RESP_VDD1_2    ///< Set input at VDD/2.
+    NRF_SAADC_RESISTOR_DISABLED = SAADC_CH_CONFIG_RESP_Bypass,       ///< Bypass resistor ladder.
+    NRF_SAADC_RESISTOR_PULLDOWN = SAADC_CH_CONFIG_RESP_Pulldown,     ///< Pull-down to GND.
+    NRF_SAADC_RESISTOR_PULLUP   = SAADC_CH_CONFIG_RESP_Pullup,       ///< Pull-up to VDD.
+#if defined(SAADC_CH_CONFIG_RESP_VDD1_2) || defined(__NRFX_DOXYGEN__)
+    NRF_SAADC_RESISTOR_VDD1_2   = SAADC_CH_CONFIG_RESP_VDD1_2,       ///< Set input at VDD/2.
+#endif
+#if defined(SAADC_CH_CONFIG_RESP_VDDAO1V8div2)
+    NRF_SAADC_RESISTOR_VDD1_2   = SAADC_CH_CONFIG_RESP_VDDAO1V8div2, ///< Set input at VDD/2.
+#endif
 } nrf_saadc_resistor_t;
 
 /** @brief Gain factor of the analog-to-digital converter input. */
 typedef enum
 {
+#if defined(SAADC_CH_CONFIG_GAIN_Gain1_6) || defined(__NRFX_DOXYGEN__)
     NRF_SAADC_GAIN1_6 = SAADC_CH_CONFIG_GAIN_Gain1_6, ///< Gain factor 1/6.
+#endif
+#if defined(SAADC_CH_CONFIG_GAIN_Gain1_5) || defined(__NRFX_DOXYGEN__)
     NRF_SAADC_GAIN1_5 = SAADC_CH_CONFIG_GAIN_Gain1_5, ///< Gain factor 1/5.
+#endif
+#if defined(SAADC_CH_CONFIG_GAIN_Gain1_4) || defined(__NRFX_DOXYGEN__)
     NRF_SAADC_GAIN1_4 = SAADC_CH_CONFIG_GAIN_Gain1_4, ///< Gain factor 1/4.
+#endif
+#if defined(SAADC_CH_CONFIG_GAIN_Gain1_3) || defined(__NRFX_DOXYGEN__)
     NRF_SAADC_GAIN1_3 = SAADC_CH_CONFIG_GAIN_Gain1_3, ///< Gain factor 1/3.
+#endif
+#if defined(SAADC_CH_CONFIG_GAIN_Gain1_2) || defined(__NRFX_DOXYGEN__)
     NRF_SAADC_GAIN1_2 = SAADC_CH_CONFIG_GAIN_Gain1_2, ///< Gain factor 1/2.
+#endif
+#if defined(SAADC_CH_CONFIG_GAIN_Gain2_3) || defined(__NRFX_DOXYGEN__)
+    NRF_SAADC_GAIN2_3 = SAADC_CH_CONFIG_GAIN_Gain2_3, ///< Gain factor 2/3.
+#endif
     NRF_SAADC_GAIN1   = SAADC_CH_CONFIG_GAIN_Gain1,   ///< Gain factor 1.
     NRF_SAADC_GAIN2   = SAADC_CH_CONFIG_GAIN_Gain2,   ///< Gain factor 2.
     NRF_SAADC_GAIN4   = SAADC_CH_CONFIG_GAIN_Gain4,   ///< Gain factor 4.
@@ -113,10 +228,18 @@ typedef enum
 /** @brief Reference selection for the analog-to-digital converter. */
 typedef enum
 {
-    NRF_SAADC_REFERENCE_INTERNAL = SAADC_CH_CONFIG_REFSEL_Internal, ///< Internal reference (0.6 V).
+#if defined(SAADC_CH_CONFIG_REFSEL_Internal) || defined(__NRFX_DOXYGEN__)
+    NRF_SAADC_REFERENCE_INTERNAL = SAADC_CH_CONFIG_REFSEL_Internal, ///< Internal reference.
+#endif
+#if defined(SAADC_CH_CONFIG_REFSEL_VDD1_4) || defined(__NRFX_DOXYGEN__)
     NRF_SAADC_REFERENCE_VDD4     = SAADC_CH_CONFIG_REFSEL_VDD1_4    ///< VDD/4 as reference.
+#endif
+#if defined(SAADC_CH_CONFIG_REFSEL_External) || defined(__NRFX_DOXYGEN__)
+    NRF_SAADC_REFERENCE_EXTERNAL = SAADC_CH_CONFIG_REFSEL_External, ///< External reference.
+#endif
 } nrf_saadc_reference_t;
 
+#if NRF_SAADC_HAS_ACQTIME_ENUM
 /** @brief Analog-to-digital converter acquisition time. */
 typedef enum
 {
@@ -127,6 +250,9 @@ typedef enum
     NRF_SAADC_ACQTIME_20US = SAADC_CH_CONFIG_TACQ_20us, ///< 20 us.
     NRF_SAADC_ACQTIME_40US = SAADC_CH_CONFIG_TACQ_40us  ///< 40 us.
 } nrf_saadc_acqtime_t;
+#else
+typedef uint16_t nrf_saadc_acqtime_t;
+#endif
 
 /** @brief Analog-to-digital converter channel mode. */
 typedef enum
@@ -145,9 +271,14 @@ typedef enum
 /** @brief Analog-to-digital converter tasks. */
 typedef enum
 {
+#if NRF_SAADC_HAS_DMA_TASKS_EVENTS
+    NRF_SAADC_TASK_START           = offsetof(NRF_SAADC_Type, TASKS_DMA.START),       ///< Start the ADC and prepare the result buffer in RAM.
+    NRF_SAADC_TASK_STOP            = offsetof(NRF_SAADC_Type, TASKS_DMA.STOP),        ///< Stop the ADC and terminate any ongoing conversion.
+#else
     NRF_SAADC_TASK_START           = offsetof(NRF_SAADC_Type, TASKS_START),           ///< Start the ADC and prepare the result buffer in RAM.
-    NRF_SAADC_TASK_SAMPLE          = offsetof(NRF_SAADC_Type, TASKS_SAMPLE),          ///< Take one ADC sample. If scan is enabled, all channels are sampled.
     NRF_SAADC_TASK_STOP            = offsetof(NRF_SAADC_Type, TASKS_STOP),            ///< Stop the ADC and terminate any ongoing conversion.
+#endif
+    NRF_SAADC_TASK_SAMPLE          = offsetof(NRF_SAADC_Type, TASKS_SAMPLE),          ///< Take one ADC sample. If scan is enabled, all channels are sampled.
     NRF_SAADC_TASK_CALIBRATEOFFSET = offsetof(NRF_SAADC_Type, TASKS_CALIBRATEOFFSET), ///< Starts offset auto-calibration.
 } nrf_saadc_task_t;
 
@@ -155,7 +286,11 @@ typedef enum
 typedef enum
 {
     NRF_SAADC_EVENT_STARTED       = offsetof(NRF_SAADC_Type, EVENTS_STARTED),       ///< The ADC has started.
+#if NRF_SAADC_HAS_DMA_TASKS_EVENTS
+    NRF_SAADC_EVENT_END           = offsetof(NRF_SAADC_Type, EVENTS_DMA.END),       ///< The ADC has filled up the result buffer.
+#else
     NRF_SAADC_EVENT_END           = offsetof(NRF_SAADC_Type, EVENTS_END),           ///< The ADC has filled up the result buffer.
+#endif
     NRF_SAADC_EVENT_DONE          = offsetof(NRF_SAADC_Type, EVENTS_DONE),          ///< A conversion task has been completed.
     NRF_SAADC_EVENT_RESULTDONE    = offsetof(NRF_SAADC_Type, EVENTS_RESULTDONE),    ///< A result is ready to get transferred to RAM.
     NRF_SAADC_EVENT_CALIBRATEDONE = offsetof(NRF_SAADC_Type, EVENTS_CALIBRATEDONE), ///< Calibration is complete.
@@ -182,7 +317,11 @@ typedef enum
 typedef enum
 {
     NRF_SAADC_INT_STARTED       = SAADC_INTENSET_STARTED_Msk,       ///< Interrupt on EVENTS_STARTED event.
+#if NRF_SAADC_HAS_DMA_TASKS_EVENTS
+    NRF_SAADC_INT_END           = SAADC_INTENSET_DMAEND_Msk,        ///< Interrupt on EVENTS_END event.
+#else
     NRF_SAADC_INT_END           = SAADC_INTENSET_END_Msk,           ///< Interrupt on EVENTS_END event.
+#endif
     NRF_SAADC_INT_DONE          = SAADC_INTENSET_DONE_Msk,          ///< Interrupt on EVENTS_DONE event.
     NRF_SAADC_INT_RESULTDONE    = SAADC_INTENSET_RESULTDONE_Msk,    ///< Interrupt on EVENTS_RESULTDONE event.
     NRF_SAADC_INT_CALIBRATEDONE = SAADC_INTENSET_CALIBRATEDONE_Msk, ///< Interrupt on EVENTS_CALIBRATEDONE event.
@@ -235,6 +374,9 @@ typedef struct
     nrf_saadc_acqtime_t   acq_time;   ///< Acquisition time.
     nrf_saadc_mode_t      mode;       ///< SAADC mode. Single-ended or differential.
     nrf_saadc_burst_t     burst;      ///< Burst mode configuration.
+#if NRF_SAADC_HAS_CONVTIME
+    uint8_t               conv_time;  ///< Conversion time.
+#endif
 } nrf_saadc_channel_config_t;
 
 
@@ -353,7 +495,7 @@ NRF_STATIC_INLINE nrf_saadc_event_t nrf_saadc_limit_event_get(uint8_t           
  * @param[in] p_reg   Pointer to the structure of registers of the peripheral.
  * @param[in] channel Channel number.
  * @param[in] pselp   Positive input.
- * @param[in] pseln   Negative input. Set to NRF_SAADC_INPUT_DISABLED in single ended mode.
+ * @param[in] pseln   Negative input. Set to @ref NRF_SAADC_INPUT_DISABLED in single ended mode.
  */
 NRF_STATIC_INLINE void nrf_saadc_channel_input_set(NRF_SAADC_Type *  p_reg,
                                                    uint8_t           channel,
@@ -587,6 +729,30 @@ NRF_STATIC_INLINE bool nrf_saadc_continuous_mode_enable_check(NRF_SAADC_Type con
  */
 NRF_STATIC_INLINE void nrf_saadc_continuous_mode_disable(NRF_SAADC_Type * p_reg);
 
+#if NRF_SAADC_HAS_LIN_CAL
+/**
+ * @brief Function for setting linearity calibration coefficient.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ * @param[in] index Coefficient number.
+ * @param[in] coeff Value of the coefficient.
+ */
+NRF_STATIC_INLINE void nrf_saadc_linearity_calibration_coeff_set(NRF_SAADC_Type * p_reg,
+                                                                 uint8_t          index,
+                                                                 uint32_t         coeff);
+
+/**
+ * @brief Function for getting linearity calibration coefficient.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ * @param[in] index Coefficient number.
+ *
+ * @return Value of the coefficient.
+ */
+NRF_STATIC_INLINE uint32_t nrf_saadc_linearity_calibration_coeff_get(NRF_SAADC_Type const * p_reg,
+                                                                     uint8_t                index);
+#endif
+
 /**
  * @brief Function for initializing the SAADC channel.
  *
@@ -667,7 +833,7 @@ NRF_STATIC_INLINE void nrf_saadc_subscribe_set(NRF_SAADC_Type * p_reg,
                                                uint8_t          channel)
 {
     *((volatile uint32_t *) ((uint8_t *) p_reg + (uint32_t) task + 0x80uL)) =
-            ((uint32_t)channel | SAADC_SUBSCRIBE_START_EN_Msk);
+            ((uint32_t)channel | NRF_SUBSCRIBE_PUBLISH_ENABLE);
 }
 
 NRF_STATIC_INLINE void nrf_saadc_subscribe_clear(NRF_SAADC_Type * p_reg, nrf_saadc_task_t task)
@@ -680,7 +846,7 @@ NRF_STATIC_INLINE void nrf_saadc_publish_set(NRF_SAADC_Type *  p_reg,
                                              uint8_t           channel)
 {
     *((volatile uint32_t *) ((uint8_t *) p_reg + (uint32_t) event + 0x80uL)) =
-            ((uint32_t)channel | SAADC_PUBLISH_STARTED_EN_Msk);
+            ((uint32_t)channel | NRF_SUBSCRIBE_PUBLISH_ENABLE);
 }
 
 NRF_STATIC_INLINE void nrf_saadc_publish_clear(NRF_SAADC_Type * p_reg, nrf_saadc_event_t event)
@@ -707,15 +873,30 @@ NRF_STATIC_INLINE void nrf_saadc_channel_input_set(NRF_SAADC_Type *  p_reg,
                                                    nrf_saadc_input_t pselp,
                                                    nrf_saadc_input_t pseln)
 {
+#if NRF_SAADC_HAS_AIN_AS_PIN
+    p_reg->CH[channel].PSELN = (NRF_PIN_NUMBER_TO_PIN(pseln) << SAADC_CH_PSELP_PIN_Pos)
+                               | (NRF_PIN_NUMBER_TO_PORT(pseln) << SAADC_CH_PSELP_PORT_Pos)
+                               | (SAADC_CH_PSELP_CONNECT_AnalogInput << SAADC_CH_PSELP_CONNECT_Pos);
+    p_reg->CH[channel].PSELP = (NRF_PIN_NUMBER_TO_PIN(pselp) << SAADC_CH_PSELP_PIN_Pos)
+                               | (NRF_PIN_NUMBER_TO_PORT(pselp) << SAADC_CH_PSELP_PORT_Pos)
+                               | (SAADC_CH_PSELP_CONNECT_AnalogInput << SAADC_CH_PSELP_CONNECT_Pos);
+#else
     p_reg->CH[channel].PSELN = pseln;
     p_reg->CH[channel].PSELP = pselp;
+#endif
 }
 
 NRF_STATIC_INLINE void nrf_saadc_channel_pos_input_set(NRF_SAADC_Type *  p_reg,
                                                        uint8_t           channel,
                                                        nrf_saadc_input_t pselp)
 {
+#if NRF_SAADC_HAS_AIN_AS_PIN
+    p_reg->CH[channel].PSELP = (NRF_PIN_NUMBER_TO_PIN(pselp) << SAADC_CH_PSELP_PIN_Pos)
+                               | (NRF_PIN_NUMBER_TO_PORT(pselp) << SAADC_CH_PSELP_PORT_Pos)
+                               | (SAADC_CH_PSELP_CONNECT_AnalogInput << SAADC_CH_PSELP_CONNECT_Pos);
+#else
     p_reg->CH[channel].PSELP = pselp;
+#endif
 }
 
 NRF_STATIC_INLINE void nrf_saadc_channel_limits_set(NRF_SAADC_Type * p_reg,
@@ -781,24 +962,41 @@ NRF_STATIC_INLINE void nrf_saadc_buffer_init(NRF_SAADC_Type *    p_reg,
                                              nrf_saadc_value_t * p_buffer,
                                              uint32_t            size)
 {
+#if NRF_SAADC_HAS_DMA_REG
+    p_reg->DMA.PTR = (uint32_t)p_buffer;
+    p_reg->DMA.MAXCNT = size;
+#else
     p_reg->RESULT.PTR = (uint32_t)p_buffer;
     p_reg->RESULT.MAXCNT = size;
+#endif
 }
 
 NRF_STATIC_INLINE void nrf_saadc_buffer_pointer_set(NRF_SAADC_Type *    p_reg,
                                                     nrf_saadc_value_t * p_buffer)
 {
+#if NRF_SAADC_HAS_DMA_REG
+    p_reg->DMA.PTR = (uint32_t)p_buffer;
+#else
     p_reg->RESULT.PTR = (uint32_t)p_buffer;
+#endif
 }
 
 NRF_STATIC_INLINE nrf_saadc_value_t * nrf_saadc_buffer_pointer_get(NRF_SAADC_Type const * p_reg)
 {
+#if NRF_SAADC_HAS_DMA_REG
+    return (nrf_saadc_value_t *)p_reg->DMA.PTR;
+#else
     return (nrf_saadc_value_t *)p_reg->RESULT.PTR;
+#endif
 }
 
 NRF_STATIC_INLINE uint16_t nrf_saadc_amount_get(NRF_SAADC_Type const * p_reg)
 {
-    return p_reg->RESULT.AMOUNT;
+#if NRF_SAADC_HAS_DMA_REG
+    return (uint16_t)p_reg->DMA.AMOUNT;
+#else
+    return (uint16_t)p_reg->RESULT.AMOUNT;
+#endif
 }
 
 NRF_STATIC_INLINE void nrf_saadc_resolution_set(NRF_SAADC_Type *       p_reg,
@@ -846,16 +1044,43 @@ NRF_STATIC_INLINE void nrf_saadc_continuous_mode_disable(NRF_SAADC_Type * p_reg)
     p_reg->SAMPLERATE = SAADC_SAMPLERATE_MODE_Task << SAADC_SAMPLERATE_MODE_Pos;
 }
 
+#if NRF_SAADC_HAS_LIN_CAL
+NRF_STATIC_INLINE void nrf_saadc_linearity_calibration_coeff_set(NRF_SAADC_Type * p_reg,
+                                                                 uint8_t          index,
+                                                                 uint32_t         coeff)
+{
+    NRFX_ASSERT(index < NRF_SAADC_LIN_CAL_MAX_COUNT);
+    NRFX_ASSERT(coeff <= NRF_SAADC_LIN_CAL_MAX);
+    p_reg->TRIM.LINCALCOEFF[index] = coeff;
+}
+
+NRF_STATIC_INLINE uint32_t nrf_saadc_linearity_calibration_coeff_get(NRF_SAADC_Type const * p_reg,
+                                                                     uint8_t                index)
+{
+    NRFX_ASSERT(index < NRF_SAADC_LIN_CAL_MAX_COUNT);
+    return p_reg->TRIM.LINCALCOEFF[index];
+}
+#endif
+
 NRF_STATIC_INLINE void nrf_saadc_channel_init(NRF_SAADC_Type *                   p_reg,
                                               uint8_t                            channel,
                                               nrf_saadc_channel_config_t const * config)
 {
+#if !NRF_SAADC_HAS_ACQTIME_ENUM
+    NRFX_ASSERT(config->acq_time <= NRF_SAADC_ACQTIME_MAX);
+#endif
+#if NRF_SAADC_HAS_CONVTIME
+    NRFX_ASSERT(config->conv_time <= NRF_SAADC_CONVTIME_MAX);
+#endif
     p_reg->CH[channel].CONFIG =
             ((config->resistor_p   << SAADC_CH_CONFIG_RESP_Pos)   & SAADC_CH_CONFIG_RESP_Msk)
             | ((config->resistor_n << SAADC_CH_CONFIG_RESN_Pos)   & SAADC_CH_CONFIG_RESN_Msk)
             | ((config->gain       << SAADC_CH_CONFIG_GAIN_Pos)   & SAADC_CH_CONFIG_GAIN_Msk)
             | ((config->reference  << SAADC_CH_CONFIG_REFSEL_Pos) & SAADC_CH_CONFIG_REFSEL_Msk)
             | ((config->acq_time   << SAADC_CH_CONFIG_TACQ_Pos)   & SAADC_CH_CONFIG_TACQ_Msk)
+#if NRF_SAADC_HAS_CONVTIME
+            | ((config->conv_time  << SAADC_CH_CONFIG_TCONV_Pos)  & SAADC_CH_CONFIG_TCONV_Msk)
+#endif
             | ((config->mode       << SAADC_CH_CONFIG_MODE_Pos)   & SAADC_CH_CONFIG_MODE_Msk)
             | ((config->burst      << SAADC_CH_CONFIG_BURST_Pos)  & SAADC_CH_CONFIG_BURST_Msk);
 }

--- a/nrfx/hal/nrf_spi.h
+++ b/nrfx/hal/nrf_spi.h
@@ -369,7 +369,7 @@ NRF_STATIC_INLINE void nrf_spi_txd_set(NRF_SPI_Type * p_reg, uint8_t data)
 
 NRF_STATIC_INLINE uint8_t nrf_spi_rxd_get(NRF_SPI_Type const * p_reg)
 {
-    return p_reg->RXD;
+    return (uint8_t)p_reg->RXD;
 }
 
 NRF_STATIC_INLINE void nrf_spi_frequency_set(NRF_SPI_Type *      p_reg,

--- a/nrfx/hal/nrf_spim.h
+++ b/nrfx/hal/nrf_spim.h
@@ -56,11 +56,55 @@ extern "C" {
  */
 #define NRF_SPIM_INST_GET(idx) NRFX_CONCAT_2(NRF_SPIM, idx)
 
+#if defined(SPIM_FREQUENCY_FREQUENCY_M16) || defined(__NRFX_DOXYGEN__)
+/** @brief Symbol indicating whether 16 MHz clock frequency is available. */
+#define NRF_SPIM_HAS_16_MHZ_FREQ 1
+#else
+#define NRF_SPIM_HAS_16_MHZ_FREQ 0
+#endif
+
 #if defined(SPIM_FREQUENCY_FREQUENCY_M32) || defined(__NRFX_DOXYGEN__)
 /** @brief Symbol indicating whether 32 MHz clock frequency is available. */
 #define NRF_SPIM_HAS_32_MHZ_FREQ 1
 #else
 #define NRF_SPIM_HAS_32_MHZ_FREQ 0
+#endif
+
+#if defined(SPIM_FREQUENCY_FREQUENCY_Msk) || defined(__NRFX_DOXYGEN__)
+/** @brief Symbol indicating whether frequency is used. */
+#define NRF_SPIM_HAS_FREQUENCY 1
+#else
+#define NRF_SPIM_HAS_FREQUENCY 0
+#endif
+
+#if defined(SPIM_PRESCALER_DIVISOR_Msk) || defined(__NRFX_DOXYGEN__)
+/** @brief Symbol indicating whether prescaler is used. */
+#define NRF_SPIM_HAS_PRESCALER 1
+#else
+#define NRF_SPIM_HAS_PRESCALER 0
+#endif
+
+#if defined(SPIM_TXD_LIST_LIST_ArrayList) || defined(__NRFX_DOXYGEN__)
+/** @brief Symbol indicating whether EasyDMA array list feature is present. */
+#define NRF_SPIM_HAS_ARRAY_LIST 1
+#else
+#define NRF_SPIM_HAS_ARRAY_LIST 0
+#endif
+
+#if defined(SPIM_DMA_RX_PTR_PTR_Msk) || defined(__NRFX_DOXYGEN__)
+/** @brief Symbol indicating whether dedicated DMA register is present. */
+#define NRF_SPIM_HAS_DMA_REG 1
+#else
+#define NRF_SPIM_HAS_DMA_REG 0
+#endif
+
+#if (defined(SPIM_TASKS_DMA_RX_ENABLEMATCH_ENABLEMATCH_Msk) && \
+     defined(SPIM_EVENTS_DMA_RX_END_END_Msk)) || \
+    defined(__NRFX_DOXYGEN__)
+/** @brief Symbol indicating whether SPIM DMA tasks and events are present. */
+#define NRF_SPIM_HAS_DMA_TASKS_EVENTS 1
+#else
+#define NRF_SPIM_HAS_DMA_TASKS_EVENTS 0
 #endif
 
 /**
@@ -71,30 +115,43 @@ extern "C" {
 #define NRF_SPIM_PIN_NOT_CONNECTED  0xFFFFFFFF
 
 /** @brief Macro for checking if the hardware chip select function is available. */
-#define NRF_SPIM_HW_CSN_PRESENT                        \
-    (NRFX_CHECK(SPIM0_FEATURE_HARDWARE_CSN_PRESENT) || \
-     NRFX_CHECK(SPIM1_FEATURE_HARDWARE_CSN_PRESENT) || \
-     NRFX_CHECK(SPIM2_FEATURE_HARDWARE_CSN_PRESENT) || \
-     NRFX_CHECK(SPIM3_FEATURE_HARDWARE_CSN_PRESENT) || \
-     NRFX_CHECK(SPIM4_FEATURE_HARDWARE_CSN_PRESENT))
+#if NRFX_FEATURE_PRESENT(SPIM, _FEATURE_HARDWARE_CSN_PRESENT) || defined(__NRFX_DOXYGEN__)
+#define NRF_SPIM_HAS_HW_CSN 1
+#else
+#define NRF_SPIM_HAS_HW_CSN 0
+#endif
 
 /** @brief Macro for checking if the DCX pin control is available. */
-#define NRF_SPIM_DCX_PRESENT                  \
-    (NRFX_CHECK(SPIM0_FEATURE_DCX_PRESENT) || \
-     NRFX_CHECK(SPIM1_FEATURE_DCX_PRESENT) || \
-     NRFX_CHECK(SPIM2_FEATURE_DCX_PRESENT) || \
-     NRFX_CHECK(SPIM3_FEATURE_DCX_PRESENT) || \
-     NRFX_CHECK(SPIM4_FEATURE_DCX_PRESENT))
+#if NRFX_FEATURE_PRESENT(SPIM, _FEATURE_HARDWARE_DCX_PRESENT) || \
+    NRFX_FEATURE_PRESENT(SPIM, _FEATURE_DCX_PRESENT) || \
+    defined(__NRFX_DOXYGEN__)
+#define NRF_SPIM_HAS_DCX 1
+#else
+#define NRF_SPIM_HAS_DCX 0
+#endif
 
 /** @brief Macro for checking if the RXDELAY function is available. */
-#define NRF_SPIM_RXDELAY_PRESENT                  \
-    (NRFX_CHECK(SPIM0_FEATURE_RXDELAY_PRESENT) || \
-     NRFX_CHECK(SPIM1_FEATURE_RXDELAY_PRESENT) || \
-     NRFX_CHECK(SPIM2_FEATURE_RXDELAY_PRESENT) || \
-     NRFX_CHECK(SPIM3_FEATURE_RXDELAY_PRESENT) || \
-     NRFX_CHECK(SPIM4_FEATURE_RXDELAY_PRESENT))
+#if NRFX_FEATURE_PRESENT(SPIM, _FEATURE_RXDELAY_PRESENT) || defined(__NRFX_DOXYGEN__)
+#define NRF_SPIM_HAS_RXDELAY 1
+#else
+#define NRF_SPIM_HAS_RXDELAY 0
+#endif
 
-#if defined(NRF_SPIM_DCX_PRESENT) || defined(__NRFX_DOXYGEN__)
+#if defined(SPIM_STALLSTAT_RX_Msk) || defined(__NRFX_DOXYGEN__)
+/** @brief Macro for checking if the STALLSTAT feature is available. */
+#define NRF_SPIM_HAS_STALLSTAT 1
+#else
+#define NRF_SPIM_HAS_STALLSTAT 0
+#endif
+
+#if NRF_SPIM_HAS_HW_CSN || NRF_SPIM_HAS_DCX || NRF_SPIM_HAS_RXDELAY
+/** @brief Symbol indicating whether any of the SPIM extended features is available. */
+#define NRF_SPIM_HAS_EXTENDED 1
+#else
+#define NRF_SPIM_HAS_EXTENDED 0
+#endif
+
+#if NRF_SPIM_HAS_DCX
 /**
  * @brief This value specified in the DCX line configuration causes this line
  *        to be set low during whole transmission (all transmitted bytes are
@@ -105,49 +162,214 @@ extern "C" {
 #define NRF_SPIM_DCX_CNT_ALL_CMD 0xF
 #endif
 
+/** @brief Base frequency value 192 MHz for SPIM. */
+#define NRF_SPIM_BASE_FREQUENCY_192MHZ (192000000UL)
+
+/** @brief Base frequency value 128 MHz for SPIM. */
+#define NRF_SPIM_BASE_FREQUENCY_128MHZ (128000000UL)
+
+/** @brief Base frequency value 64 MHz for SPIM. */
+#define NRF_SPIM_BASE_FREQUENCY_64MHZ (64000000UL)
+
+/** @brief Base frequency value 32 MHz for SPIM. */
+#define NRF_SPIM_BASE_FREQUENCY_32MHZ (32000000UL)
+
+/** @brief Base frequency value 16 MHz for SPIM. */
+#define NRF_SPIM_BASE_FREQUENCY_16MHZ (16000000UL)
+
+/** @brief Minimal SPIM frequency in Hz. */
+#define NRF_SPIM_MIN_FREQUENCY (125000UL)
+
+#if NRF_SPIM_HAS_PRESCALER
+/** @brief Maximum value of PRESCALER register. */
+#define NRF_SPIM_PRESCALER_MAX SPIM_PRESCALER_DIVISOR_Max
+
+/** @brief Minimum value of PRESCALER register. */
+#define NRF_SPIM_PRESCALER_MIN SPIM_PRESCALER_DIVISOR_Min
+#endif
+
+#if NRF_SPIM_HAS_DMA_TASKS_EVENTS
+/** @brief Max number of RX patterns. */
+#define NRF_SPIM_DMA_RX_PATTERN_MAX_COUNT SPIM_DMA_RX_MATCH_CANDIDATE_MaxCount
+#endif
+
+#if !defined(NRF_SPIM_IS_128MHZ_SPIM)
+/** @brief Macro for checking whether the base frequency for the specified SPIM instance is 128 MHz. */
+#define NRF_SPIM_IS_128MHZ_SPIM(p_reg) false
+#endif
+
+#if !defined(NRF_SPIM_IS_64MHZ_SPIM)
+/** @brief Macro for checking whether the base frequency for the specified SPIM instance is 64 MHz. */
+#define NRF_SPIM_IS_64MHZ_SPIM(p_reg) false
+#endif
+
+#if !defined(NRF_SPIM_IS_32MHZ_SPIM)
+/** @brief Macro for checking whether the base frequency for the specified SPIM instance is 32 MHz. */
+#define NRF_SPIM_IS_32MHZ_SPIM(p_reg) false
+#endif
+
+#if !defined(NRF_SPIM_IS_16MHZ_SPIM)
+/** @brief Macro for checking whether the base frequency for the specified SPIM instance is 16 MHz. */
+#define NRF_SPIM_IS_16MHZ_SPIM(p_reg) true
+#endif
+
+/** @brief Macro for getting base frequency value in Hz for the specified SPIM instance. */
+#define NRF_SPIM_BASE_FREQUENCY_GET(p_reg)                                 \
+    ((NRF_SPIM_IS_16MHZ_SPIM(p_reg))  ? (NRF_SPIM_BASE_FREQUENCY_16MHZ):   \
+    ((NRF_SPIM_IS_32MHZ_SPIM(p_reg))  ? (NRF_SPIM_BASE_FREQUENCY_32MHZ) :  \
+    ((NRF_SPIM_IS_64MHZ_SPIM(p_reg))  ? (NRF_SPIM_BASE_FREQUENCY_64MHZ) :  \
+    ((NRF_SPIM_IS_128MHZ_SPIM(p_reg)) ? (NRF_SPIM_BASE_FREQUENCY_128MHZ) : \
+    (NRF_SPIM_BASE_FREQUENCY_192MHZ)))))
+
+#if NRF_SPIM_HAS_PRESCALER
+/**
+ * @brief Macro for computing prescaler value for a given SPIM instance and desired frequency.
+ *
+ * @warning Not every combination of base and desired frequency is supported.
+ *          The @ref NRF_SPIM_FREQUENCY_STATIC_CHECK macro can be used to check if the desired frequency is supported.
+ *
+ * @param[in] p_reg     Pointer to the structure of registers of the peripheral.
+ * @param[in] frequency Desired frequency value in Hz.
+ */
+#define NRF_SPIM_PRESCALER_CALCULATE(p_reg, frequency) \
+        ((uint32_t)(NRF_SPIM_BASE_FREQUENCY_GET(p_reg)) / (uint32_t)(frequency))
+#endif
+
+/**
+ * @brief Macro for checking whether specified frequency can be achieved for a given SPIM instance.
+ *
+ * @note This macro uses a compile-time assertion.
+ *
+ * @param[in] p_reg     Pointer to the structure of registers of the peripheral.
+ * @param[in] frequency Desired frequency value in Hz.
+ */
+#define NRF_SPIM_FREQUENCY_STATIC_CHECK(p_reg, frequency)                                          \
+    NRFX_STATIC_ASSERT(                                                                            \
+    NRFX_COND_CODE_1(NRF_SPIM_HAS_PRESCALER,                                                       \
+        ((NRF_SPIM_BASE_FREQUENCY_GET(p_reg) % (uint32_t)frequency == 0) &&                        \
+        (NRFX_IS_EVEN(NRF_SPIM_PRESCALER_CALCULATE(p_reg, (uint32_t)frequency))) &&                \
+        (NRF_SPIM_PRESCALER_CALCULATE(p_reg, (uint32_t)frequency) >= (NRF_SPIM_PRESCALER_MIN)) &&  \
+        (NRF_SPIM_PRESCALER_CALCULATE(p_reg, (uint32_t)frequency) <= (NRF_SPIM_PRESCALER_MAX)))    \
+        ,                                                                                          \
+        (((uint32_t)frequency == (uint32_t)NRFX_KHZ_TO_HZ(125)) ||                                 \
+         ((uint32_t)frequency == (uint32_t)NRFX_KHZ_TO_HZ(250)) ||                                 \
+         ((uint32_t)frequency == (uint32_t)NRFX_KHZ_TO_HZ(500)) ||                                 \
+         ((uint32_t)frequency == (uint32_t)NRFX_MHZ_TO_HZ(1))   ||                                 \
+         ((uint32_t)frequency == (uint32_t)NRFX_MHZ_TO_HZ(2))   ||                                 \
+         ((uint32_t)frequency == (uint32_t)NRFX_MHZ_TO_HZ(4))   ||                                 \
+         ((uint32_t)frequency == (uint32_t)NRFX_MHZ_TO_HZ(8))   ||                                 \
+         (((uint32_t)frequency == (uint32_t)NRFX_MHZ_TO_HZ(16)) && (NRF_SPIM_HAS_16_MHZ_FREQ)) ||  \
+         (((uint32_t)frequency == (uint32_t)NRFX_MHZ_TO_HZ(32)) && (NRF_SPIM_HAS_32_MHZ_FREQ)) )), \
+        "The specified frequency cannot be achieved with the given SPIM instance.")
+
 /** @brief SPIM tasks. */
 typedef enum
 {
-    NRF_SPIM_TASK_START   = offsetof(NRF_SPIM_Type, TASKS_START),   ///< Start SPI transaction.
-    NRF_SPIM_TASK_STOP    = offsetof(NRF_SPIM_Type, TASKS_STOP),    ///< Stop SPI transaction.
-    NRF_SPIM_TASK_SUSPEND = offsetof(NRF_SPIM_Type, TASKS_SUSPEND), ///< Suspend SPI transaction.
-    NRF_SPIM_TASK_RESUME  = offsetof(NRF_SPIM_Type, TASKS_RESUME)   ///< Resume SPI transaction.
+    NRF_SPIM_TASK_START           = offsetof(NRF_SPIM_Type, TASKS_START),                  ///< Start SPI transaction.
+    NRF_SPIM_TASK_STOP            = offsetof(NRF_SPIM_Type, TASKS_STOP),                   ///< Stop SPI transaction.
+    NRF_SPIM_TASK_SUSPEND         = offsetof(NRF_SPIM_Type, TASKS_SUSPEND),                ///< Suspend SPI transaction.
+    NRF_SPIM_TASK_RESUME          = offsetof(NRF_SPIM_Type, TASKS_RESUME),                 ///< Resume SPI transaction.
+#if NRF_SPIM_HAS_DMA_TASKS_EVENTS
+    NRF_SPIM_TASK_ENABLERXMATCH0  = offsetof(NRF_SPIM_Type, TASKS_DMA.RX.ENABLEMATCH[0]),  ///< Enable SPI pattern matching functionality for pattern 0.
+    NRF_SPIM_TASK_ENABLERXMATCH1  = offsetof(NRF_SPIM_Type, TASKS_DMA.RX.ENABLEMATCH[1]),  ///< Enable SPI pattern matching functionality for pattern 1.
+    NRF_SPIM_TASK_ENABLERXMATCH2  = offsetof(NRF_SPIM_Type, TASKS_DMA.RX.ENABLEMATCH[2]),  ///< Enable SPI pattern matching functionality for pattern 2.
+    NRF_SPIM_TASK_ENABLERXMATCH3  = offsetof(NRF_SPIM_Type, TASKS_DMA.RX.ENABLEMATCH[3]),  ///< Enable SPI pattern matching functionality for pattern 3.
+    NRF_SPIM_TASK_DISABLERXMATCH0 = offsetof(NRF_SPIM_Type, TASKS_DMA.RX.DISABLEMATCH[0]), ///< Disable SPI pattern matching functionality for pattern 0.
+    NRF_SPIM_TASK_DISABLERXMATCH1 = offsetof(NRF_SPIM_Type, TASKS_DMA.RX.DISABLEMATCH[1]), ///< Disable SPI pattern matching functionality for pattern 1.
+    NRF_SPIM_TASK_DISABLERXMATCH2 = offsetof(NRF_SPIM_Type, TASKS_DMA.RX.DISABLEMATCH[2]), ///< Disable SPI pattern matching functionality for pattern 2.
+    NRF_SPIM_TASK_DISABLERXMATCH3 = offsetof(NRF_SPIM_Type, TASKS_DMA.RX.DISABLEMATCH[3])  ///< Disable SPI pattern matching functionality for pattern 3.
+#endif
 } nrf_spim_task_t;
 
 /** @brief SPIM events. */
 typedef enum
 {
-    NRF_SPIM_EVENT_STOPPED = offsetof(NRF_SPIM_Type, EVENTS_STOPPED), ///< SPI transaction has stopped.
-    NRF_SPIM_EVENT_ENDRX   = offsetof(NRF_SPIM_Type, EVENTS_ENDRX),   ///< End of RXD buffer reached.
-    NRF_SPIM_EVENT_END     = offsetof(NRF_SPIM_Type, EVENTS_END),     ///< End of RXD buffer and TXD buffer reached.
-    NRF_SPIM_EVENT_ENDTX   = offsetof(NRF_SPIM_Type, EVENTS_ENDTX),   ///< End of TXD buffer reached.
-    NRF_SPIM_EVENT_STARTED = offsetof(NRF_SPIM_Type, EVENTS_STARTED)  ///< Transaction started.
+    NRF_SPIM_EVENT_STARTED    = offsetof(NRF_SPIM_Type, EVENTS_STARTED),         ///< SPI transaction has started.
+    NRF_SPIM_EVENT_STOPPED    = offsetof(NRF_SPIM_Type, EVENTS_STOPPED),         ///< SPI transaction has stopped.
+#if NRF_SPIM_HAS_DMA_TASKS_EVENTS
+    NRF_SPIM_EVENT_RXSTARTED  = offsetof(NRF_SPIM_Type, EVENTS_DMA.RX.READY),    ///< Receive sequence started.
+    NRF_SPIM_EVENT_RXBUSERROR = offsetof(NRF_SPIM_Type, EVENTS_DMA.RX.BUSERROR), ///< Memory bus error occurred during the RX transfer.
+    NRF_SPIM_EVENT_RXMATCH0   = offsetof(NRF_SPIM_Type, EVENTS_DMA.RX.MATCH[0]), ///< Pattern match for pattern 0 detected.
+    NRF_SPIM_EVENT_RXMATCH1   = offsetof(NRF_SPIM_Type, EVENTS_DMA.RX.MATCH[1]), ///< Pattern match for pattern 1 detected.
+    NRF_SPIM_EVENT_RXMATCH2   = offsetof(NRF_SPIM_Type, EVENTS_DMA.RX.MATCH[2]), ///< Pattern match for pattern 2 detected.
+    NRF_SPIM_EVENT_RXMATCH3   = offsetof(NRF_SPIM_Type, EVENTS_DMA.RX.MATCH[3]), ///< Pattern match for pattern 3 detected.
+    NRF_SPIM_EVENT_TXSTARTED  = offsetof(NRF_SPIM_Type, EVENTS_DMA.TX.READY),    ///< Transmit sequence started.
+    NRF_SPIM_EVENT_TXBUSERROR = offsetof(NRF_SPIM_Type, EVENTS_DMA.TX.BUSERROR), ///< Memory bus error occurred during the TX transfer.
+    NRF_SPIM_EVENT_ENDRX      = offsetof(NRF_SPIM_Type, EVENTS_DMA.RX.END),      ///< End of RXD buffer reached.
+    NRF_SPIM_EVENT_ENDTX      = offsetof(NRF_SPIM_Type, EVENTS_DMA.TX.END),      ///< End of TXD buffer reached.
+#else
+    NRF_SPIM_EVENT_ENDRX      = offsetof(NRF_SPIM_Type, EVENTS_ENDRX),           ///< End of RXD buffer reached.
+    NRF_SPIM_EVENT_ENDTX      = offsetof(NRF_SPIM_Type, EVENTS_ENDTX),           ///< End of TXD buffer reached.
+#endif
+    NRF_SPIM_EVENT_END        = offsetof(NRF_SPIM_Type, EVENTS_END)              ///< End of RXD buffer and TXD buffer reached.
 } nrf_spim_event_t;
 
-/**
- * @brief SPIM shortcuts.
- */
+/** @brief SPIM shortcuts. */
 typedef enum
 {
-    NRF_SPIM_SHORT_END_START_MASK = SPIM_SHORTS_END_START_Msk, ///< Shortcut between END event and START task.
-    NRF_SPIM_ALL_SHORTS_MASK      = SPIM_SHORTS_END_START_Msk  ///< All SPIM shortcuts.
+    NRF_SPIM_SHORT_END_START_MASK                = SPIM_SHORTS_END_START_Msk,                          ///< Shortcut between END event and START task.
+#if NRF_SPIM_HAS_DMA_TASKS_EVENTS
+    NRF_SPIM_SHORT_RXMATCH0_ENABLERXMATCH1_MASK  = SPIM_SHORTS_DMA_RX_MATCH0_DMA_RX_ENABLEMATCH1_Msk,  ///< Shortcut between DMA.RX.MATCH0 event and DMA.RX.ENABLEMATCH1 task.
+    NRF_SPIM_SHORT_RXMATCH1_ENABLERXMATCH2_MASK  = SPIM_SHORTS_DMA_RX_MATCH1_DMA_RX_ENABLEMATCH2_Msk,  ///< Shortcut between DMA.RX.MATCH1 event and DMA.RX.ENABLEMATCH2 task.
+    NRF_SPIM_SHORT_RXMATCH2_ENABLERXMATCH3_MASK  = SPIM_SHORTS_DMA_RX_MATCH2_DMA_RX_ENABLEMATCH3_Msk,  ///< Shortcut between DMA.RX.MATCH2 event and DMA.RX.ENABLEMATCH3 task.
+    NRF_SPIM_SHORT_RXMATCH3_ENABLERXMATCH4_MASK  = SPIM_SHORTS_DMA_RX_MATCH3_DMA_RX_ENABLEMATCH4_Msk,  ///< Shortcut between DMA.RX.MATCH3 event and DMA.RX.ENABLEMATCH4 task.
+    NRF_SPIM_SHORT_RXMATCH0_DISABLERXMATCH0_MASK = SPIM_SHORTS_DMA_RX_MATCH0_DMA_RX_DISABLEMATCH0_Msk, ///< Shortcut between DMA.RX.MATCH0 event and DMA.RX.DISABLEMATCH0 task.
+    NRF_SPIM_SHORT_RXMATCH1_DISABLERXMATCH1_MASK = SPIM_SHORTS_DMA_RX_MATCH1_DMA_RX_DISABLEMATCH1_Msk, ///< Shortcut between DMA.RX.MATCH1 event and DMA.RX.DISABLEMATCH1 task.
+    NRF_SPIM_SHORT_RXMATCH2_DISABLERXMATCH2_MASK = SPIM_SHORTS_DMA_RX_MATCH2_DMA_RX_DISABLEMATCH2_Msk, ///< Shortcut between DMA.RX.MATCH2 event and DMA.RX.DISABLEMATCH2 task.
+    NRF_SPIM_SHORT_RXMATCH3_DISABLERXMATCH3_MASK = SPIM_SHORTS_DMA_RX_MATCH3_DMA_RX_DISABLEMATCH3_Msk, ///< Shortcut between DMA.RX.MATCH3 event and DMA.RX.DISABLEMATCH3 task.
+#endif
+    NRF_SPIM_ALL_SHORTS_MASK      = SPIM_SHORTS_END_START_Msk
+#if NRF_SPIM_HAS_DMA_TASKS_EVENTS
+                                  | SPIM_SHORTS_DMA_RX_MATCH0_DMA_RX_ENABLEMATCH1_Msk
+                                  | SPIM_SHORTS_DMA_RX_MATCH1_DMA_RX_ENABLEMATCH2_Msk
+                                  | SPIM_SHORTS_DMA_RX_MATCH2_DMA_RX_ENABLEMATCH3_Msk
+                                  | SPIM_SHORTS_DMA_RX_MATCH3_DMA_RX_ENABLEMATCH4_Msk
+                                  | SPIM_SHORTS_DMA_RX_MATCH0_DMA_RX_DISABLEMATCH0_Msk
+                                  | SPIM_SHORTS_DMA_RX_MATCH1_DMA_RX_DISABLEMATCH1_Msk
+                                  | SPIM_SHORTS_DMA_RX_MATCH2_DMA_RX_DISABLEMATCH2_Msk
+                                  | SPIM_SHORTS_DMA_RX_MATCH3_DMA_RX_DISABLEMATCH3_Msk                 ///< All SPIM shortcuts.
+#endif
 } nrf_spim_short_mask_t;
 
 /** @brief SPIM interrupts. */
 typedef enum
 {
-    NRF_SPIM_INT_STOPPED_MASK = SPIM_INTENSET_STOPPED_Msk,  ///< Interrupt on STOPPED event.
-    NRF_SPIM_INT_ENDRX_MASK   = SPIM_INTENSET_ENDRX_Msk,    ///< Interrupt on ENDRX event.
-    NRF_SPIM_INT_END_MASK     = SPIM_INTENSET_END_Msk,      ///< Interrupt on END event.
-    NRF_SPIM_INT_ENDTX_MASK   = SPIM_INTENSET_ENDTX_Msk,    ///< Interrupt on ENDTX event.
-    NRF_SPIM_INT_STARTED_MASK = SPIM_INTENSET_STARTED_Msk,  ///< Interrupt on STARTED event.
-    NRF_SPIM_ALL_INTS_MASK    = SPIM_INTENSET_STOPPED_Msk |
-                                SPIM_INTENSET_ENDRX_Msk   |
-                                SPIM_INTENSET_END_Msk     |
-                                SPIM_INTENSET_ENDTX_Msk   |
-                                SPIM_INTENSET_STARTED_Msk   ///< All SPIM interrupts.
+    NRF_SPIM_INT_STARTED_MASK    = SPIM_INTENSET_STARTED_Msk,       ///< Interrupt on STARTED event.
+    NRF_SPIM_INT_STOPPED_MASK    = SPIM_INTENSET_STOPPED_Msk,       ///< Interrupt on STOPPED event.
+#if NRF_SPIM_HAS_DMA_TASKS_EVENTS
+    NRF_SPIM_INT_RXREADY_MASK    = SPIM_INTENSET_DMARXREADY_Msk,    ///< Interrupt on DMA.RX.READY event.
+    NRF_SPIM_INT_RXBUSERROR_MASK = SPIM_INTENSET_DMARXBUSERROR_Msk, ///< Interrupt on DMA.RX.BUSERROR event.
+    NRF_SPIM_INT_RXMATCH0_MASK   = SPIM_INTENSET_DMARXMATCH0_Msk,   ///< Interrupt on DMA.RX.MATCH0 event.
+    NRF_SPIM_INT_RXMATCH1_MASK   = SPIM_INTENSET_DMARXMATCH1_Msk,   ///< Interrupt on DMA.RX.MATCH1 event.
+    NRF_SPIM_INT_RXMATCH2_MASK   = SPIM_INTENSET_DMARXMATCH2_Msk,   ///< Interrupt on DMA.RX.MATCH2 event.
+    NRF_SPIM_INT_RXMATCH3_MASK   = SPIM_INTENSET_DMARXMATCH3_Msk,   ///< Interrupt on DMA.RX.MATCH3 event.
+    NRF_SPIM_INT_TXREADY_MASK    = SPIM_INTENSET_DMATXREADY_Msk,    ///< Interrupt on DMA.TX.READY event.
+    NRF_SPIM_INT_TXBUSERROR_MASK = SPIM_INTENSET_DMATXBUSERROR_Msk, ///< Interrupt on DMA.TX.BUSERROR event.
+    NRF_SPIM_INT_ENDRX_MASK      = SPIM_INTENSET_DMARXEND_Msk,      ///< Interrupt on ENDRX event.
+    NRF_SPIM_INT_ENDTX_MASK      = SPIM_INTENSET_DMATXEND_Msk,      ///< Interrupt on ENDTX event.
+#else
+    NRF_SPIM_INT_ENDRX_MASK      = SPIM_INTENSET_ENDRX_Msk,         ///< Interrupt on ENDRX event.
+    NRF_SPIM_INT_ENDTX_MASK      = SPIM_INTENSET_ENDTX_Msk,         ///< Interrupt on ENDTX event.
+#endif
+    NRF_SPIM_INT_END_MASK        = SPIM_INTENSET_END_Msk,           ///< Interrupt on END event.
+    NRF_SPIM_ALL_INTS_MASK       = NRF_SPIM_INT_STARTED_MASK
+                                 | NRF_SPIM_INT_STOPPED_MASK
+#if NRF_SPIM_HAS_DMA_TASKS_EVENTS
+                                 | NRF_SPIM_INT_RXREADY_MASK
+                                 | NRF_SPIM_INT_RXBUSERROR_MASK
+                                 | NRF_SPIM_INT_RXMATCH0_MASK
+                                 | NRF_SPIM_INT_RXMATCH1_MASK
+                                 | NRF_SPIM_INT_RXMATCH2_MASK
+                                 | NRF_SPIM_INT_RXMATCH3_MASK
+                                 | NRF_SPIM_INT_TXREADY_MASK
+                                 | NRF_SPIM_INT_TXBUSERROR_MASK
+#endif
+                                 | NRF_SPIM_INT_ENDRX_MASK
+                                 | NRF_SPIM_INT_ENDTX_MASK
+                                 | NRF_SPIM_INT_END_MASK            ///< All SPIM interrupts.
 } nrf_spim_int_mask_t;
 
+#if NRF_SPIM_HAS_FREQUENCY
 /** @brief SPI master data rates. */
 typedef enum
 {
@@ -157,16 +379,17 @@ typedef enum
     NRF_SPIM_FREQ_1M   = SPIM_FREQUENCY_FREQUENCY_M1,      ///< 1 Mbps.
     NRF_SPIM_FREQ_2M   = SPIM_FREQUENCY_FREQUENCY_M2,      ///< 2 Mbps.
     NRF_SPIM_FREQ_4M   = SPIM_FREQUENCY_FREQUENCY_M4,      ///< 4 Mbps.
-    // [conversion to 'int' needed to prevent compilers from complaining
-    //  that the provided value (0x80000000UL) is out of range of "int"]
+    // Conversion to int is needed to prevent compilers from getting an error message
+    // that the provided value (0x80000000UL) is out of range for int.
     NRF_SPIM_FREQ_8M   = (int)SPIM_FREQUENCY_FREQUENCY_M8, ///< 8 Mbps.
-#if defined(SPIM_FREQUENCY_FREQUENCY_M16) || defined(__NRFX_DOXYGEN__)
+#if NRF_SPIM_HAS_16_MHZ_FREQ
     NRF_SPIM_FREQ_16M  = SPIM_FREQUENCY_FREQUENCY_M16,     ///< 16 Mbps.
 #endif
-#if defined(SPIM_FREQUENCY_FREQUENCY_M32) || defined(__NRFX_DOXYGEN__)
+#if NRF_SPIM_HAS_32_MHZ_FREQ
     NRF_SPIM_FREQ_32M  = SPIM_FREQUENCY_FREQUENCY_M32      ///< 32 Mbps.
 #endif
 } nrf_spim_frequency_t;
+#endif // NRF_SPIM_HAS_FREQUENCY
 
 /** @brief SPI modes. */
 typedef enum
@@ -184,15 +407,19 @@ typedef enum
     NRF_SPIM_BIT_ORDER_LSB_FIRST = SPIM_CONFIG_ORDER_LsbFirst  ///< Least significant bit shifted out first.
 } nrf_spim_bit_order_t;
 
-#if (NRF_SPIM_HW_CSN_PRESENT) || defined(__NRFX_DOXYGEN__)
+#if NRF_SPIM_HAS_HW_CSN
 /** @brief SPI CSN pin polarity. */
 typedef enum
 {
+#if defined(SPIM_CSNPOL_CSNPOL0_LOW)
+    NRF_SPIM_CSN_POL_LOW  = SPIM_CSNPOL_CSNPOL0_LOW, ///< Active low (idle state high).
+    NRF_SPIM_CSN_POL_HIGH = SPIM_CSNPOL_CSNPOL0_HIGH ///< Active high (idle state low).
+#else
     NRF_SPIM_CSN_POL_LOW  = SPIM_CSNPOL_CSNPOL_LOW, ///< Active low (idle state high).
     NRF_SPIM_CSN_POL_HIGH = SPIM_CSNPOL_CSNPOL_HIGH ///< Active high (idle state low).
+#endif
 } nrf_spim_csn_pol_t;
-#endif // (NRF_SPIM_HW_CSN_PRESENT) || defined(__NRFX_DOXYGEN__)
-
+#endif
 
 /**
  * @brief Function for activating the specified SPIM task.
@@ -281,6 +508,26 @@ NRF_STATIC_INLINE uint32_t nrf_spim_shorts_get(NRF_SPIM_Type const * p_reg);
  */
 NRF_STATIC_INLINE void nrf_spim_int_enable(NRF_SPIM_Type * p_reg,
                                            uint32_t        mask);
+
+#if NRF_SPIM_HAS_PRESCALER
+/**
+ * @brief Function for setting the prescaler value.
+ *
+ * @param[in] p_reg     Pointer to the structure of registers of the peripheral.
+ * @param[in] prescaler Prescaler value.
+ */
+NRF_STATIC_INLINE void nrf_spim_prescaler_set(NRF_SPIM_Type * p_reg,
+                                              uint32_t        prescaler);
+
+/**
+ * @brief Function for getting the prescaler value.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ *
+ * @return Prescaler value.
+ */
+NRF_STATIC_INLINE uint32_t nrf_spim_prescaler_get(NRF_SPIM_Type const * p_reg);
+#endif
 
 /**
  * @brief Function for disabling the specified interrupts.
@@ -404,7 +651,7 @@ NRF_STATIC_INLINE uint32_t nrf_spim_mosi_pin_get(NRF_SPIM_Type const * p_reg);
  */
 NRF_STATIC_INLINE uint32_t nrf_spim_miso_pin_get(NRF_SPIM_Type const * p_reg);
 
-#if (NRF_SPIM_HW_CSN_PRESENT) || defined(__NRFX_DOXYGEN__)
+#if NRF_SPIM_HAS_HW_CSN
 /**
  * @brief Function for configuring the SPIM hardware CSN pin.
  *
@@ -422,9 +669,18 @@ NRF_STATIC_INLINE void nrf_spim_csn_configure(NRF_SPIM_Type *    p_reg,
                                               uint32_t           pin,
                                               nrf_spim_csn_pol_t polarity,
                                               uint32_t           duration);
-#endif // (NRF_SPIM_HW_CSN_PRESENT) || defined(__NRFX_DOXYGEN__)
 
-#if NRF_SPIM_DCX_PRESENT || defined(__NRFX_DOXYGEN__)
+/**
+ * @brief Function for getting the CSN pin selection.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ *
+ * @return CSN pin selection.
+ */
+NRF_STATIC_INLINE uint32_t nrf_spim_csn_pin_get(NRF_SPIM_Type const * p_reg);
+#endif
+
+#if NRF_SPIM_HAS_DCX
 /**
  * @brief Function for configuring the SPIM DCX pin.
  *
@@ -459,9 +715,9 @@ NRF_STATIC_INLINE uint32_t nrf_spim_dcx_pin_get(NRF_SPIM_Type const * p_reg);
  */
 NRF_STATIC_INLINE void nrf_spim_dcx_cnt_set(NRF_SPIM_Type * p_reg,
                                             uint32_t        count);
-#endif // NRF_SPIM_DCX_PRESENT || defined(__NRFX_DOXYGEN__)
+#endif // NRF_SPIM_HAS_DCX
 
-#if NRF_SPIM_RXDELAY_PRESENT || defined(__NRFX_DOXYGEN__)
+#if NRF_SPIM_HAS_RXDELAY
 /**
  * @brief Function for configuring the extended SPIM interface.
  *
@@ -471,9 +727,9 @@ NRF_STATIC_INLINE void nrf_spim_dcx_cnt_set(NRF_SPIM_Type * p_reg,
  */
 NRF_STATIC_INLINE void nrf_spim_iftiming_set(NRF_SPIM_Type * p_reg,
                                              uint32_t        rxdelay);
-#endif // NRF_SPIM_RXDELAY_PRESENT || defined(__NRFX_DOXYGEN__)
+#endif
 
-#if defined(SPIM_STALLSTAT_RX_Msk) || defined(__NRFX_DOXYGEN__)
+#if NRF_SPIM_HAS_STALLSTAT
 /**
  * @brief Function for clearing stall status for RX EasyDMA RAM accesses.
  *
@@ -489,9 +745,7 @@ NRF_STATIC_INLINE void nrf_spim_stallstat_rx_clear(NRF_SPIM_Type * p_reg);
  * @return Stall status of RX EasyDMA RAM accesses.
  */
 NRF_STATIC_INLINE bool nrf_spim_stallstat_rx_get(NRF_SPIM_Type const * p_reg);
-#endif // defined(SPIM_STALLSTAT_RX_Msk) || defined(__NRFX_DOXYGEN__)
 
-#if defined(SPIM_STALLSTAT_TX_Msk) || defined(__NRFX_DOXYGEN__)
 /**
  * @brief Function for clearing stall status for TX EasyDMA RAM accesses.
  *
@@ -507,8 +761,9 @@ NRF_STATIC_INLINE void nrf_spim_stallstat_tx_clear(NRF_SPIM_Type * p_reg);
  * @return Stall status of TX EasyDMA RAM accesses.
  */
 NRF_STATIC_INLINE bool nrf_spim_stallstat_tx_get(NRF_SPIM_Type const * p_reg);
-#endif // defined(SPIM_STALLSTAT_TX_Msk) || defined(__NRFX_DOXYGEN__)
+#endif // NRF_SPIM_HAS_STALLSTAT
 
+#if NRF_SPIM_HAS_FREQUENCY
 /**
  * @brief Function for setting the SPI master data rate.
  *
@@ -517,6 +772,16 @@ NRF_STATIC_INLINE bool nrf_spim_stallstat_tx_get(NRF_SPIM_Type const * p_reg);
  */
 NRF_STATIC_INLINE void nrf_spim_frequency_set(NRF_SPIM_Type *      p_reg,
                                               nrf_spim_frequency_t frequency);
+
+/**
+ * @brief Function for getting the SPI master data rate.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ *
+ * @retval SPI master frequency.
+ */
+NRF_STATIC_INLINE nrf_spim_frequency_t nrf_spim_frequency_get(NRF_SPIM_Type * p_reg);
+#endif
 
 /**
  * @brief Function for setting the transmit buffer.
@@ -530,6 +795,24 @@ NRF_STATIC_INLINE void nrf_spim_tx_buffer_set(NRF_SPIM_Type * p_reg,
                                               size_t          length);
 
 /**
+ * @brief Function for getting number of bytes transmitted in the last transaction.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ *
+ * @retval Amount of bytes transmitted.
+ */
+NRF_STATIC_INLINE uint32_t nrf_spim_tx_amount_get(NRF_SPIM_Type const * p_reg);
+
+/**
+ * @brief Function for getting number of bytes to be transmitted in the next transaction.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ *
+ * @retval Amount of bytes to be transmitted.
+ */
+NRF_STATIC_INLINE uint32_t nrf_spim_tx_maxcnt_get(NRF_SPIM_Type const * p_reg);
+
+/**
  * @brief Function for setting the receive buffer.
  *
  * @param[in] p_reg    Pointer to the structure of registers of the peripheral.
@@ -539,6 +822,24 @@ NRF_STATIC_INLINE void nrf_spim_tx_buffer_set(NRF_SPIM_Type * p_reg,
 NRF_STATIC_INLINE void nrf_spim_rx_buffer_set(NRF_SPIM_Type * p_reg,
                                               uint8_t *       p_buffer,
                                               size_t          length);
+
+/**
+ * @brief Function for getting number of bytes received in the last transaction.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ *
+ * @retval Amount of bytes received.
+ */
+NRF_STATIC_INLINE uint32_t nrf_spim_rx_amount_get(NRF_SPIM_Type const * p_reg);
+
+/**
+ * @brief Function for getting number of bytes to be received in the next transaction.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ *
+ * @retval Amount of bytes to be received.
+ */
+NRF_STATIC_INLINE uint32_t nrf_spim_rx_maxcnt_get(NRF_SPIM_Type const * p_reg);
 
 /**
  * @brief Function for setting the SPI configuration.
@@ -561,6 +862,7 @@ NRF_STATIC_INLINE void nrf_spim_configure(NRF_SPIM_Type *      p_reg,
 NRF_STATIC_INLINE void nrf_spim_orc_set(NRF_SPIM_Type * p_reg,
                                         uint8_t         orc);
 
+#if NRF_SPIM_HAS_ARRAY_LIST
 /**
  * @brief Function for enabling the TX list feature.
  *
@@ -588,7 +890,135 @@ NRF_STATIC_INLINE void nrf_spim_rx_list_enable(NRF_SPIM_Type * p_reg);
  * @param[in] p_reg Pointer to the structure of registers of the peripheral.
  */
 NRF_STATIC_INLINE void nrf_spim_rx_list_disable(NRF_SPIM_Type * p_reg);
+#endif
 
+#if NRF_SPIM_HAS_DMA_TASKS_EVENTS
+/**
+ * @brief Function for enabling individual pattern match filters.
+ *
+ * @param[in] p_reg  Pointer to the structure of registers of the peripheral.
+ * @param[in] index  Index of pattern match filter.
+ * @param[in] enable True if pattern match filter is to be enabled, false otherwise.
+ */
+NRF_STATIC_INLINE void nrf_spim_rx_pattern_match_enable_set(NRF_SPIM_Type * p_reg,
+                                                            uint8_t         index,
+                                                            bool            enable);
+
+/**
+ * @brief Function for checking if the specified pattern match filter is enabled.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ * @param[in] index Index of pattern match filter.
+ *
+ * @retval true  Pattern match filter is enabled.
+ * @retval false Pattern match filter is disabled.
+ */
+NRF_STATIC_INLINE bool nrf_spim_rx_pattern_match_enable_check(NRF_SPIM_Type const * p_reg,
+                                                              uint8_t               index);
+
+/**
+ * @brief Function for enabling one-shot operation for the specified match filter.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ * @param[in] index Index of pattern match filter.
+ */
+NRF_STATIC_INLINE void nrf_spim_rx_pattern_match_one_shot_enable(NRF_SPIM_Type * p_reg,
+                                                                 uint8_t         index);
+
+/**
+ * @brief Function for disabling one-shot operation for the specified match filter.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ * @param[in] index Index of pattern match filter.
+ */
+NRF_STATIC_INLINE void nrf_spim_rx_pattern_match_one_shot_disable(NRF_SPIM_Type * p_reg,
+                                                                  uint8_t         index);
+
+/**
+ * @brief Function for checking if specified pattern match filter is configured as one-shot.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ * @param[in] index Index of pattern match filter.
+ *
+ * @retval true  Pattern match filter is configured as one-shot.
+ * @retval false Pattern match filter is configured as continuous.
+ */
+NRF_STATIC_INLINE bool nrf_spim_rx_pattern_match_one_shot_check(NRF_SPIM_Type const * p_reg,
+                                                                uint8_t               index);
+
+/**
+ * @brief Function for setting the pattern to be looked for by the specified match filter.
+ *
+ * @param[in] p_reg   Pointer to the structure of registers of the peripheral.
+ * @param[in] index   Index of pattern match filter.
+ * @param[in] pattern Pattern to be looked for.
+ *                    Match will trigger the corresponding event, if enabled.
+ */
+NRF_STATIC_INLINE void nrf_spim_rx_pattern_match_candidate_set(NRF_SPIM_Type * p_reg,
+                                                               uint8_t         index,
+                                                               uint32_t        pattern);
+
+/**
+ * @brief Function for getting the pattern that the specified match filter is looking for.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ * @param[in] index Index of pattern match filter.
+ *
+ * @return Pattern that the specified match filter is looking for.
+ */
+NRF_STATIC_INLINE uint32_t nrf_spim_rx_pattern_match_candidate_get(NRF_SPIM_Type const * p_reg,
+                                                                   uint8_t               index);
+#endif // NRF_SPIM_HAS_DMA_TASKS_EVENTS
+
+#if NRF_SPIM_HAS_DMA_REG
+/**
+ * @brief Function for enabling the termination of the RX transaction after detecting the BUSERROR event.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ */
+NRF_STATIC_INLINE void nrf_spim_rx_terminate_on_bus_error_enable(NRF_SPIM_Type * p_reg);
+
+/**
+ * @brief Function for disabling the termination of the RX transaction after detecting the BUSERROR event.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ */
+NRF_STATIC_INLINE void nrf_spim_rx_terminate_on_bus_error_disable(NRF_SPIM_Type * p_reg);
+
+/**
+ * @brief Function for checking if RX transaction termination after detecting the BUSERROR event is enabled.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ *
+ * @retval true  RX transaction termination after detecting a BUSERROR event is enabled.
+ * @retval false RX transaction termination after detecting a BUSERROR event is disabled.
+ */
+NRF_STATIC_INLINE bool nrf_spim_rx_terminate_on_bus_error_check(NRF_SPIM_Type const * p_reg);
+
+/**
+ * @brief Function for enabling the termination of the TX transaction after detecting the BUSERROR event.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ */
+NRF_STATIC_INLINE void nrf_spim_tx_terminate_on_bus_error_enable(NRF_SPIM_Type * p_reg);
+
+/**
+ * @brief Function for disabling the termination of the TX transaction after detecting the BUSERROR event.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ */
+NRF_STATIC_INLINE void nrf_spim_tx_terminate_on_bus_error_disable(NRF_SPIM_Type * p_reg);
+
+/**
+ * @brief Function for checking if TX transaction termination after detecting the BUSERROR event is enabled.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ *
+ * @retval true  TX transaction termination after detecting a BUSERROR event is enabled.
+ * @retval false TX transaction termination after detecting a BUSERROR event is disabled.
+ */
+NRF_STATIC_INLINE bool nrf_spim_tx_terminate_on_bus_error_check(NRF_SPIM_Type const * p_reg);
+#endif // NRF_SPIM_HAS_DMA_REG
 
 #ifndef NRF_DECLARE_ONLY
 
@@ -657,13 +1087,29 @@ NRF_STATIC_INLINE uint32_t nrf_spim_int_enable_check(NRF_SPIM_Type const * p_reg
     return p_reg->INTENSET & mask;
 }
 
+#if NRF_SPIM_HAS_PRESCALER
+NRF_STATIC_INLINE void nrf_spim_prescaler_set(NRF_SPIM_Type * p_reg,
+                                              uint32_t        prescaler)
+{
+    NRFX_ASSERT(prescaler >= NRF_SPIM_PRESCALER_MIN);
+    NRFX_ASSERT(prescaler <= NRF_SPIM_PRESCALER_MAX);
+    NRFX_ASSERT(NRFX_IS_EVEN(prescaler));
+    p_reg->PRESCALER = prescaler;
+}
+
+NRF_STATIC_INLINE uint32_t nrf_spim_prescaler_get(NRF_SPIM_Type const * p_reg)
+{
+    return p_reg->PRESCALER;
+}
+#endif
+
 #if defined(DPPI_PRESENT)
 NRF_STATIC_INLINE void nrf_spim_subscribe_set(NRF_SPIM_Type * p_reg,
                                               nrf_spim_task_t task,
                                               uint8_t         channel)
 {
     *((volatile uint32_t *) ((uint8_t *) p_reg + (uint32_t) task + 0x80uL)) =
-            ((uint32_t)channel | SPIM_SUBSCRIBE_START_EN_Msk);
+            ((uint32_t)channel | NRF_SUBSCRIBE_PUBLISH_ENABLE);
 }
 
 NRF_STATIC_INLINE void nrf_spim_subscribe_clear(NRF_SPIM_Type * p_reg,
@@ -677,7 +1123,7 @@ NRF_STATIC_INLINE void nrf_spim_publish_set(NRF_SPIM_Type *  p_reg,
                                             uint8_t          channel)
 {
     *((volatile uint32_t *) ((uint8_t *) p_reg + (uint32_t) event + 0x80uL)) =
-            ((uint32_t)channel | SPIM_PUBLISH_STARTED_EN_Msk);
+            ((uint32_t)channel | NRF_SUBSCRIBE_PUBLISH_ENABLE);
 }
 
 NRF_STATIC_INLINE void nrf_spim_publish_clear(NRF_SPIM_Type *  p_reg,
@@ -685,7 +1131,7 @@ NRF_STATIC_INLINE void nrf_spim_publish_clear(NRF_SPIM_Type *  p_reg,
 {
     *((volatile uint32_t *) ((uint8_t *) p_reg + (uint32_t) event + 0x80uL)) = 0;
 }
-#endif // defined(DPPI_PRESENT)
+#endif
 
 NRF_STATIC_INLINE void nrf_spim_enable(NRF_SPIM_Type * p_reg)
 {
@@ -722,46 +1168,65 @@ NRF_STATIC_INLINE uint32_t nrf_spim_miso_pin_get(NRF_SPIM_Type const * p_reg)
     return p_reg->PSEL.MISO;
 }
 
-#if NRF_SPIM_HW_CSN_PRESENT
+#if NRF_SPIM_HAS_HW_CSN
 NRF_STATIC_INLINE void nrf_spim_csn_configure(NRF_SPIM_Type *    p_reg,
                                               uint32_t           pin,
                                               nrf_spim_csn_pol_t polarity,
                                               uint32_t           duration)
 {
+#if defined(SPIM_CSNPOL_CSNPOL0_LOW)
+    p_reg->PSEL.CSN[0] = pin;
+#else
     p_reg->PSEL.CSN = pin;
+#endif
     p_reg->CSNPOL = polarity;
     p_reg->IFTIMING.CSNDUR = duration;
 }
-#endif // NRF_SPIM_HW_CSN_PRESENT
 
-#if NRF_SPIM_DCX_PRESENT
-NRF_STATIC_INLINE void nrf_spim_dcx_pin_set(NRF_SPIM_Type * p_reg,
-                                            uint32_t        dcx_pin)
+NRF_STATIC_INLINE uint32_t nrf_spim_csn_pin_get(NRF_SPIM_Type const * p_reg)
 {
+#if defined(SPIM_CSNPOL_CSNPOL0_LOW)
+    return p_reg->PSEL.CSN[0];
+#else
+    return p_reg->PSEL.CSN;
+#endif
+}
+#endif // NRF_SPIM_HAS_HW_CSN
+
+#if NRF_SPIM_HAS_DCX
+NRF_STATIC_INLINE void nrf_spim_dcx_pin_set(NRF_SPIM_Type * p_reg, uint32_t dcx_pin)
+{
+#if defined(SPIM_PSEL_DCX_PIN_Msk)
+    p_reg->PSEL.DCX = dcx_pin;
+#else
     p_reg->PSELDCX = dcx_pin;
+#endif
 }
 
 NRF_STATIC_INLINE uint32_t nrf_spim_dcx_pin_get(NRF_SPIM_Type const * p_reg)
 {
+#if defined(SPIM_PSEL_DCX_PIN_Msk)
+    return p_reg->PSEL.DCX;
+#else
     return p_reg->PSELDCX;
+#endif
 }
 
-NRF_STATIC_INLINE void nrf_spim_dcx_cnt_set(NRF_SPIM_Type * p_reg,
-                                            uint32_t        dcx_cnt)
+NRF_STATIC_INLINE void nrf_spim_dcx_cnt_set(NRF_SPIM_Type * p_reg, uint32_t dcx_cnt)
 {
     p_reg->DCXCNT = dcx_cnt;
 }
-#endif // NRF_SPIM_DCX_PRESENT
+#endif // NRF_SPIM_HAS_DCX
 
-#if NRF_SPIM_RXDELAY_PRESENT
+#if NRF_SPIM_HAS_RXDELAY
 NRF_STATIC_INLINE void nrf_spim_iftiming_set(NRF_SPIM_Type * p_reg,
                                              uint32_t        rxdelay)
 {
     p_reg->IFTIMING.RXDELAY = rxdelay;
 }
-#endif // NRF_SPIM_RXDELAY_PRESENT
+#endif
 
-#if defined(SPIM_STALLSTAT_RX_Msk)
+#if NRF_SPIM_HAS_STALLSTAT
 NRF_STATIC_INLINE void nrf_spim_stallstat_rx_clear(NRF_SPIM_Type * p_reg)
 {
     p_reg->STALLSTAT &= ~(SPIM_STALLSTAT_RX_Msk);
@@ -771,9 +1236,7 @@ NRF_STATIC_INLINE bool nrf_spim_stallstat_rx_get(NRF_SPIM_Type const * p_reg)
 {
     return (p_reg->STALLSTAT & SPIM_STALLSTAT_RX_Msk) != 0;
 }
-#endif // defined(SPIM_STALLSTAT_RX_Msk)
 
-#if defined(SPIM_STALLSTAT_TX_Msk)
 NRF_STATIC_INLINE void nrf_spim_stallstat_tx_clear(NRF_SPIM_Type * p_reg)
 {
     p_reg->STALLSTAT &= ~(SPIM_STALLSTAT_TX_Msk);
@@ -783,28 +1246,81 @@ NRF_STATIC_INLINE bool nrf_spim_stallstat_tx_get(NRF_SPIM_Type const * p_reg)
 {
     return (p_reg->STALLSTAT & SPIM_STALLSTAT_TX_Msk) != 0;
 }
-#endif // defined(SPIM_STALLSTAT_TX_Msk)
+#endif
 
+#if NRF_SPIM_HAS_FREQUENCY
 NRF_STATIC_INLINE void nrf_spim_frequency_set(NRF_SPIM_Type *      p_reg,
                                               nrf_spim_frequency_t frequency)
 {
     p_reg->FREQUENCY = (uint32_t)frequency;
 }
 
+NRF_STATIC_INLINE nrf_spim_frequency_t nrf_spim_frequency_get(NRF_SPIM_Type * p_reg)
+{
+    return (nrf_spim_frequency_t)(p_reg->FREQUENCY);
+}
+#endif
+
 NRF_STATIC_INLINE void nrf_spim_tx_buffer_set(NRF_SPIM_Type * p_reg,
                                               uint8_t const * p_buffer,
                                               size_t          length)
 {
+#if NRF_SPIM_HAS_DMA_REG
+    p_reg->DMA.TX.PTR    = (uint32_t)p_buffer;
+    p_reg->DMA.TX.MAXCNT = length;
+#else
     p_reg->TXD.PTR    = (uint32_t)p_buffer;
     p_reg->TXD.MAXCNT = length;
+#endif
+}
+
+NRF_STATIC_INLINE uint32_t nrf_spim_tx_amount_get(NRF_SPIM_Type const * p_reg)
+{
+#if NRF_SPIM_HAS_DMA_REG
+    return p_reg->DMA.TX.AMOUNT;
+#else
+    return p_reg->TXD.AMOUNT;
+#endif
+}
+
+NRF_STATIC_INLINE uint32_t nrf_spim_tx_maxcnt_get(NRF_SPIM_Type const * p_reg)
+{
+#if NRF_SPIM_HAS_DMA_REG
+    return p_reg->DMA.TX.MAXCNT;
+#else
+    return p_reg->TXD.MAXCNT;
+#endif
 }
 
 NRF_STATIC_INLINE void nrf_spim_rx_buffer_set(NRF_SPIM_Type * p_reg,
-                                              uint8_t * p_buffer,
-                                              size_t    length)
+                                              uint8_t *       p_buffer,
+                                              size_t          length)
 {
+#if NRF_SPIM_HAS_DMA_REG
+    p_reg->DMA.RX.PTR    = (uint32_t)p_buffer;
+    p_reg->DMA.RX.MAXCNT = length;
+#else
     p_reg->RXD.PTR    = (uint32_t)p_buffer;
     p_reg->RXD.MAXCNT = length;
+#endif
+}
+
+NRF_STATIC_INLINE uint32_t nrf_spim_rx_amount_get(NRF_SPIM_Type const * p_reg)
+{
+#if NRF_SPIM_HAS_DMA_REG
+    return p_reg->DMA.RX.AMOUNT;
+#else
+    return p_reg->RXD.AMOUNT;
+#endif
+}
+
+NRF_STATIC_INLINE uint32_t nrf_spim_rx_maxcnt_get(NRF_SPIM_Type const * p_reg)
+{
+#if NRF_SPIM_HAS_DMA_REG
+    return p_reg->DMA.RX.MAXCNT;
+#else
+    return p_reg->RXD.MAXCNT;
+#endif
 }
 
 NRF_STATIC_INLINE void nrf_spim_configure(NRF_SPIM_Type *      p_reg,
@@ -845,7 +1361,7 @@ NRF_STATIC_INLINE void nrf_spim_orc_set(NRF_SPIM_Type * p_reg,
     p_reg->ORC = orc;
 }
 
-
+#if NRF_SPIM_HAS_ARRAY_LIST
 NRF_STATIC_INLINE void nrf_spim_tx_list_enable(NRF_SPIM_Type * p_reg)
 {
     p_reg->TXD.LIST = SPIM_TXD_LIST_LIST_ArrayList << SPIM_TXD_LIST_LIST_Pos;
@@ -865,6 +1381,209 @@ NRF_STATIC_INLINE void nrf_spim_rx_list_disable(NRF_SPIM_Type * p_reg)
 {
     p_reg->RXD.LIST = SPIM_RXD_LIST_LIST_Disabled << SPIM_RXD_LIST_LIST_Pos;
 }
+#endif
+
+#if NRF_SPIM_HAS_DMA_TASKS_EVENTS
+NRF_STATIC_INLINE void nrf_spim_rx_pattern_match_enable_set(NRF_SPIM_Type * p_reg,
+                                                            uint8_t         index,
+                                                            bool            enable)
+{
+    NRFX_ASSERT(index < NRF_SPIM_DMA_RX_PATTERN_MAX_COUNT);
+    switch (index)
+    {
+        case 0:
+            p_reg->DMA.RX.MATCH.CONFIG = ((p_reg->DMA.RX.MATCH.CONFIG &
+                                         ~SPIM_DMA_RX_MATCH_CONFIG_ENABLE0_Msk) |
+                                         ((enable ?
+                                           SPIM_DMA_RX_MATCH_CONFIG_ENABLE0_Enabled :
+                                           SPIM_DMA_RX_MATCH_CONFIG_ENABLE0_Disabled)
+                                           << SPIM_DMA_RX_MATCH_CONFIG_ENABLE0_Pos));
+            break;
+        case 1:
+            p_reg->DMA.RX.MATCH.CONFIG = ((p_reg->DMA.RX.MATCH.CONFIG &
+                                         ~SPIM_DMA_RX_MATCH_CONFIG_ENABLE1_Msk) |
+                                         ((enable ?
+                                           SPIM_DMA_RX_MATCH_CONFIG_ENABLE1_Enabled :
+                                           SPIM_DMA_RX_MATCH_CONFIG_ENABLE1_Disabled)
+                                           << SPIM_DMA_RX_MATCH_CONFIG_ENABLE1_Pos));
+            break;
+        case 2:
+            p_reg->DMA.RX.MATCH.CONFIG = ((p_reg->DMA.RX.MATCH.CONFIG &
+                                         ~SPIM_DMA_RX_MATCH_CONFIG_ENABLE2_Msk) |
+                                         ((enable ?
+                                           SPIM_DMA_RX_MATCH_CONFIG_ENABLE2_Enabled :
+                                           SPIM_DMA_RX_MATCH_CONFIG_ENABLE2_Disabled)
+                                           << SPIM_DMA_RX_MATCH_CONFIG_ENABLE2_Pos));
+            break;
+        case 3:
+            p_reg->DMA.RX.MATCH.CONFIG = ((p_reg->DMA.RX.MATCH.CONFIG &
+                                         ~SPIM_DMA_RX_MATCH_CONFIG_ENABLE3_Msk) |
+                                         ((enable ?
+                                           SPIM_DMA_RX_MATCH_CONFIG_ENABLE3_Enabled :
+                                           SPIM_DMA_RX_MATCH_CONFIG_ENABLE3_Disabled)
+                                           << SPIM_DMA_RX_MATCH_CONFIG_ENABLE3_Pos));
+            break;
+        default:
+            NRFX_ASSERT(false);
+            break;
+    }
+}
+
+NRF_STATIC_INLINE bool nrf_spim_rx_pattern_match_enable_check(NRF_SPIM_Type const * p_reg,
+                                                              uint8_t               index)
+{
+    NRFX_ASSERT(index < NRF_SPIM_DMA_RX_PATTERN_MAX_COUNT);
+    switch (index)
+    {
+        case 0:
+            return ((p_reg->DMA.RX.MATCH.CONFIG & SPIM_DMA_RX_MATCH_CONFIG_ENABLE0_Msk)
+                    >> SPIM_DMA_RX_MATCH_CONFIG_ENABLE0_Pos) ==
+                    SPIM_DMA_RX_MATCH_CONFIG_ENABLE0_Enabled;
+        case 1:
+            return ((p_reg->DMA.RX.MATCH.CONFIG & SPIM_DMA_RX_MATCH_CONFIG_ENABLE1_Msk)
+                    >> SPIM_DMA_RX_MATCH_CONFIG_ENABLE1_Pos) ==
+                    SPIM_DMA_RX_MATCH_CONFIG_ENABLE1_Enabled;
+        case 2:
+            return ((p_reg->DMA.RX.MATCH.CONFIG & SPIM_DMA_RX_MATCH_CONFIG_ENABLE2_Msk)
+                    >> SPIM_DMA_RX_MATCH_CONFIG_ENABLE2_Pos) ==
+                    SPIM_DMA_RX_MATCH_CONFIG_ENABLE2_Enabled;
+        case 3:
+            return ((p_reg->DMA.RX.MATCH.CONFIG & SPIM_DMA_RX_MATCH_CONFIG_ENABLE3_Msk)
+                    >> SPIM_DMA_RX_MATCH_CONFIG_ENABLE3_Pos) ==
+                    SPIM_DMA_RX_MATCH_CONFIG_ENABLE3_Enabled;
+        default:
+            NRFX_ASSERT(false);
+            return 0;
+    }
+}
+
+NRF_STATIC_INLINE void nrf_spim_rx_pattern_match_one_shot_enable(NRF_SPIM_Type * p_reg,
+                                                                 uint8_t         index)
+{
+    NRFX_ASSERT(index < NRF_SPIM_DMA_RX_PATTERN_MAX_COUNT);
+    switch (index)
+    {
+        case 0:
+            p_reg->DMA.RX.MATCH.CONFIG |= SPIM_DMA_RX_MATCH_CONFIG_ONESHOT0_Msk;
+            break;
+        case 1:
+            p_reg->DMA.RX.MATCH.CONFIG |= SPIM_DMA_RX_MATCH_CONFIG_ONESHOT1_Msk;
+            break;
+        case 2:
+            p_reg->DMA.RX.MATCH.CONFIG |= SPIM_DMA_RX_MATCH_CONFIG_ONESHOT2_Msk;
+            break;
+        case 3:
+            p_reg->DMA.RX.MATCH.CONFIG |= SPIM_DMA_RX_MATCH_CONFIG_ONESHOT3_Msk;
+            break;
+        default:
+            NRFX_ASSERT(false);
+            break;
+    }
+}
+
+NRF_STATIC_INLINE void nrf_spim_rx_pattern_match_one_shot_disable(NRF_SPIM_Type * p_reg,
+                                                                  uint8_t         index)
+{
+    NRFX_ASSERT(index < NRF_SPIM_DMA_RX_PATTERN_MAX_COUNT);
+    switch (index)
+    {
+        case 0:
+            p_reg->DMA.RX.MATCH.CONFIG &= ~(SPIM_DMA_RX_MATCH_CONFIG_ONESHOT0_Msk);
+            break;
+        case 1:
+            p_reg->DMA.RX.MATCH.CONFIG &= ~(SPIM_DMA_RX_MATCH_CONFIG_ONESHOT1_Msk);
+            break;
+        case 2:
+            p_reg->DMA.RX.MATCH.CONFIG &= ~(SPIM_DMA_RX_MATCH_CONFIG_ONESHOT2_Msk);
+            break;
+        case 3:
+            p_reg->DMA.RX.MATCH.CONFIG &= ~(SPIM_DMA_RX_MATCH_CONFIG_ONESHOT3_Msk);
+            break;
+        default:
+            NRFX_ASSERT(false);
+            break;
+    }
+}
+
+NRF_STATIC_INLINE bool nrf_spim_rx_pattern_match_one_shot_check(NRF_SPIM_Type const * p_reg,
+                                                                uint8_t               index)
+{
+    NRFX_ASSERT(index < NRF_SPIM_DMA_RX_PATTERN_MAX_COUNT);
+    switch (index)
+    {
+        case 0:
+            return ((p_reg->DMA.RX.MATCH.CONFIG & SPIM_DMA_RX_MATCH_CONFIG_ONESHOT0_Msk)
+                    >> SPIM_DMA_RX_MATCH_CONFIG_ONESHOT0_Pos) ==
+                    SPIM_DMA_RX_MATCH_CONFIG_ONESHOT0_Oneshot;
+        case 1:
+            return ((p_reg->DMA.RX.MATCH.CONFIG & SPIM_DMA_RX_MATCH_CONFIG_ONESHOT1_Msk)
+                    >> SPIM_DMA_RX_MATCH_CONFIG_ONESHOT1_Pos) ==
+                    SPIM_DMA_RX_MATCH_CONFIG_ONESHOT1_Oneshot;
+        case 2:
+            return ((p_reg->DMA.RX.MATCH.CONFIG & SPIM_DMA_RX_MATCH_CONFIG_ONESHOT2_Msk)
+                    >> SPIM_DMA_RX_MATCH_CONFIG_ONESHOT2_Pos) ==
+                    SPIM_DMA_RX_MATCH_CONFIG_ONESHOT2_Oneshot;
+        case 3:
+            return ((p_reg->DMA.RX.MATCH.CONFIG & SPIM_DMA_RX_MATCH_CONFIG_ONESHOT3_Msk)
+                    >> SPIM_DMA_RX_MATCH_CONFIG_ONESHOT3_Pos) ==
+                    SPIM_DMA_RX_MATCH_CONFIG_ONESHOT3_Oneshot;
+        default:
+            NRFX_ASSERT(false);
+            return 0;
+    }
+}
+
+NRF_STATIC_INLINE void nrf_spim_rx_pattern_match_candidate_set(NRF_SPIM_Type * p_reg,
+                                                               uint8_t         index,
+                                                               uint32_t        pattern)
+{
+    NRFX_ASSERT(index < NRF_SPIM_DMA_RX_PATTERN_MAX_COUNT);
+    p_reg->DMA.RX.MATCH.CANDIDATE[index] = pattern;
+}
+
+NRF_STATIC_INLINE uint32_t nrf_spim_rx_pattern_match_candidate_get(NRF_SPIM_Type const * p_reg,
+                                                                   uint8_t               index)
+{
+    NRFX_ASSERT(index < NRF_SPIM_DMA_RX_PATTERN_MAX_COUNT);
+    return p_reg->DMA.RX.MATCH.CANDIDATE[index];
+}
+#endif // NRF_SPIM_HAS_DMA_TASKS_EVENTS
+
+#if NRF_SPIM_HAS_DMA_REG
+NRF_STATIC_INLINE void nrf_spim_rx_terminate_on_bus_error_enable(NRF_SPIM_Type * p_reg)
+{
+    p_reg->DMA.RX.TERMINATEONBUSERROR |= SPIM_DMA_RX_TERMINATEONBUSERROR_ENABLE_Msk;
+}
+
+NRF_STATIC_INLINE void nrf_spim_rx_terminate_on_bus_error_disable(NRF_SPIM_Type * p_reg)
+{
+    p_reg->DMA.RX.TERMINATEONBUSERROR &= ~(SPIM_DMA_RX_TERMINATEONBUSERROR_ENABLE_Msk);
+}
+
+NRF_STATIC_INLINE bool nrf_spim_rx_terminate_on_bus_error_check(NRF_SPIM_Type const * p_reg)
+{
+    return ((p_reg->DMA.RX.TERMINATEONBUSERROR & SPIM_DMA_RX_TERMINATEONBUSERROR_ENABLE_Msk)
+            >> SPIM_DMA_RX_TERMINATEONBUSERROR_ENABLE_Pos) ==
+            SPIM_DMA_RX_ENABLE_ENABLE_Enabled;
+}
+
+NRF_STATIC_INLINE void nrf_spim_tx_terminate_on_bus_error_enable(NRF_SPIM_Type * p_reg)
+{
+    p_reg->DMA.TX.TERMINATEONBUSERROR |= SPIM_DMA_TX_TERMINATEONBUSERROR_ENABLE_Msk;
+}
+
+NRF_STATIC_INLINE void nrf_spim_tx_terminate_on_bus_error_disable(NRF_SPIM_Type * p_reg)
+{
+    p_reg->DMA.TX.TERMINATEONBUSERROR &= ~(SPIM_DMA_TX_TERMINATEONBUSERROR_ENABLE_Msk);
+}
+
+NRF_STATIC_INLINE bool nrf_spim_tx_terminate_on_bus_error_check(NRF_SPIM_Type const * p_reg)
+{
+    return ((p_reg->DMA.TX.TERMINATEONBUSERROR & SPIM_DMA_TX_TERMINATEONBUSERROR_ENABLE_Msk)
+            >> SPIM_DMA_TX_TERMINATEONBUSERROR_ENABLE_Pos) ==
+            SPIM_DMA_TX_ENABLE_ENABLE_Enabled;
+}
+#endif // NRF_SPIM_HAS_DMA_REG
 
 #endif // NRF_DECLARE_ONLY
 

--- a/nrfx/hal/nrf_spis.h
+++ b/nrfx/hal/nrf_spis.h
@@ -47,6 +47,13 @@ extern "C" {
  * @brief   Hardware access layer for managing the SPIS peripheral.
  */
 
+#if defined(SPIS_DMA_TX_PTR_PTR_Msk) || defined(__NRFX_DOXYGEN__)
+/** @brief Symbol indicating whether dedicated DMA register is present. */
+#define NRF_SPIS_HAS_DMA_REG 1
+#else
+#define NRF_SPIS_HAS_DMA_REG 0
+#endif
+
 /**
  * @brief Macro getting pointer to the structure of registers of the SPIS peripheral.
  *
@@ -527,7 +534,7 @@ NRF_STATIC_INLINE void nrf_spis_subscribe_set(NRF_SPIS_Type * p_reg,
                                               uint8_t         channel)
 {
     *((volatile uint32_t *) ((uint8_t *) p_reg + (uint32_t) task + 0x80uL)) =
-            ((uint32_t)channel | SPIS_SUBSCRIBE_ACQUIRE_EN_Msk);
+            ((uint32_t)channel | NRF_SUBSCRIBE_PUBLISH_ENABLE);
 }
 
 NRF_STATIC_INLINE void nrf_spis_subscribe_clear(NRF_SPIS_Type * p_reg,
@@ -541,7 +548,7 @@ NRF_STATIC_INLINE void nrf_spis_publish_set(NRF_SPIS_Type *  p_reg,
                                             uint8_t          channel)
 {
     *((volatile uint32_t *) ((uint8_t *) p_reg + (uint32_t) event + 0x80uL)) =
-            ((uint32_t)channel | SPIS_PUBLISH_END_EN_Msk);
+            ((uint32_t)channel | NRF_SUBSCRIBE_PUBLISH_ENABLE);
 }
 
 NRF_STATIC_INLINE void nrf_spis_publish_clear(NRF_SPIS_Type *  p_reg,
@@ -634,6 +641,9 @@ NRF_STATIC_INLINE void nrf_spis_tx_buffer_set(NRF_SPIS_Type * p_reg,
 #if defined (NRF51)
     p_reg->TXDPTR = (uint32_t)p_buffer;
     p_reg->MAXTX  = length;
+#elif NRF_SPIS_HAS_DMA_REG
+    p_reg->DMA.TX.PTR    = (uint32_t)p_buffer;
+    p_reg->DMA.TX.MAXCNT = length;
 #else
     p_reg->TXD.PTR    = (uint32_t)p_buffer;
     p_reg->TXD.MAXCNT = length;
@@ -647,6 +657,9 @@ NRF_STATIC_INLINE void nrf_spis_rx_buffer_set(NRF_SPIS_Type * p_reg,
 #if defined (NRF51)
     p_reg->RXDPTR = (uint32_t)p_buffer;
     p_reg->MAXRX  = length;
+#elif NRF_SPIS_HAS_DMA_REG
+    p_reg->DMA.RX.PTR    = (uint32_t)p_buffer;
+    p_reg->DMA.RX.MAXCNT = length;
 #else
     p_reg->RXD.PTR    = (uint32_t)p_buffer;
     p_reg->RXD.MAXCNT = length;
@@ -657,6 +670,8 @@ NRF_STATIC_INLINE size_t nrf_spis_tx_amount_get(NRF_SPIS_Type const * p_reg)
 {
 #if defined (NRF51)
     return p_reg->AMOUNTTX;
+#elif NRF_SPIS_HAS_DMA_REG
+    return p_reg->DMA.TX.AMOUNT;
 #else
     return p_reg->TXD.AMOUNT;
 #endif
@@ -666,6 +681,8 @@ NRF_STATIC_INLINE size_t nrf_spis_rx_amount_get(NRF_SPIS_Type const * p_reg)
 {
 #if defined (NRF51)
     return p_reg->AMOUNTRX;
+#elif NRF_SPIS_HAS_DMA_REG
+    return p_reg->DMA.RX.AMOUNT;
 #else
     return p_reg->RXD.AMOUNT;
 #endif

--- a/nrfx/hal/nrf_spu.h
+++ b/nrfx/hal/nrf_spu.h
@@ -47,22 +47,104 @@ extern "C" {
  * @brief   Hardware access layer for managing the System Protection Unit (SPU) peripheral.
  */
 
+#if defined(SPU_PERIPH_PERM_OWNERPROG_Msk) || defined(__NRFX_DOXYGEN__)
+/** @brief Presence of ownership feature. */
+#define NRF_SPU_HAS_OWNERSHIP 1
+#else
+#define NRF_SPU_HAS_OWNERSHIP 0
+#endif
+
+#if defined(SPU_FLASHREGION_PERM_EXECUTE_Msk) || defined(__NRFX_DOXYGEN__)
+/** @brief Presence of memory feature. */
+#define NRF_SPU_HAS_MEMORY 1
+#else
+#define NRF_SPU_HAS_MEMORY 0
+#endif
+
+#if defined(SPU_FEATURE_BELLS_DOMAIN_MaxCount) || defined(__NRFX_DOXYGEN__)
+/** @brief Symbol indicating whether SPU uses DOMAIN register name. */
+#define NRF_SPU_HAS_DOMAIN 1
+#else
+#define NRF_SPU_HAS_DOMAIN 0
+#endif
+
+#if NRF_SPU_HAS_OWNERSHIP
+
+/** @brief Number of peripherals. */
+#define NRF_SPU_PERIPH_COUNT                     SPU_PERIPH_MaxCount
+
+/** @brief Number of IPCT channels. */
+#define NRF_SPU_FEATURE_IPCT_CHANNEL_COUNT       SPU_FEATURE_IPCT_CH_MaxCount
+
+/** @brief Number of IPCT interrupts. */
+#define NRF_SPU_FEATURE_IPCT_INTERRUPT_COUNT     SPU_FEATURE_IPCT_INTERRUPT_MaxCount
+
+/** @brief Number of DPPI channels. */
+#define NRF_SPU_FEATURE_DPPI_CHANNEL_COUNT       SPU_FEATURE_DPPIC_CH_MaxCount
+
+/** @brief Number of DPPI channel groups. */
+#define NRF_SPU_FEATURE_DPPI_CHANNEL_GROUP_COUNT SPU_FEATURE_DPPIC_CHG_MaxCount
+
+/** @brief Number of GPIOTEs. */
+#define NRF_SPU_FEATURE_GPIOTE_COUNT             SPU_FEATURE_GPIOTE_MaxCount
+
+/** @brief Number of GPIOTE channels. */
+#define NRF_SPU_FEATURE_GPIOTE_CHANNEL_COUNT     SPU_FEATURE_GPIOTE_CH_MaxCount
+
+/** @brief Number of GPIOTE interrupts. */
+#define NRF_SPU_FEATURE_GPIOTE_INTERRUPT_COUNT   SPU_FEATURE_GPIOTE_INTERRUPT_MaxCount
+
+/** @brief Number of GPIOs. */
+#define NRF_SPU_FEATURE_GPIO_COUNT               SPU_FEATURE_GPIO_MaxCount
+
+/** @brief Number of GPIO pins. */
+#define NRF_SPU_FEATURE_GPIO_PIN_COUNT           SPU_FEATURE_GPIO_PIN_MaxCount
+
+/** @brief Number of GRTC compare channels. */
+#define NRF_SPU_FEATURE_GRTC_CC_COUNT            SPU_FEATURE_GRTC_CC_MaxCount
+
+/** @brief Number of GRTC interrupts.. */
+#define NRF_SPU_FEATURE_GRTC_INTERRUPT_COUNT     SPU_FEATURE_GRTC_INTERRUPT_MaxCount
+
+/** @brief Number of BELL domains. */
+#if NRF_SPU_HAS_DOMAIN
+#define NRF_SPU_FEATURE_BELL_DOMAIN_COUNT        SPU_FEATURE_BELLS_DOMAIN_MaxCount
+#else
+#define NRF_SPU_FEATURE_BELLS_PROCESSOR_COUNT    SPU_FEATURE_BELLS_PROCESSOR_MaxCount
+#endif
+
+/** @brief Number of BELL Domain/Processor features. */
+#if NRF_SPU_HAS_DOMAIN
+#define NRF_SPU_FEATURE_BELL_BELL_COUNT          SPU_FEATURE_BELLS_DOMAIN_BELL_MaxCount
+#else
+#define NRF_SPU_FEATURE_BELLS_TASKS_COUNT        SPU_FEATURE_BELLS_PROCESSOR_TASKS_MaxCount
+#define NRF_SPU_FEATURE_BELLS_EVENTS_COUNT       SPU_FEATURE_BELLS_PROCESSOR_EVENTS_MaxCount
+#define NRF_SPU_FEATURE_BELLS_INTERRUPT_COUNT    SPU_FEATURE_BELLS_PROCESSOR_INTERRUPT_MaxCount
+#endif
+
+#endif
+
 /** @brief SPU events. */
 typedef enum
 {
-    NRF_SPU_EVENT_RAMACCERR    = offsetof(NRF_SPU_Type, EVENTS_RAMACCERR),   ///< A security violation has been detected for the RAM memory space.
-    NRF_SPU_EVENT_FLASHACCERR  = offsetof(NRF_SPU_Type, EVENTS_FLASHACCERR), ///< A security violation has been detected for the Flash memory space.
-    NRF_SPU_EVENT_PERIPHACCERR = offsetof(NRF_SPU_Type, EVENTS_PERIPHACCERR) ///< A security violation has been detected on one or several peripherals.
+#if NRF_SPU_HAS_MEMORY
+    NRF_SPU_EVENT_RAMACCERR    = offsetof(NRF_SPU_Type, EVENTS_RAMACCERR),    ///< A security violation has been detected for the RAM memory space.
+    NRF_SPU_EVENT_FLASHACCERR  = offsetof(NRF_SPU_Type, EVENTS_FLASHACCERR),  ///< A security violation has been detected for the Flash memory space.
+#endif
+    NRF_SPU_EVENT_PERIPHACCERR = offsetof(NRF_SPU_Type, EVENTS_PERIPHACCERR), ///< A security violation has been detected on one or several peripherals.
 } nrf_spu_event_t;
 
 /** @brief SPU interrupts. */
 typedef enum
 {
+#if NRF_SPU_HAS_MEMORY
     NRF_SPU_INT_RAMACCERR_MASK     = SPU_INTENSET_RAMACCERR_Msk,   ///< Interrupt on RAMACCERR event.
     NRF_SPU_INT_FLASHACCERR_MASK   = SPU_INTENSET_FLASHACCERR_Msk, ///< Interrupt on FLASHACCERR event.
+#endif
     NRF_SPU_INT_PERIPHACCERR_MASK  = SPU_INTENSET_PERIPHACCERR_Msk ///< Interrupt on PERIPHACCERR event.
 } nrf_spu_int_mask_t;
 
+#if NRF_SPU_HAS_MEMORY
 /** @brief SPU Non-Secure Callable (NSC) region size. */
 typedef enum
 {
@@ -84,6 +166,49 @@ typedef enum
     NRF_SPU_MEM_PERM_WRITE   = SPU_FLASHREGION_PERM_WRITE_Msk,   ///< Allow write operation on particular memory region.
     NRF_SPU_MEM_PERM_READ    = SPU_FLASHREGION_PERM_READ_Msk     ///< Allow read operation from particular memory region.
 } nrf_spu_mem_perm_t;
+#endif
+
+#if NRF_SPU_HAS_OWNERSHIP
+/** @brief SPU read capabilities for TrustZone Cortex-M secure attribute. */
+typedef enum
+{
+    NRF_SPU_SECUREMAPPING_NONSECURE      = SPU_PERIPH_PERM_SECUREMAPPING_NonSecure,      /**< Peripheral is always accessible as non-secure. */
+    NRF_SPU_SECUREMAPPING_SECURE         = SPU_PERIPH_PERM_SECUREMAPPING_Secure,         /**< Peripheral is always accessible as secure. */
+    NRF_SPU_SECUREMAPPING_USERSELECTABLE = SPU_PERIPH_PERM_SECUREMAPPING_UserSelectable, /**< Non-secure or secure attribute for this peripheral is defined by the PERIPH[n].PERM register. */
+    NRF_SPU_SECUREMAPPING_SPLIT          = SPU_PERIPH_PERM_SECUREMAPPING_Split,          /**< Peripheral implements the split security mechanism. */
+} nrf_spu_securemapping_t;
+
+/** @brief SPU DMA capabilities. */
+typedef enum
+{
+    NRF_SPU_DMA_NODMA               = SPU_PERIPH_PERM_DMA_NoDMA,               /**< Peripheral has no DMA capability. */
+    NRF_SPU_DMA_NOSEPARATEATTRIBUTE = SPU_PERIPH_PERM_DMA_NoSeparateAttribute, /**< DMA transfers always have the same security attribute as assigned to the peripheral. */
+    NRF_SPU_DMA_SEPARATEATTRIBUTE   = SPU_PERIPH_PERM_DMA_SeparateAttribute,   /**< DMA transfers can have a different security attribute than the one assigned to the peripheral. */
+} nrf_spu_dma_t;
+
+/** @brief SPU features. */
+typedef enum
+{
+    NRF_SPU_FEATURE_IPCT_CHANNEL,       /**< IPCT channel. */
+    NRF_SPU_FEATURE_IPCT_INTERRUPT,     /**< IPCT interrupt. */
+    NRF_SPU_FEATURE_DPPI_CHANNEL,       /**< DPPI channel. */
+    NRF_SPU_FEATURE_DPPI_CHANNEL_GROUP, /**< DPPI channel group. */
+    NRF_SPU_FEATURE_GPIOTE_CHANNEL,     /**< GPIOTE channel. */
+    NRF_SPU_FEATURE_GPIOTE_INTERRUPT,   /**< GPIOTE interrupt. */
+    NRF_SPU_FEATURE_GPIO_PIN,           /**< GPIO pin. */
+    NRF_SPU_FEATURE_GRTC_CC,            /**< GRTC compare channel. */
+    NRF_SPU_FEATURE_GRTC_SYSCOUNTER,    /**< GRTC SYSCOUNTER. */
+    NRF_SPU_FEATURE_GRTC_INTERRUPT,     /**< GRTC interrupt. */
+#if NRF_SPU_HAS_DOMAIN
+    NRF_SPU_FEATURE_BELLS_BELL,         /**< BELLS bell pair. */
+#else
+    NRF_SPU_FEATURE_BELLS_TASKS,        /**< BELLS tasks pair. */
+    NRF_SPU_FEATURE_BELLS_EVENTS,       /**< BELLS events pair. */
+    NRF_SPU_FEATURE_BELLS_INTERRUPT,    /**< BELLS interrupt pair. */
+#endif
+} nrf_spu_feature_t;
+
+#endif
 
 /**
  * @brief Function for clearing a specific SPU event.
@@ -134,6 +259,7 @@ NRF_STATIC_INLINE void nrf_spu_int_disable(NRF_SPU_Type * p_reg,
  */
 NRF_STATIC_INLINE uint32_t nrf_spu_int_enable_check(NRF_SPU_Type const * p_reg, uint32_t mask);
 
+#if NRF_SPU_HAS_MEMORY
 /**
  * @brief Function for setting up publication configuration of a given SPU event.
  *
@@ -287,6 +413,339 @@ NRF_STATIC_INLINE void nrf_spu_extdomain_set(NRF_SPU_Type * p_reg,
                                              uint32_t       domain_id,
                                              bool           secure_attr,
                                              bool           lock_conf);
+#endif
+
+#if NRF_SPU_HAS_OWNERSHIP
+
+/**
+ * @brief Function for getting the address of the security violation.
+ *
+ * @note The event PERIPHACCERR must be cleared to clear this register.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ *
+ * @return Address of the transaction that caused first error.
+ */
+NRF_STATIC_INLINE uint32_t nrf_spu_periphaccerr_address_get(NRF_SPU_Type const * p_reg);
+
+/**
+ * @brief Function for getting the owner ID of the security violation.
+ *
+ * @note The event PERIPHACCERR must be cleared to clear this register.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ *
+ * @return Owner ID of the transaction that caused first error.
+ */
+NRF_STATIC_INLINE nrf_owner_t nrf_spu_periphaccerr_ownerid_get(NRF_SPU_Type const * p_reg);
+
+/**
+ * @brief Function for getting the capabilities for TrustZone Cortex-M secure attribute
+ *        of the specified slave.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ * @param[in] index Peripheral slave index.
+ *
+ * @return TrustZone capabilities.
+ */
+NRF_STATIC_INLINE
+nrf_spu_securemapping_t nrf_spu_periph_perm_securemapping_get(NRF_SPU_Type const * p_reg,
+                                                              uint8_t              index);
+
+/**
+ * @brief Function for getting the DMA capabilities of the specified slave.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ * @param[in] index Peripheral slave index.
+ *
+ * @return DMA capabilities.
+ */
+NRF_STATIC_INLINE nrf_spu_dma_t nrf_spu_periph_perm_dma_get(NRF_SPU_Type const * p_reg,
+                                                            uint8_t              index);
+
+/**
+ * @brief Function for getting the security mapping of the specified slave.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ * @param[in] index Peripheral slave index.
+ *
+ * @retval true  Peripheral is mapped in secure peripheral address space.
+ * @retval false If TrustZone capabilities are @ref NRF_SPU_SECUREMAPPING_USERSELECTABLE,
+ *               then peripheral is mapped in non-secure peripheral address space.
+ *               If TrustZone capabilities are @ref NRF_SPU_SECUREMAPPING_SPLIT,
+ *               then peripheral is mapped in non-secure and secure peripheral address space.
+ */
+NRF_STATIC_INLINE bool nrf_spu_periph_perm_secattr_get(NRF_SPU_Type const * p_reg,
+                                                       uint8_t              index);
+
+/**
+ * @brief Function for setting the security mapping of the specified slave.
+ *
+ * @note This bit has effect only if TrustZone capabilities are either
+ *       @ref NRF_SPU_SECUREMAPPING_USERSELECTABLE or @ref NRF_SPU_SECUREMAPPING_SPLIT.
+ *
+ * @param[in] p_reg  Pointer to the structure of registers of the peripheral.
+ * @param[in] index  Peripheral slave index.
+ * @param[in] enable True if security mapping is to be set, false otherwise.
+ */
+NRF_STATIC_INLINE void nrf_spu_periph_perm_secattr_set(NRF_SPU_Type * p_reg,
+                                                       uint8_t        index,
+                                                       bool           enable);
+
+/**
+ * @brief Function for getting the security attribution for the DMA transfer
+ *        of the specified slave.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ * @param[in] index Peripheral slave index.
+ *
+ * @return True if DMA transfers initiated by this peripheral have the secure attribute set,
+ *         false otherwise.
+ */
+NRF_STATIC_INLINE bool nrf_spu_periph_perm_dmasec_get(NRF_SPU_Type const * p_reg,
+                                                      uint8_t              index);
+
+/**
+ * @brief Function for setting the security attribution for the DMA transfer
+ *        of the specified slave.
+ *
+ * @note This bit has effect only if peripheral security mapping is enabled.
+ *
+ * @param[in] p_reg  Pointer to the structure of registers of the peripheral.
+ * @param[in] index  Peripheral slave index.
+ * @param[in] enable True if secure attribute for the DMA transfer is to be set, false otherwise.
+ */
+NRF_STATIC_INLINE void nrf_spu_periph_perm_dmasec_set(NRF_SPU_Type * p_reg,
+                                                      uint8_t        index,
+                                                      bool           enable);
+
+/**
+ * @brief Function for getting the status of the peripheral access lock of the specified slave.
+ *
+ * @note When peripheral access lock is enabled, reading or modifying the registers of the peripheral
+ *       is blocked.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ * @param[in] index Peripheral slave index.
+ *
+ * @return True if the peripheral access is locked, false otherwise.
+ */
+NRF_STATIC_INLINE bool nrf_spu_periph_perm_block_get(NRF_SPU_Type const * p_reg,
+                                                     uint8_t              index);
+
+/**
+ * @brief Function for enabling the peripheral access lock of the specified slave.
+ *
+ * @note When peripheral access lock is enabled, reading or modifying the registers of the peripheral
+ *       is blocked.
+ *
+ * @param[in] p_reg  Pointer to the structure of registers of the peripheral.
+ * @param[in] index  Peripheral slave index.
+ */
+NRF_STATIC_INLINE void nrf_spu_periph_perm_block_enable(NRF_SPU_Type * p_reg,
+                                                        uint8_t        index);
+
+/**
+ * @brief Function for getting the status of the peripheral management lock of the specified slave.
+ *
+ * @note When peripheral management lock is enabled, modifying the SPU configuration associated
+ *       with specified peripheral is not possible.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ * @param[in] index Peripheral slave index.
+ *
+ * @return True if the peripheral management is locked, false otherwise.
+ */
+NRF_STATIC_INLINE bool nrf_spu_periph_perm_lock_get(NRF_SPU_Type const * p_reg,
+                                                    uint8_t              index);
+
+/**
+ * @brief Function for enabling the peripheral management lock of the specified slave.
+ *
+ * @note When peripheral management lock is enabled, modifying the SPU configuration associated
+ *       with specified peripheral is not possible.
+ *
+ * @param[in] p_reg  Pointer to the structure of registers of the peripheral.
+ * @param[in] index  Peripheral slave index.
+ */
+NRF_STATIC_INLINE void nrf_spu_periph_perm_lock_enable(NRF_SPU_Type * p_reg,
+                                                       uint8_t        index);
+
+/**
+ * @brief Function for getting the peripheral owner ID of the specified slave.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ * @param[in] index Peripheral slave index.
+ *
+ * @return Owner ID.
+ */
+NRF_STATIC_INLINE nrf_owner_t nrf_spu_periph_perm_ownerid_get(NRF_SPU_Type const * p_reg,
+                                                              uint8_t              index);
+
+/**
+ * @brief Function for setting the peripheral owner ID of the specified slave.
+ *
+ * @param[in] p_reg    Pointer to the structure of registers of the peripheral.
+ * @param[in] index    Peripheral slave index.
+ * @param[in] owner_id Owner ID to be set.
+ */
+NRF_STATIC_INLINE void nrf_spu_periph_perm_ownerid_set(NRF_SPU_Type * p_reg,
+                                                       uint8_t        index,
+                                                       nrf_owner_t    owner_id);
+
+/**
+ * @brief Function for getting the indication if owner ID of the specified slave
+ *        is programmable or not.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ * @param[in] index Peripheral slave index.
+ *
+ * @return True if owner ID is programmable, false otherwise.
+ */
+NRF_STATIC_INLINE bool nrf_spu_periph_perm_ownerprog_get(NRF_SPU_Type const * p_reg,
+                                                         uint8_t              index);
+
+/**
+ * @brief Function for getting the indication if peripheral with
+ *        the specified slave index is present.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ * @param[in] index Peripheral slave index.
+ *
+ * @return True if peripheral is present, false otherwise.
+ */
+NRF_STATIC_INLINE bool nrf_spu_periph_perm_present_get(NRF_SPU_Type const * p_reg,
+                                                       uint8_t              index);
+
+/**
+ * @brief Function for getting the security mapping of the specified feature.
+ *
+ * @param[in] p_reg    Pointer to the structure of registers of the peripheral.
+ * @param[in] feature  Feature to be accessed.
+ * @param[in] index    Feature index.
+ * @param[in] subindex Feature subindex. Only used for applicable features, otherwise skipped.
+ *
+ * @retval true  Feature is available for secure usage.
+ * @retval false Feature is available for non-secure usage.
+ */
+NRF_STATIC_INLINE bool nrf_spu_feature_secattr_get(NRF_SPU_Type const * p_reg,
+                                                   nrf_spu_feature_t    feature,
+                                                   uint8_t              index,
+                                                   uint8_t              subindex);
+
+/**
+ * @brief Function for setting the security mapping of the specified feature.
+ *
+ * @param[in] p_reg    Pointer to the structure of registers of the peripheral.
+ * @param[in] feature  Feature to be accessed.
+ * @param[in] index    Feature index.
+ * @param[in] subindex Feature subindex. Only used for applicable features, otherwise skipped.
+ * @param[in] enable   True if security mapping is to be set, false otherwise.
+ */
+NRF_STATIC_INLINE void nrf_spu_feature_secattr_set(NRF_SPU_Type *    p_reg,
+                                                   nrf_spu_feature_t feature,
+                                                   uint8_t           index,
+                                                   uint8_t           subindex,
+                                                   bool              enable);
+
+/**
+ * @brief Function for getting the status of the management lock of the specified feature.
+ *
+ * @note When feature management lock is enabled, modifying the SPU configuration associated
+ *       with specified feature is not possible.
+ *
+ * @param[in] p_reg    Pointer to the structure of registers of the peripheral.
+ * @param[in] feature  Feature to be accessed.
+ * @param[in] index    Feature index.
+ * @param[in] subindex Feature subindex. Only used for applicable features, otherwise skipped.
+ *
+ * @return True if feature management is locked, false otherwise.
+ */
+NRF_STATIC_INLINE bool nrf_spu_feature_lock_get(NRF_SPU_Type const * p_reg,
+                                                nrf_spu_feature_t    feature,
+                                                uint8_t              index,
+                                                uint8_t              subindex);
+
+/**
+ * @brief Function for enabling the management lock of the specified feature.
+ *
+ * @note When feature management lock is enabled, modifying the SPU configuration associated
+ *       with specified feature is not possible.
+ *
+ * @param[in] p_reg    Pointer to the structure of registers of the peripheral.
+ * @param[in] feature  Feature to be accessed.
+ * @param[in] index    Feature index.
+ * @param[in] subindex Feature subindex. Only used for applicable features, otherwise skipped.
+ */
+NRF_STATIC_INLINE void nrf_spu_feature_lock_enable(NRF_SPU_Type *    p_reg,
+                                                   nrf_spu_feature_t feature,
+                                                   uint8_t           index,
+                                                   uint8_t           subindex);
+
+/**
+ * @brief Function for getting status of the access lock of the specified feature.
+ *
+ * @note When feature access lock is enabled, reading or modifying the registers of the feature
+ *       is blocked.
+ *
+ * @param[in] p_reg    Pointer to the structure of registers of the peripheral.
+ * @param[in] feature  Feature to be accessed.
+ * @param[in] index    Feature index.
+ * @param[in] subindex Feature subindex. Only used for applicable features, otherwise skipped.
+ *
+ * @return True if the feature access is locked, false otherwise.
+ */
+NRF_STATIC_INLINE bool nrf_spu_feature_block_get(NRF_SPU_Type const * p_reg,
+                                                 nrf_spu_feature_t    feature,
+                                                 uint8_t              index,
+                                                 uint8_t              subindex);
+
+/**
+ * @brief Function for enabling the feature block of the specified feature.
+ *
+ * @note When feature access lock is enabled, reading or modifying the registers of the feature
+ *       is blocked.
+ *
+ * @param[in] p_reg    Pointer to the structure of registers of the peripheral.
+ * @param[in] feature  Feature to be accessed.
+ * @param[in] index    Feature index.
+ * @param[in] subindex Feature subindex. Only used for applicable features, otherwise skipped.
+ */
+NRF_STATIC_INLINE void nrf_spu_feature_block_enable(NRF_SPU_Type *    p_reg,
+                                                    nrf_spu_feature_t feature,
+                                                    uint8_t           index,
+                                                    uint8_t           subindex);
+
+/**
+ * @brief Function for getting the feature owner ID of the specified feature.
+ *
+ * @param[in] p_reg    Pointer to the structure of registers of the peripheral.
+ * @param[in] feature  Feature to be accessed.
+ * @param[in] index    Feature index.
+ * @param[in] subindex Feature subindex. Only used for applicable features, otherwise skipped.
+ *
+ * @return Owner ID.
+ */
+NRF_STATIC_INLINE nrf_owner_t nrf_spu_feature_ownerid_get(NRF_SPU_Type const * p_reg,
+                                                          nrf_spu_feature_t    feature,
+                                                          uint8_t              index,
+                                                          uint8_t              subindex);
+
+/**
+ * @brief Function for setting the feature owner ID of the specified feature.
+ *
+ * @param[in] p_reg    Pointer to the structure of registers of the peripheral.
+ * @param[in] feature  Feature to be accessed.
+ * @param[in] index    Feature index.
+ * @param[in] subindex Feature subindex. Only used for applicable features, otherwise skipped.
+ * @param[in] owner_id Owner ID to be set.
+ */
+NRF_STATIC_INLINE void nrf_spu_feature_ownerid_set(NRF_SPU_Type *    p_reg,
+                                                   nrf_spu_feature_t feature,
+                                                   uint8_t           index,
+                                                   uint8_t           subindex,
+                                                   nrf_owner_t       owner_id);
+#endif
 
 #ifndef NRF_DECLARE_ONLY
 
@@ -320,12 +779,13 @@ NRF_STATIC_INLINE uint32_t nrf_spu_int_enable_check(NRF_SPU_Type const * p_reg, 
     return p_reg->INTENSET & mask;
 }
 
+#if NRF_SPU_HAS_MEMORY
 NRF_STATIC_INLINE void nrf_spu_publish_set(NRF_SPU_Type *  p_reg,
                                            nrf_spu_event_t event,
                                            uint32_t        channel)
 {
     *((volatile uint32_t *) ((uint8_t *) p_reg + (uint32_t) event + 0x80uL)) =
-        (channel | (SPU_PUBLISH_RAMACCERR_EN_Msk));
+        (channel | (NRF_SUBSCRIBE_PUBLISH_ENABLE));
 }
 
 NRF_STATIC_INLINE void nrf_spu_publish_clear(NRF_SPU_Type *  p_reg,
@@ -451,6 +911,1165 @@ NRF_STATIC_INLINE void nrf_spu_extdomain_set(NRF_SPU_Type * p_reg,
         (secure_attr ? SPU_EXTDOMAIN_PERM_SECATTR_Msk : 0) |
         (lock_conf   ? SPU_EXTDOMAIN_PERM_LOCK_Msk    : 0);
 }
+#endif
+
+#if NRF_SPU_HAS_OWNERSHIP
+NRF_STATIC_INLINE uint32_t nrf_spu_periphaccerr_address_get(NRF_SPU_Type const * p_reg)
+{
+    return p_reg->PERIPHACCERR.ADDRESS;
+}
+
+NRF_STATIC_INLINE nrf_owner_t nrf_spu_periphaccerr_ownerid_get(NRF_SPU_Type const * p_reg)
+{
+    return (nrf_owner_t)p_reg->PERIPHACCERR.INFO;
+}
+
+NRF_STATIC_INLINE bool nrf_spu_periph_perm_present_get(NRF_SPU_Type const * p_reg,
+                                                       uint8_t              index)
+{
+    NRFX_ASSERT(index < NRF_SPU_PERIPH_COUNT);
+    return (p_reg->PERIPH[index].PERM & SPU_PERIPH_PERM_PRESENT_Msk) >>
+           SPU_PERIPH_PERM_PRESENT_Pos;
+}
+
+NRF_STATIC_INLINE bool nrf_spu_periph_perm_ownerprog_get(NRF_SPU_Type const * p_reg,
+                                                         uint8_t              index)
+{
+    NRFX_ASSERT(index < NRF_SPU_PERIPH_COUNT);
+    return (p_reg->PERIPH[index].PERM & SPU_PERIPH_PERM_OWNERPROG_Msk) >>
+           SPU_PERIPH_PERM_OWNERPROG_Pos;
+}
+
+NRF_STATIC_INLINE bool nrf_spu_periph_perm_lock_get(NRF_SPU_Type const * p_reg,
+                                                    uint8_t              index)
+{
+    NRFX_ASSERT(index < NRF_SPU_PERIPH_COUNT);
+    return (p_reg->PERIPH[index].PERM & SPU_PERIPH_PERM_LOCK_Msk) >>
+           SPU_PERIPH_PERM_LOCK_Pos;
+}
+
+NRF_STATIC_INLINE bool nrf_spu_periph_perm_block_get(NRF_SPU_Type const * p_reg,
+                                                     uint8_t              index)
+{
+    NRFX_ASSERT(index < NRF_SPU_PERIPH_COUNT);
+    return (p_reg->PERIPH[index].PERM & SPU_PERIPH_PERM_BLOCK_Msk) >>
+           SPU_PERIPH_PERM_BLOCK_Pos;
+}
+
+NRF_STATIC_INLINE bool nrf_spu_periph_perm_dmasec_get(NRF_SPU_Type const * p_reg,
+                                                      uint8_t              index)
+{
+    NRFX_ASSERT(index < NRF_SPU_PERIPH_COUNT);
+    return (p_reg->PERIPH[index].PERM & SPU_PERIPH_PERM_DMASEC_Msk) >>
+           SPU_PERIPH_PERM_DMASEC_Pos;
+}
+
+NRF_STATIC_INLINE bool nrf_spu_periph_perm_secattr_get(NRF_SPU_Type const * p_reg,
+                                                       uint8_t              index)
+{
+    NRFX_ASSERT(index < NRF_SPU_PERIPH_COUNT);
+    return (p_reg->PERIPH[index].PERM & SPU_PERIPH_PERM_SECATTR_Msk) >>
+           SPU_PERIPH_PERM_SECATTR_Pos;
+}
+
+NRF_STATIC_INLINE void nrf_spu_periph_perm_lock_enable(NRF_SPU_Type * p_reg,
+                                                       uint8_t        index)
+{
+    NRFX_ASSERT(index < NRF_SPU_PERIPH_COUNT);
+    p_reg->PERIPH[index].PERM = ((p_reg->PERIPH[index].PERM & ~SPU_PERIPH_PERM_LOCK_Msk)
+                                 | (SPU_PERIPH_PERM_LOCK_Locked <<
+                                    SPU_PERIPH_PERM_LOCK_Pos));
+}
+
+NRF_STATIC_INLINE void nrf_spu_periph_perm_block_enable(NRF_SPU_Type * p_reg,
+                                                        uint8_t        index)
+{
+    NRFX_ASSERT(index < NRF_SPU_PERIPH_COUNT);
+    p_reg->PERIPH[index].PERM = ((p_reg->PERIPH[index].PERM & ~SPU_PERIPH_PERM_BLOCK_Msk)
+                                 | (SPU_PERIPH_PERM_BLOCK_Blocked <<
+                                    SPU_PERIPH_PERM_BLOCK_Pos));
+}
+
+NRF_STATIC_INLINE void nrf_spu_periph_perm_dmasec_set(NRF_SPU_Type * p_reg,
+                                                      uint8_t        index,
+                                                      bool           enable)
+{
+    NRFX_ASSERT(index < NRF_SPU_PERIPH_COUNT);
+    p_reg->PERIPH[index].PERM = ((p_reg->PERIPH[index].PERM & ~SPU_PERIPH_PERM_DMASEC_Msk)
+                                 | ((enable ? SPU_PERIPH_PERM_DMASEC_Secure :
+                                     SPU_PERIPH_PERM_DMASEC_NonSecure) <<
+                                    SPU_PERIPH_PERM_DMASEC_Pos));
+}
+
+NRF_STATIC_INLINE void nrf_spu_periph_perm_secattr_set(NRF_SPU_Type * p_reg,
+                                                       uint8_t        index,
+                                                       bool           enable)
+{
+    NRFX_ASSERT(index < NRF_SPU_PERIPH_COUNT);
+    p_reg->PERIPH[index].PERM = ((p_reg->PERIPH[index].PERM & ~SPU_PERIPH_PERM_SECATTR_Msk)
+                                 | ((enable ? SPU_PERIPH_PERM_SECATTR_Secure :
+                                     SPU_PERIPH_PERM_SECATTR_NonSecure) <<
+                                    SPU_PERIPH_PERM_SECATTR_Pos));
+}
+
+NRF_STATIC_INLINE
+nrf_spu_securemapping_t nrf_spu_periph_perm_securemapping_get(NRF_SPU_Type const * p_reg,
+                                                              uint8_t              index)
+{
+    NRFX_ASSERT(index < NRF_SPU_PERIPH_COUNT);
+
+    return (nrf_spu_securemapping_t)((p_reg->PERIPH[index].PERM
+                                      & SPU_PERIPH_PERM_SECUREMAPPING_Msk) >>
+                                     SPU_PERIPH_PERM_SECUREMAPPING_Pos);
+}
+
+NRF_STATIC_INLINE nrf_spu_dma_t nrf_spu_periph_perm_dma_get(NRF_SPU_Type const * p_reg,
+                                                            uint8_t              index)
+{
+    NRFX_ASSERT(index < NRF_SPU_PERIPH_COUNT);
+
+    return (nrf_spu_dma_t)((p_reg->PERIPH[index].PERM & SPU_PERIPH_PERM_DMA_Msk) >>
+                           SPU_PERIPH_PERM_DMA_Pos);
+}
+
+NRF_STATIC_INLINE nrf_owner_t nrf_spu_periph_perm_ownerid_get(NRF_SPU_Type const * p_reg,
+                                                              uint8_t              index)
+{
+    NRFX_ASSERT(index < NRF_SPU_PERIPH_COUNT);
+
+    return (nrf_owner_t)((p_reg->PERIPH[index].PERM & SPU_PERIPH_PERM_OWNERID_Msk) >>
+                         SPU_PERIPH_PERM_OWNERID_Pos);
+}
+
+NRF_STATIC_INLINE void nrf_spu_periph_perm_ownerid_set(NRF_SPU_Type * p_reg,
+                                                       uint8_t        index,
+                                                       nrf_owner_t    owner_id)
+{
+    NRFX_ASSERT(index < NRF_SPU_PERIPH_COUNT);
+
+    p_reg->PERIPH[index].PERM = ((p_reg->PERIPH[index].PERM & ~SPU_PERIPH_PERM_OWNERID_Msk) |
+                                 ((owner_id << SPU_PERIPH_PERM_OWNERID_Pos)
+                                  & SPU_PERIPH_PERM_OWNERID_Msk));
+}
+
+NRF_STATIC_INLINE bool nrf_spu_feature_secattr_get(NRF_SPU_Type const * p_reg,
+                                                   nrf_spu_feature_t    feature,
+                                                   uint8_t              index,
+                                                   uint8_t              subindex)
+{
+    switch (feature)
+    {
+        case NRF_SPU_FEATURE_IPCT_CHANNEL:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_IPCT_CHANNEL_COUNT);
+            return (p_reg->FEATURE.IPCT.CH[index]
+                    & SPU_FEATURE_IPCT_CH_SECATTR_Msk)
+                   >> SPU_FEATURE_IPCT_CH_SECATTR_Pos;
+
+        case NRF_SPU_FEATURE_IPCT_INTERRUPT:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_IPCT_INTERRUPT_COUNT);
+            return (p_reg->FEATURE.IPCT.INTERRUPT[index]
+                    & SPU_FEATURE_IPCT_INTERRUPT_SECATTR_Msk)
+                   >> SPU_FEATURE_IPCT_INTERRUPT_SECATTR_Pos;
+
+        case NRF_SPU_FEATURE_DPPI_CHANNEL:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_DPPI_CHANNEL_COUNT);
+            return (p_reg->FEATURE.DPPIC.CH[index]
+                    & SPU_FEATURE_DPPIC_CH_SECATTR_Msk)
+                   >> SPU_FEATURE_DPPIC_CH_SECATTR_Pos;
+
+        case NRF_SPU_FEATURE_DPPI_CHANNEL_GROUP:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_DPPI_CHANNEL_GROUP_COUNT);
+            return (p_reg->FEATURE.DPPIC.CHG[index]
+                    & SPU_FEATURE_DPPIC_CHG_SECATTR_Msk)
+                   >> SPU_FEATURE_DPPIC_CHG_SECATTR_Pos;
+
+        case NRF_SPU_FEATURE_GPIOTE_CHANNEL:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_GPIOTE_COUNT);
+            NRFX_ASSERT(subindex < NRF_SPU_FEATURE_GPIOTE_CHANNEL_COUNT);
+            return (p_reg->FEATURE.GPIOTE[index].CH[subindex]
+                    & SPU_FEATURE_GPIOTE_CH_SECATTR_Msk)
+                   >> SPU_FEATURE_GPIOTE_CH_SECATTR_Pos;
+
+        case NRF_SPU_FEATURE_GPIOTE_INTERRUPT:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_GPIOTE_COUNT);
+            NRFX_ASSERT(subindex < NRF_SPU_FEATURE_GPIOTE_INTERRUPT_COUNT);
+            return (p_reg->FEATURE.GPIOTE[index].INTERRUPT[subindex]
+                    & SPU_FEATURE_GPIOTE_INTERRUPT_SECATTR_Msk)
+                   >> SPU_FEATURE_GPIOTE_INTERRUPT_SECATTR_Pos;
+
+        case NRF_SPU_FEATURE_GPIO_PIN:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_GPIO_COUNT);
+            NRFX_ASSERT(subindex < NRF_SPU_FEATURE_GPIO_PIN_COUNT);
+            return (p_reg->FEATURE.GPIO[index].PIN[subindex]
+                    & SPU_FEATURE_GPIO_PIN_SECATTR_Msk)
+                   >> SPU_FEATURE_GPIO_PIN_SECATTR_Pos;
+
+        case NRF_SPU_FEATURE_GRTC_CC:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_GRTC_CC_COUNT);
+            return (p_reg->FEATURE.GRTC.CC[index]
+                    & SPU_FEATURE_GRTC_CC_SECATTR_Msk)
+                   >> SPU_FEATURE_GRTC_CC_SECATTR_Pos;
+
+        case NRF_SPU_FEATURE_GRTC_SYSCOUNTER:
+            return (p_reg->FEATURE.GRTC.SYSCOUNTER
+                    & SPU_FEATURE_GRTC_SYSCOUNTER_SECATTR_Msk)
+                   >> SPU_FEATURE_GRTC_SYSCOUNTER_SECATTR_Pos;
+
+        case NRF_SPU_FEATURE_GRTC_INTERRUPT:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_GRTC_INTERRUPT_COUNT);
+            return (p_reg->FEATURE.GRTC.INTERRUPT[index]
+                    & SPU_FEATURE_GRTC_INTERRUPT_SECATTR_Msk)
+                   >> SPU_FEATURE_GRTC_INTERRUPT_SECATTR_Pos;
+
+#if NRF_SPU_HAS_DOMAIN
+        case NRF_SPU_FEATURE_BELLS_BELL:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_BELL_BELL_COUNT);
+            return (p_reg->FEATURE.BELLS.DOMAIN[index].BELL[subindex]
+                    & SPU_FEATURE_BELLS_DOMAIN_BELL_SECATTR_Msk)
+                   >> SPU_FEATURE_BELLS_DOMAIN_BELL_SECATTR_Pos;
+#else
+        case NRF_SPU_FEATURE_BELLS_TASKS:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_BELLS_TASKS_COUNT);
+            return (p_reg->FEATURE.BELLS.PROCESSOR[index].TASKS[subindex]
+                    & SPU_FEATURE_BELLS_PROCESSOR_TASKS_SECATTR_Msk)
+                   >> SPU_FEATURE_BELLS_PROCESSOR_TASKS_SECATTR_Pos;
+
+        case NRF_SPU_FEATURE_BELLS_EVENTS:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_BELLS_EVENTS_COUNT);
+            return (p_reg->FEATURE.BELLS.PROCESSOR[index].EVENTS[subindex]
+                    & SPU_FEATURE_BELLS_PROCESSOR_EVENTS_SECATTR_Msk)
+                   >> SPU_FEATURE_BELLS_PROCESSOR_EVENTS_SECATTR_Pos;
+
+        case NRF_SPU_FEATURE_BELLS_INTERRUPT:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_BELLS_INTERRUPT_COUNT);
+            return (p_reg->FEATURE.BELLS.PROCESSOR[index].INTERRUPT[subindex]
+                    & SPU_FEATURE_BELLS_PROCESSOR_INTERRUPT_SECATTR_Msk)
+                   >> SPU_FEATURE_BELLS_PROCESSOR_INTERRUPT_SECATTR_Pos;
+#endif
+
+        default:
+            NRFX_ASSERT(0);
+            return false;
+    }
+}
+
+NRF_STATIC_INLINE bool nrf_spu_feature_lock_get(NRF_SPU_Type const * p_reg,
+                                                nrf_spu_feature_t    feature,
+                                                uint8_t              index,
+                                                uint8_t              subindex)
+{
+    switch (feature)
+    {
+        case NRF_SPU_FEATURE_IPCT_CHANNEL:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_IPCT_CHANNEL_COUNT);
+            return (p_reg->FEATURE.IPCT.CH[index]
+                    & SPU_FEATURE_IPCT_CH_LOCK_Msk)
+                   >> SPU_FEATURE_IPCT_CH_LOCK_Pos;
+
+        case NRF_SPU_FEATURE_IPCT_INTERRUPT:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_IPCT_INTERRUPT_COUNT);
+            return (p_reg->FEATURE.IPCT.INTERRUPT[index]
+                    & SPU_FEATURE_IPCT_INTERRUPT_LOCK_Msk)
+                   >> SPU_FEATURE_IPCT_INTERRUPT_LOCK_Pos;
+
+        case NRF_SPU_FEATURE_DPPI_CHANNEL:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_DPPI_CHANNEL_COUNT);
+            return (p_reg->FEATURE.DPPIC.CH[index]
+                    & SPU_FEATURE_DPPIC_CH_LOCK_Msk)
+                   >> SPU_FEATURE_DPPIC_CH_LOCK_Pos;
+
+        case NRF_SPU_FEATURE_DPPI_CHANNEL_GROUP:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_DPPI_CHANNEL_GROUP_COUNT);
+            return (p_reg->FEATURE.DPPIC.CHG[index]
+                    & SPU_FEATURE_DPPIC_CHG_LOCK_Msk)
+                   >> SPU_FEATURE_DPPIC_CHG_LOCK_Pos;
+
+        case NRF_SPU_FEATURE_GPIOTE_CHANNEL:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_GPIOTE_COUNT);
+            NRFX_ASSERT(subindex < NRF_SPU_FEATURE_GPIOTE_CHANNEL_COUNT);
+            return (p_reg->FEATURE.GPIOTE[index].CH[subindex]
+                    & SPU_FEATURE_GPIOTE_CH_LOCK_Msk)
+                   >> SPU_FEATURE_GPIOTE_CH_LOCK_Pos;
+
+        case NRF_SPU_FEATURE_GPIOTE_INTERRUPT:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_GPIOTE_COUNT);
+            NRFX_ASSERT(subindex < NRF_SPU_FEATURE_GPIOTE_INTERRUPT_COUNT);
+            return (p_reg->FEATURE.GPIOTE[index].INTERRUPT[subindex]
+                    & SPU_FEATURE_GPIOTE_INTERRUPT_LOCK_Msk)
+                   >> SPU_FEATURE_GPIOTE_INTERRUPT_LOCK_Pos;
+
+        case NRF_SPU_FEATURE_GPIO_PIN:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_GPIO_COUNT);
+            NRFX_ASSERT(subindex < NRF_SPU_FEATURE_GPIO_PIN_COUNT);
+            return (p_reg->FEATURE.GPIO[index].PIN[subindex]
+                    & SPU_FEATURE_GPIO_PIN_LOCK_Msk)
+                   >> SPU_FEATURE_GPIO_PIN_LOCK_Pos;
+
+        case NRF_SPU_FEATURE_GRTC_CC:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_GRTC_CC_COUNT);
+            return (p_reg->FEATURE.GRTC.CC[index]
+                    & SPU_FEATURE_GRTC_CC_LOCK_Msk)
+                   >> SPU_FEATURE_GRTC_CC_LOCK_Pos;
+
+        case NRF_SPU_FEATURE_GRTC_SYSCOUNTER:
+            return (p_reg->FEATURE.GRTC.SYSCOUNTER
+                    & SPU_FEATURE_GRTC_SYSCOUNTER_LOCK_Msk)
+                   >> SPU_FEATURE_GRTC_SYSCOUNTER_LOCK_Pos;
+
+        case NRF_SPU_FEATURE_GRTC_INTERRUPT:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_GRTC_INTERRUPT_COUNT);
+            return (p_reg->FEATURE.GRTC.INTERRUPT[index]
+                    & SPU_FEATURE_GRTC_INTERRUPT_LOCK_Msk)
+                   >> SPU_FEATURE_GRTC_INTERRUPT_LOCK_Pos;
+
+#if NRF_SPU_HAS_DOMAIN
+        case NRF_SPU_FEATURE_BELLS_BELL:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_BELL_BELL_COUNT);
+            return (p_reg->FEATURE.BELLS.DOMAIN[index].BELL[subindex]
+                    & SPU_FEATURE_BELLS_DOMAIN_BELL_LOCK_Msk)
+                   >> SPU_FEATURE_BELLS_DOMAIN_BELL_LOCK_Pos;
+#else
+        case NRF_SPU_FEATURE_BELLS_TASKS:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_BELLS_TASKS_COUNT);
+            return (p_reg->FEATURE.BELLS.PROCESSOR[index].TASKS[subindex]
+                    & SPU_FEATURE_BELLS_PROCESSOR_TASKS_LOCK_Msk)
+                   >> SPU_FEATURE_BELLS_PROCESSOR_TASKS_LOCK_Pos;
+
+        case NRF_SPU_FEATURE_BELLS_EVENTS:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_BELLS_EVENTS_COUNT);
+            return (p_reg->FEATURE.BELLS.PROCESSOR[index].EVENTS[subindex]
+                    & SPU_FEATURE_BELLS_PROCESSOR_EVENTS_LOCK_Msk)
+                   >> SPU_FEATURE_BELLS_PROCESSOR_EVENTS_LOCK_Pos;
+
+        case NRF_SPU_FEATURE_BELLS_INTERRUPT:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_BELLS_INTERRUPT_COUNT);
+            return (p_reg->FEATURE.BELLS.PROCESSOR[index].INTERRUPT[subindex]
+                    & SPU_FEATURE_BELLS_PROCESSOR_INTERRUPT_LOCK_Msk)
+                   >> SPU_FEATURE_BELLS_PROCESSOR_INTERRUPT_LOCK_Pos;
+#endif
+        default:
+            NRFX_ASSERT(0);
+            return false;
+    }
+}
+
+NRF_STATIC_INLINE bool nrf_spu_feature_block_get(NRF_SPU_Type const * p_reg,
+                                                 nrf_spu_feature_t    feature,
+                                                 uint8_t              index,
+                                                 uint8_t              subindex)
+{
+    switch (feature)
+    {
+        case NRF_SPU_FEATURE_IPCT_CHANNEL:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_IPCT_CHANNEL_COUNT);
+            return (p_reg->FEATURE.IPCT.CH[index]
+                    & SPU_FEATURE_IPCT_CH_BLOCK_Msk)
+                   >> SPU_FEATURE_IPCT_CH_BLOCK_Pos;
+
+        case NRF_SPU_FEATURE_IPCT_INTERRUPT:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_IPCT_INTERRUPT_COUNT);
+            return (p_reg->FEATURE.IPCT.INTERRUPT[index]
+                    & SPU_FEATURE_IPCT_INTERRUPT_BLOCK_Msk)
+                   >> SPU_FEATURE_IPCT_INTERRUPT_BLOCK_Pos;
+
+        case NRF_SPU_FEATURE_DPPI_CHANNEL:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_DPPI_CHANNEL_COUNT);
+            return (p_reg->FEATURE.DPPIC.CH[index]
+                    & SPU_FEATURE_DPPIC_CH_BLOCK_Msk)
+                   >> SPU_FEATURE_DPPIC_CH_BLOCK_Pos;
+
+        case NRF_SPU_FEATURE_DPPI_CHANNEL_GROUP:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_DPPI_CHANNEL_GROUP_COUNT);
+            return (p_reg->FEATURE.DPPIC.CHG[index]
+                    & SPU_FEATURE_DPPIC_CHG_BLOCK_Msk)
+                   >> SPU_FEATURE_DPPIC_CHG_BLOCK_Pos;
+
+        case NRF_SPU_FEATURE_GPIOTE_CHANNEL:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_GPIOTE_COUNT);
+            NRFX_ASSERT(subindex < NRF_SPU_FEATURE_GPIOTE_CHANNEL_COUNT);
+            return (p_reg->FEATURE.GPIOTE[index].CH[subindex]
+                    & SPU_FEATURE_GPIOTE_CH_BLOCK_Msk)
+                   >> SPU_FEATURE_GPIOTE_CH_BLOCK_Pos;
+
+        case NRF_SPU_FEATURE_GPIOTE_INTERRUPT:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_GPIOTE_COUNT);
+            NRFX_ASSERT(subindex < NRF_SPU_FEATURE_GPIOTE_INTERRUPT_COUNT);
+            return (p_reg->FEATURE.GPIOTE[index].INTERRUPT[subindex]
+                    & SPU_FEATURE_GPIOTE_INTERRUPT_BLOCK_Msk)
+                   >> SPU_FEATURE_GPIOTE_INTERRUPT_BLOCK_Pos;
+
+        case NRF_SPU_FEATURE_GPIO_PIN:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_GPIO_COUNT);
+            NRFX_ASSERT(subindex < NRF_SPU_FEATURE_GPIO_PIN_COUNT);
+            return (p_reg->FEATURE.GPIO[index].PIN[subindex]
+                    & SPU_FEATURE_GPIO_PIN_BLOCK_Msk)
+                   >> SPU_FEATURE_GPIO_PIN_BLOCK_Pos;
+
+        case NRF_SPU_FEATURE_GRTC_CC:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_GRTC_CC_COUNT);
+            return (p_reg->FEATURE.GRTC.CC[index]
+                    & SPU_FEATURE_GRTC_CC_BLOCK_Msk)
+                   >> SPU_FEATURE_GRTC_CC_BLOCK_Pos;
+
+        case NRF_SPU_FEATURE_GRTC_SYSCOUNTER:
+            return (p_reg->FEATURE.GRTC.SYSCOUNTER
+                    & SPU_FEATURE_GRTC_SYSCOUNTER_BLOCK_Msk)
+                   >> SPU_FEATURE_GRTC_SYSCOUNTER_BLOCK_Pos;
+
+        case NRF_SPU_FEATURE_GRTC_INTERRUPT:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_GRTC_INTERRUPT_COUNT);
+            return (p_reg->FEATURE.GRTC.INTERRUPT[index]
+                    & SPU_FEATURE_GRTC_INTERRUPT_BLOCK_Msk)
+                   >> SPU_FEATURE_GRTC_INTERRUPT_BLOCK_Pos;
+
+#if NRF_SPU_HAS_DOMAIN
+        case NRF_SPU_FEATURE_BELLS_BELL:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_BELL_BELL_COUNT);
+            return (p_reg->FEATURE.BELLS.DOMAIN[index].BELL[subindex]
+                    & SPU_FEATURE_BELLS_DOMAIN_BELL_BLOCK_Msk)
+                   >> SPU_FEATURE_BELLS_DOMAIN_BELL_BLOCK_Pos;
+#else
+        case NRF_SPU_FEATURE_BELLS_TASKS:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_BELLS_TASKS_COUNT);
+            return (p_reg->FEATURE.BELLS.PROCESSOR[index].TASKS[subindex]
+                    & SPU_FEATURE_BELLS_PROCESSOR_TASKS_BLOCK_Msk)
+                   >> SPU_FEATURE_BELLS_PROCESSOR_TASKS_BLOCK_Pos;
+
+        case NRF_SPU_FEATURE_BELLS_EVENTS:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_BELLS_EVENTS_COUNT);
+            return (p_reg->FEATURE.BELLS.PROCESSOR[index].EVENTS[subindex]
+                    & SPU_FEATURE_BELLS_PROCESSOR_EVENTS_BLOCK_Msk)
+                   >> SPU_FEATURE_BELLS_PROCESSOR_EVENTS_BLOCK_Pos;
+
+        case NRF_SPU_FEATURE_BELLS_INTERRUPT:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_BELLS_INTERRUPT_COUNT);
+            return (p_reg->FEATURE.BELLS.PROCESSOR[index].INTERRUPT[subindex]
+                    & SPU_FEATURE_BELLS_PROCESSOR_INTERRUPT_BLOCK_Msk)
+                   >> SPU_FEATURE_BELLS_PROCESSOR_INTERRUPT_BLOCK_Pos;
+#endif
+        default:
+            NRFX_ASSERT(0);
+            return false;
+    }
+}
+
+NRF_STATIC_INLINE nrf_owner_t nrf_spu_feature_ownerid_get(NRF_SPU_Type const * p_reg,
+                                                          nrf_spu_feature_t    feature,
+                                                          uint8_t              index,
+                                                          uint8_t              subindex)
+{
+    switch (feature)
+    {
+        case NRF_SPU_FEATURE_IPCT_CHANNEL:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_IPCT_CHANNEL_COUNT);
+            return (nrf_owner_t)((p_reg->FEATURE.IPCT.CH[index]
+                                  & SPU_FEATURE_IPCT_CH_OWNERID_Msk)
+                                 >> SPU_FEATURE_IPCT_CH_OWNERID_Pos);
+
+        case NRF_SPU_FEATURE_IPCT_INTERRUPT:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_IPCT_INTERRUPT_COUNT);
+            return (nrf_owner_t)((p_reg->FEATURE.IPCT.INTERRUPT[index]
+                                  & SPU_FEATURE_IPCT_INTERRUPT_OWNERID_Msk)
+                                 >> SPU_FEATURE_IPCT_INTERRUPT_OWNERID_Pos);
+
+        case NRF_SPU_FEATURE_DPPI_CHANNEL:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_DPPI_CHANNEL_COUNT);
+            return (nrf_owner_t)((p_reg->FEATURE.DPPIC.CH[index]
+                                  & SPU_FEATURE_DPPIC_CH_OWNERID_Msk)
+                                 >> SPU_FEATURE_DPPIC_CH_OWNERID_Pos);
+
+        case NRF_SPU_FEATURE_DPPI_CHANNEL_GROUP:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_DPPI_CHANNEL_GROUP_COUNT);
+            return (nrf_owner_t)((p_reg->FEATURE.DPPIC.CHG[index]
+                                  & SPU_FEATURE_DPPIC_CHG_OWNERID_Msk)
+                                 >> SPU_FEATURE_DPPIC_CHG_OWNERID_Pos);
+
+        case NRF_SPU_FEATURE_GPIOTE_CHANNEL:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_GPIOTE_COUNT);
+            NRFX_ASSERT(subindex < NRF_SPU_FEATURE_GPIOTE_CHANNEL_COUNT);
+            return (nrf_owner_t)((p_reg->FEATURE.GPIOTE[index].CH[subindex]
+                                  & SPU_FEATURE_GPIOTE_CH_OWNERID_Msk)
+                                 >> SPU_FEATURE_GPIOTE_CH_OWNERID_Pos);
+
+        case NRF_SPU_FEATURE_GPIOTE_INTERRUPT:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_GPIOTE_COUNT);
+            NRFX_ASSERT(subindex < NRF_SPU_FEATURE_GPIOTE_INTERRUPT_COUNT);
+            return (nrf_owner_t)((p_reg->FEATURE.GPIOTE[index].INTERRUPT[subindex]
+                                  & SPU_FEATURE_GPIOTE_INTERRUPT_OWNERID_Msk)
+                                 >> SPU_FEATURE_GPIOTE_INTERRUPT_OWNERID_Pos);
+
+        case NRF_SPU_FEATURE_GPIO_PIN:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_GPIO_COUNT);
+            NRFX_ASSERT(subindex < NRF_SPU_FEATURE_GPIO_PIN_COUNT);
+            return (nrf_owner_t)((p_reg->FEATURE.GPIO[index].PIN[subindex]
+                                  & SPU_FEATURE_GPIO_PIN_OWNERID_Msk)
+                                 >> SPU_FEATURE_GPIO_PIN_OWNERID_Pos);
+
+        case NRF_SPU_FEATURE_GRTC_CC:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_GRTC_CC_COUNT);
+            return (nrf_owner_t)((p_reg->FEATURE.GRTC.CC[index]
+                                  & SPU_FEATURE_GRTC_CC_OWNERID_Msk)
+                                 >> SPU_FEATURE_GRTC_CC_OWNERID_Pos);
+
+        case NRF_SPU_FEATURE_GRTC_SYSCOUNTER:
+            return (nrf_owner_t)((p_reg->FEATURE.GRTC.SYSCOUNTER
+                                  & SPU_FEATURE_GRTC_SYSCOUNTER_OWNERID_Msk)
+                                 >> SPU_FEATURE_GRTC_SYSCOUNTER_OWNERID_Pos);
+
+        case NRF_SPU_FEATURE_GRTC_INTERRUPT:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_GRTC_INTERRUPT_COUNT);
+            return (nrf_owner_t)((p_reg->FEATURE.GRTC.INTERRUPT[index]
+                                  & SPU_FEATURE_GRTC_INTERRUPT_OWNERID_Msk)
+                                 >> SPU_FEATURE_GRTC_INTERRUPT_OWNERID_Pos);
+
+#if NRF_SPU_HAS_DOMAIN
+        case NRF_SPU_FEATURE_BELLS_BELL:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_BELL_BELL_COUNT);
+            return (nrf_owner_t)((p_reg->FEATURE.BELLS.DOMAIN[index].BELL[subindex]
+                    & SPU_FEATURE_BELLS_DOMAIN_BELL_OWNERID_Msk)
+                   >> SPU_FEATURE_BELLS_DOMAIN_BELL_OWNERID_Pos);
+#else
+        case NRF_SPU_FEATURE_BELLS_TASKS:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_BELLS_TASKS_COUNT);
+            return (nrf_owner_t)((p_reg->FEATURE.BELLS.PROCESSOR[index].TASKS[subindex]
+                    & SPU_FEATURE_BELLS_PROCESSOR_TASKS_OWNERID_Msk)
+                   >> SPU_FEATURE_BELLS_PROCESSOR_TASKS_OWNERID_Pos);
+
+        case NRF_SPU_FEATURE_BELLS_EVENTS:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_BELLS_EVENTS_COUNT);
+            return (nrf_owner_t)((p_reg->FEATURE.BELLS.PROCESSOR[index].EVENTS[subindex]
+                    & SPU_FEATURE_BELLS_PROCESSOR_EVENTS_OWNERID_Msk)
+                   >> SPU_FEATURE_BELLS_PROCESSOR_EVENTS_OWNERID_Pos);
+
+        case NRF_SPU_FEATURE_BELLS_INTERRUPT:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_BELLS_INTERRUPT_COUNT);
+            return (nrf_owner_t)((p_reg->FEATURE.BELLS.PROCESSOR[index].INTERRUPT[subindex]
+                    & SPU_FEATURE_BELLS_PROCESSOR_INTERRUPT_OWNERID_Msk)
+                   >> SPU_FEATURE_BELLS_PROCESSOR_INTERRUPT_OWNERID_Pos);
+#endif
+        default:
+            NRFX_ASSERT(0);
+            return (nrf_owner_t)0;
+    }
+}
+
+NRF_STATIC_INLINE void nrf_spu_feature_secattr_set(NRF_SPU_Type *    p_reg,
+                                                   nrf_spu_feature_t feature,
+                                                   uint8_t           index,
+                                                   uint8_t           subindex,
+                                                   bool              enable)
+{
+    switch (feature)
+    {
+        case NRF_SPU_FEATURE_IPCT_CHANNEL:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_IPCT_CHANNEL_COUNT);
+            p_reg->FEATURE.IPCT.CH[index] =
+                ((p_reg->FEATURE.IPCT.CH[index] &
+                  ~SPU_FEATURE_IPCT_CH_SECATTR_Msk) |
+                 ((enable ?
+                   SPU_FEATURE_IPCT_CH_SECATTR_Secure :
+                   SPU_FEATURE_IPCT_CH_SECATTR_NonSecure)
+                  << SPU_FEATURE_IPCT_CH_SECATTR_Pos));
+            break;
+
+        case NRF_SPU_FEATURE_IPCT_INTERRUPT:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_IPCT_INTERRUPT_COUNT);
+            p_reg->FEATURE.IPCT.INTERRUPT[index] =
+                ((p_reg->FEATURE.IPCT.INTERRUPT[index] &
+                  ~SPU_FEATURE_IPCT_INTERRUPT_SECATTR_Msk) |
+                 ((enable ?
+                   SPU_FEATURE_IPCT_INTERRUPT_SECATTR_Secure :
+                   SPU_FEATURE_IPCT_INTERRUPT_SECATTR_NonSecure)
+                  <<  SPU_FEATURE_IPCT_INTERRUPT_SECATTR_Pos));
+            break;
+
+        case NRF_SPU_FEATURE_DPPI_CHANNEL:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_DPPI_CHANNEL_COUNT);
+            p_reg->FEATURE.DPPIC.CH[index] =
+                ((p_reg->FEATURE.DPPIC.CH[index] &
+                  ~SPU_FEATURE_DPPIC_CH_SECATTR_Msk) |
+                 ((enable ?
+                   SPU_FEATURE_DPPIC_CH_SECATTR_Secure :
+                   SPU_FEATURE_DPPIC_CH_SECATTR_NonSecure)
+                  <<  SPU_FEATURE_DPPIC_CH_SECATTR_Pos));
+            break;
+
+        case NRF_SPU_FEATURE_DPPI_CHANNEL_GROUP:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_DPPI_CHANNEL_GROUP_COUNT);
+            p_reg->FEATURE.DPPIC.CHG[index] =
+                ((p_reg->FEATURE.DPPIC.CHG[index] &
+                  ~SPU_FEATURE_DPPIC_CHG_SECATTR_Msk) |
+                 ((enable ?
+                   SPU_FEATURE_DPPIC_CHG_SECATTR_Secure :
+                   SPU_FEATURE_DPPIC_CHG_SECATTR_NonSecure)
+                  <<  SPU_FEATURE_DPPIC_CHG_SECATTR_Pos));
+            break;
+
+        case NRF_SPU_FEATURE_GPIOTE_CHANNEL:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_GPIOTE_COUNT);
+            NRFX_ASSERT(subindex < NRF_SPU_FEATURE_GPIOTE_CHANNEL_COUNT);
+            p_reg->FEATURE.GPIOTE[index].CH[subindex] =
+                ((p_reg->FEATURE.GPIOTE[index].CH[subindex] &
+                  ~SPU_FEATURE_GPIOTE_CH_SECATTR_Msk) |
+                 ((enable ?
+                   SPU_FEATURE_GPIOTE_CH_SECATTR_Secure :
+                   SPU_FEATURE_GPIOTE_CH_SECATTR_NonSecure)
+                  <<  SPU_FEATURE_GPIOTE_CH_SECATTR_Pos));
+            break;
+
+        case NRF_SPU_FEATURE_GPIOTE_INTERRUPT:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_GPIOTE_COUNT);
+            NRFX_ASSERT(subindex < NRF_SPU_FEATURE_GPIOTE_INTERRUPT_COUNT);
+            p_reg->FEATURE.GPIOTE[index].INTERRUPT[subindex] =
+                ((p_reg->FEATURE.GPIOTE[index].INTERRUPT[subindex] &
+                  ~SPU_FEATURE_GPIOTE_INTERRUPT_SECATTR_Msk) |
+                 ((enable ?
+                   SPU_FEATURE_GPIOTE_INTERRUPT_SECATTR_Secure :
+                   SPU_FEATURE_GPIOTE_INTERRUPT_SECATTR_NonSecure)
+                  <<  SPU_FEATURE_GPIOTE_INTERRUPT_SECATTR_Pos));
+            break;
+
+        case NRF_SPU_FEATURE_GPIO_PIN:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_GPIO_COUNT);
+            NRFX_ASSERT(subindex < NRF_SPU_FEATURE_GPIO_PIN_COUNT);
+            p_reg->FEATURE.GPIO[index].PIN[subindex] =
+                ((p_reg->FEATURE.GPIO[index].PIN[subindex] &
+                  ~SPU_FEATURE_GPIO_PIN_SECATTR_Msk) |
+                 ((enable ?
+                   SPU_FEATURE_GPIO_PIN_SECATTR_Secure :
+                   SPU_FEATURE_GPIO_PIN_SECATTR_NonSecure)
+                  <<  SPU_FEATURE_GPIO_PIN_SECATTR_Pos));
+            break;
+
+        case NRF_SPU_FEATURE_GRTC_CC:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_GRTC_CC_COUNT);
+            p_reg->FEATURE.GRTC.CC[index] =
+                ((p_reg->FEATURE.GRTC.CC[index] &
+                  ~SPU_FEATURE_GRTC_CC_SECATTR_Msk) |
+                 ((enable ?
+                   SPU_FEATURE_GRTC_CC_SECATTR_Secure :
+                   SPU_FEATURE_GRTC_CC_SECATTR_NonSecure)
+                  <<  SPU_FEATURE_GRTC_CC_SECATTR_Pos));
+            break;
+
+        case NRF_SPU_FEATURE_GRTC_SYSCOUNTER:
+            p_reg->FEATURE.GRTC.SYSCOUNTER =
+                ((p_reg->FEATURE.GRTC.SYSCOUNTER &
+                  ~SPU_FEATURE_GRTC_SYSCOUNTER_SECATTR_Msk) |
+                 ((enable ?
+                   SPU_FEATURE_GRTC_SYSCOUNTER_SECATTR_Secure :
+                   SPU_FEATURE_GRTC_SYSCOUNTER_SECATTR_NonSecure)
+                  <<  SPU_FEATURE_GRTC_SYSCOUNTER_SECATTR_Pos));
+            break;
+
+        case NRF_SPU_FEATURE_GRTC_INTERRUPT:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_GRTC_INTERRUPT_COUNT);
+            p_reg->FEATURE.GRTC.INTERRUPT[index] =
+                ((p_reg->FEATURE.GRTC.INTERRUPT[index] &
+                  ~SPU_FEATURE_GRTC_INTERRUPT_SECATTR_Msk) |
+                 ((enable ?
+                   SPU_FEATURE_GRTC_INTERRUPT_SECATTR_Secure :
+                   SPU_FEATURE_GRTC_INTERRUPT_SECATTR_NonSecure)
+                  <<  SPU_FEATURE_GRTC_INTERRUPT_SECATTR_Pos));
+            break;
+
+#if NRF_SPU_HAS_DOMAIN
+        case NRF_SPU_FEATURE_BELLS_BELL:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_BELL_BELL_COUNT);
+            p_reg->FEATURE.BELLS.DOMAIN[index].BELL[subindex] =
+                ((p_reg->FEATURE.BELLS.DOMAIN[index].BELL[subindex] &
+                  ~SPU_FEATURE_BELLS_DOMAIN_BELL_SECATTR_Msk) |
+                 ((enable ?
+                   SPU_FEATURE_BELLS_DOMAIN_BELL_SECATTR_Secure :
+                   SPU_FEATURE_BELLS_DOMAIN_BELL_SECATTR_NonSecure)
+                  <<  SPU_FEATURE_BELLS_DOMAIN_BELL_SECATTR_Pos));
+            break;
+#else
+        case NRF_SPU_FEATURE_BELLS_TASKS:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_BELLS_TASKS_COUNT);
+            p_reg->FEATURE.BELLS.PROCESSOR[index].TASKS[subindex] =
+                ((p_reg->FEATURE.BELLS.PROCESSOR[index].TASKS[subindex] &
+                  ~SPU_FEATURE_BELLS_PROCESSOR_TASKS_SECATTR_Msk) |
+                 ((enable ?
+                   SPU_FEATURE_BELLS_PROCESSOR_TASKS_SECATTR_Secure :
+                   SPU_FEATURE_BELLS_PROCESSOR_TASKS_SECATTR_NonSecure)
+                  <<  SPU_FEATURE_BELLS_PROCESSOR_TASKS_SECATTR_Pos));
+            break;
+
+        case NRF_SPU_FEATURE_BELLS_EVENTS:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_BELLS_EVENTS_COUNT);
+            p_reg->FEATURE.BELLS.PROCESSOR[index].EVENTS[subindex] =
+                ((p_reg->FEATURE.BELLS.PROCESSOR[index].EVENTS[subindex] &
+                  ~SPU_FEATURE_BELLS_PROCESSOR_EVENTS_SECATTR_Msk) |
+                 ((enable ?
+                   SPU_FEATURE_BELLS_PROCESSOR_EVENTS_SECATTR_Secure :
+                   SPU_FEATURE_BELLS_PROCESSOR_EVENTS_SECATTR_NonSecure)
+                  <<  SPU_FEATURE_BELLS_PROCESSOR_EVENTS_SECATTR_Pos));
+            break;
+
+        case NRF_SPU_FEATURE_BELLS_INTERRUPT:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_BELLS_INTERRUPT_COUNT);
+            p_reg->FEATURE.BELLS.PROCESSOR[index].INTERRUPT[subindex] =
+                ((p_reg->FEATURE.BELLS.PROCESSOR[index].INTERRUPT[subindex] &
+                  ~SPU_FEATURE_BELLS_PROCESSOR_INTERRUPT_SECATTR_Msk) |
+                 ((enable ?
+                   SPU_FEATURE_BELLS_PROCESSOR_INTERRUPT_SECATTR_Secure :
+                   SPU_FEATURE_BELLS_PROCESSOR_INTERRUPT_SECATTR_NonSecure)
+                  <<  SPU_FEATURE_BELLS_PROCESSOR_INTERRUPT_SECATTR_Pos));
+            break;
+#endif
+
+        default:
+            NRFX_ASSERT(0);
+            break;
+    }
+}
+
+NRF_STATIC_INLINE void nrf_spu_feature_lock_enable(NRF_SPU_Type *    p_reg,
+                                                   nrf_spu_feature_t feature,
+                                                   uint8_t           index,
+                                                   uint8_t           subindex)
+{
+    switch (feature)
+    {
+        case NRF_SPU_FEATURE_IPCT_CHANNEL:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_IPCT_CHANNEL_COUNT);
+            p_reg->FEATURE.IPCT.CH[index] =
+                ((p_reg->FEATURE.IPCT.CH[index] &
+                  ~SPU_FEATURE_IPCT_CH_LOCK_Msk) |
+                 (SPU_FEATURE_IPCT_CH_LOCK_Locked
+                  << SPU_FEATURE_IPCT_CH_LOCK_Pos));
+            break;
+
+        case NRF_SPU_FEATURE_IPCT_INTERRUPT:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_IPCT_INTERRUPT_COUNT);
+            p_reg->FEATURE.IPCT.INTERRUPT[index] =
+                ((p_reg->FEATURE.IPCT.INTERRUPT[index] &
+                  ~SPU_FEATURE_IPCT_INTERRUPT_LOCK_Msk) |
+                 (SPU_FEATURE_IPCT_INTERRUPT_LOCK_Locked
+                  << SPU_FEATURE_IPCT_INTERRUPT_LOCK_Pos));
+            break;
+
+        case NRF_SPU_FEATURE_DPPI_CHANNEL:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_DPPI_CHANNEL_COUNT);
+            p_reg->FEATURE.DPPIC.CH[index] =
+                ((p_reg->FEATURE.DPPIC.CH[index] &
+                  ~SPU_FEATURE_DPPIC_CH_LOCK_Msk) |
+                 (SPU_FEATURE_DPPIC_CH_LOCK_Locked
+                  << SPU_FEATURE_DPPIC_CH_LOCK_Pos));
+            break;
+
+        case NRF_SPU_FEATURE_DPPI_CHANNEL_GROUP:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_DPPI_CHANNEL_GROUP_COUNT);
+            p_reg->FEATURE.DPPIC.CHG[index] =
+                ((p_reg->FEATURE.DPPIC.CHG[index] &
+                  ~SPU_FEATURE_DPPIC_CHG_LOCK_Msk) |
+                 (SPU_FEATURE_DPPIC_CHG_LOCK_Locked
+                  << SPU_FEATURE_DPPIC_CHG_LOCK_Pos));
+            break;
+
+        case NRF_SPU_FEATURE_GPIOTE_CHANNEL:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_GPIOTE_COUNT);
+            NRFX_ASSERT(subindex < NRF_SPU_FEATURE_GPIOTE_CHANNEL_COUNT);
+            p_reg->FEATURE.GPIOTE[index].CH[subindex] =
+                ((p_reg->FEATURE.GPIOTE[index].CH[subindex] &
+                  ~SPU_FEATURE_GPIOTE_CH_LOCK_Msk) |
+                 (SPU_FEATURE_GPIOTE_CH_LOCK_Locked
+                  << SPU_FEATURE_GPIOTE_CH_LOCK_Pos));
+            break;
+
+        case NRF_SPU_FEATURE_GPIOTE_INTERRUPT:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_GPIOTE_COUNT);
+            NRFX_ASSERT(subindex < NRF_SPU_FEATURE_GPIOTE_INTERRUPT_COUNT);
+            p_reg->FEATURE.GPIOTE[index].INTERRUPT[subindex] =
+                ((p_reg->FEATURE.GPIOTE[index].INTERRUPT[subindex] &
+                  ~SPU_FEATURE_GPIOTE_INTERRUPT_LOCK_Msk) |
+                 (SPU_FEATURE_GPIOTE_INTERRUPT_LOCK_Locked
+                  << SPU_FEATURE_GPIOTE_INTERRUPT_LOCK_Pos));
+            break;
+
+        case NRF_SPU_FEATURE_GPIO_PIN:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_GPIO_COUNT);
+            NRFX_ASSERT(subindex < NRF_SPU_FEATURE_GPIO_PIN_COUNT);
+            p_reg->FEATURE.GPIO[index].PIN[subindex] =
+                ((p_reg->FEATURE.GPIO[index].PIN[subindex] &
+                  ~SPU_FEATURE_GPIO_PIN_LOCK_Msk) |
+                 (SPU_FEATURE_GPIO_PIN_LOCK_Locked
+                  << SPU_FEATURE_GPIO_PIN_LOCK_Pos));
+            break;
+
+        case NRF_SPU_FEATURE_GRTC_CC:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_GRTC_CC_COUNT);
+            p_reg->FEATURE.GRTC.CC[index] =
+                ((p_reg->FEATURE.GRTC.CC[index] &
+                  ~SPU_FEATURE_GRTC_CC_LOCK_Msk) |
+                 (SPU_FEATURE_GRTC_CC_LOCK_Locked
+                  << SPU_FEATURE_GRTC_CC_LOCK_Pos));
+            break;
+
+        case NRF_SPU_FEATURE_GRTC_SYSCOUNTER:
+            p_reg->FEATURE.GRTC.SYSCOUNTER =
+                ((p_reg->FEATURE.GRTC.SYSCOUNTER &
+                  ~SPU_FEATURE_GRTC_SYSCOUNTER_LOCK_Msk) |
+                 (SPU_FEATURE_GRTC_SYSCOUNTER_LOCK_Locked
+                  << SPU_FEATURE_GRTC_SYSCOUNTER_LOCK_Pos));
+            break;
+
+        case NRF_SPU_FEATURE_GRTC_INTERRUPT:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_GRTC_INTERRUPT_COUNT);
+            p_reg->FEATURE.GRTC.INTERRUPT[index] =
+                ((p_reg->FEATURE.GRTC.INTERRUPT[index] &
+                  ~SPU_FEATURE_GRTC_INTERRUPT_LOCK_Msk) |
+                 (SPU_FEATURE_GRTC_INTERRUPT_LOCK_Locked
+                  << SPU_FEATURE_GRTC_INTERRUPT_LOCK_Pos));
+            break;
+
+#if NRF_SPU_HAS_DOMAIN
+        case NRF_SPU_FEATURE_BELLS_BELL:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_BELL_BELL_COUNT);
+            p_reg->FEATURE.BELLS.DOMAIN[index].BELL[subindex] =
+                ((p_reg->FEATURE.BELLS.DOMAIN[index].BELL[subindex] &
+                  ~SPU_FEATURE_BELLS_DOMAIN_BELL_LOCK_Msk) |
+                 (SPU_FEATURE_BELLS_DOMAIN_BELL_LOCK_Locked
+                  << SPU_FEATURE_BELLS_DOMAIN_BELL_LOCK_Pos));
+            break;
+#else
+        case NRF_SPU_FEATURE_BELLS_TASKS:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_BELLS_TASKS_COUNT);
+            p_reg->FEATURE.BELLS.PROCESSOR[index].TASKS[subindex] =
+                ((p_reg->FEATURE.BELLS.PROCESSOR[index].TASKS[subindex] &
+                  ~SPU_FEATURE_BELLS_PROCESSOR_TASKS_LOCK_Msk) |
+                 (SPU_FEATURE_BELLS_PROCESSOR_TASKS_LOCK_Locked
+                  << SPU_FEATURE_BELLS_PROCESSOR_TASKS_LOCK_Pos));
+            break;
+
+        case NRF_SPU_FEATURE_BELLS_EVENTS:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_BELLS_EVENTS_COUNT);
+            p_reg->FEATURE.BELLS.PROCESSOR[index].EVENTS[subindex] =
+                ((p_reg->FEATURE.BELLS.PROCESSOR[index].EVENTS[subindex] &
+                  ~SPU_FEATURE_BELLS_PROCESSOR_EVENTS_LOCK_Msk) |
+                 (SPU_FEATURE_BELLS_PROCESSOR_EVENTS_LOCK_Locked
+                  << SPU_FEATURE_BELLS_PROCESSOR_EVENTS_LOCK_Pos));
+            break;
+
+        case NRF_SPU_FEATURE_BELLS_INTERRUPT:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_BELLS_INTERRUPT_COUNT);
+            p_reg->FEATURE.BELLS.PROCESSOR[index].INTERRUPT[subindex] =
+                ((p_reg->FEATURE.BELLS.PROCESSOR[index].INTERRUPT[subindex] &
+                  ~SPU_FEATURE_BELLS_PROCESSOR_INTERRUPT_LOCK_Msk) |
+                 (SPU_FEATURE_BELLS_PROCESSOR_INTERRUPT_LOCK_Locked
+                  << SPU_FEATURE_BELLS_PROCESSOR_INTERRUPT_LOCK_Pos));
+            break;
+#endif
+
+        default:
+            NRFX_ASSERT(0);
+            break;
+    }
+}
+
+NRF_STATIC_INLINE void nrf_spu_feature_block_enable(NRF_SPU_Type *    p_reg,
+                                                    nrf_spu_feature_t feature,
+                                                    uint8_t           index,
+                                                    uint8_t           subindex)
+{
+    switch (feature)
+    {
+        case NRF_SPU_FEATURE_IPCT_CHANNEL:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_IPCT_CHANNEL_COUNT);
+            p_reg->FEATURE.IPCT.CH[index] =
+                ((p_reg->FEATURE.IPCT.CH[index] &
+                  ~SPU_FEATURE_IPCT_CH_BLOCK_Msk) |
+                 (SPU_FEATURE_IPCT_CH_BLOCK_Blocked
+                  << SPU_FEATURE_IPCT_CH_BLOCK_Pos));
+            break;
+
+        case NRF_SPU_FEATURE_IPCT_INTERRUPT:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_IPCT_INTERRUPT_COUNT);
+            p_reg->FEATURE.IPCT.INTERRUPT[index] =
+                ((p_reg->FEATURE.IPCT.INTERRUPT[index] &
+                  ~SPU_FEATURE_IPCT_INTERRUPT_BLOCK_Msk) |
+                 (SPU_FEATURE_IPCT_INTERRUPT_BLOCK_Blocked
+                  << SPU_FEATURE_IPCT_INTERRUPT_BLOCK_Pos));
+            break;
+
+        case NRF_SPU_FEATURE_DPPI_CHANNEL:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_DPPI_CHANNEL_COUNT);
+            p_reg->FEATURE.DPPIC.CH[index] =
+                ((p_reg->FEATURE.DPPIC.CH[index] &
+                  ~SPU_FEATURE_DPPIC_CH_BLOCK_Msk) |
+                 (SPU_FEATURE_DPPIC_CH_BLOCK_Blocked
+                  << SPU_FEATURE_DPPIC_CH_BLOCK_Pos));
+            break;
+
+        case NRF_SPU_FEATURE_DPPI_CHANNEL_GROUP:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_DPPI_CHANNEL_GROUP_COUNT);
+            p_reg->FEATURE.DPPIC.CHG[index] =
+                ((p_reg->FEATURE.DPPIC.CHG[index] &
+                  ~SPU_FEATURE_DPPIC_CHG_BLOCK_Msk) |
+                 (SPU_FEATURE_DPPIC_CHG_BLOCK_Blocked
+                  << SPU_FEATURE_DPPIC_CHG_BLOCK_Pos));
+            break;
+
+        case NRF_SPU_FEATURE_GPIOTE_CHANNEL:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_GPIOTE_COUNT);
+            NRFX_ASSERT(subindex < NRF_SPU_FEATURE_GPIOTE_CHANNEL_COUNT);
+            p_reg->FEATURE.GPIOTE[index].CH[subindex] =
+                ((p_reg->FEATURE.GPIOTE[index].CH[subindex] &
+                  ~SPU_FEATURE_GPIOTE_CH_BLOCK_Msk) |
+                 (SPU_FEATURE_GPIOTE_CH_BLOCK_Blocked
+                  << SPU_FEATURE_GPIOTE_CH_BLOCK_Pos));
+            break;
+
+        case NRF_SPU_FEATURE_GPIOTE_INTERRUPT:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_GPIOTE_COUNT);
+            NRFX_ASSERT(subindex < NRF_SPU_FEATURE_GPIOTE_INTERRUPT_COUNT);
+            p_reg->FEATURE.GPIOTE[index].INTERRUPT[subindex] =
+                ((p_reg->FEATURE.GPIOTE[index].INTERRUPT[subindex] &
+                  ~SPU_FEATURE_GPIOTE_INTERRUPT_BLOCK_Msk) |
+                 (SPU_FEATURE_GPIOTE_INTERRUPT_BLOCK_Blocked
+                  << SPU_FEATURE_GPIOTE_INTERRUPT_BLOCK_Pos));
+            break;
+
+        case NRF_SPU_FEATURE_GPIO_PIN:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_GPIO_COUNT);
+            NRFX_ASSERT(subindex < NRF_SPU_FEATURE_GPIO_PIN_COUNT);
+            p_reg->FEATURE.GPIO[index].PIN[subindex] =
+                ((p_reg->FEATURE.GPIO[index].PIN[subindex] &
+                  ~SPU_FEATURE_GPIO_PIN_BLOCK_Msk) |
+                 (SPU_FEATURE_GPIO_PIN_BLOCK_Blocked
+                  << SPU_FEATURE_GPIO_PIN_BLOCK_Pos));
+            break;
+
+        case NRF_SPU_FEATURE_GRTC_CC:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_GRTC_CC_COUNT);
+            p_reg->FEATURE.GRTC.CC[index] =
+                ((p_reg->FEATURE.GRTC.CC[index] &
+                  ~SPU_FEATURE_GRTC_CC_BLOCK_Msk) |
+                 (SPU_FEATURE_GRTC_CC_BLOCK_Blocked
+                  << SPU_FEATURE_GRTC_CC_BLOCK_Pos));
+            break;
+
+        case NRF_SPU_FEATURE_GRTC_SYSCOUNTER:
+            p_reg->FEATURE.GRTC.SYSCOUNTER =
+                ((p_reg->FEATURE.GRTC.SYSCOUNTER &
+                  ~SPU_FEATURE_GRTC_SYSCOUNTER_BLOCK_Msk) |
+                 (SPU_FEATURE_GRTC_SYSCOUNTER_BLOCK_Blocked
+                  << SPU_FEATURE_GRTC_SYSCOUNTER_BLOCK_Pos));
+            break;
+
+        case NRF_SPU_FEATURE_GRTC_INTERRUPT:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_GRTC_INTERRUPT_COUNT);
+            p_reg->FEATURE.GRTC.INTERRUPT[index] =
+                ((p_reg->FEATURE.GRTC.INTERRUPT[index] &
+                  ~SPU_FEATURE_GRTC_INTERRUPT_BLOCK_Msk) |
+                 (SPU_FEATURE_GRTC_INTERRUPT_BLOCK_Blocked
+                  << SPU_FEATURE_GRTC_INTERRUPT_BLOCK_Pos));
+            break;
+
+#if NRF_SPU_HAS_DOMAIN
+        case NRF_SPU_FEATURE_BELLS_BELL:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_BELL_BELL_COUNT);
+            p_reg->FEATURE.BELLS.DOMAIN[index].BELL[subindex] =
+                ((p_reg->FEATURE.BELLS.DOMAIN[index].BELL[subindex] &
+                  ~SPU_FEATURE_BELLS_DOMAIN_BELL_BLOCK_Msk) |
+                 (SPU_FEATURE_BELLS_DOMAIN_BELL_BLOCK_Blocked
+                  << SPU_FEATURE_BELLS_DOMAIN_BELL_BLOCK_Pos));
+            break;
+#else
+        case NRF_SPU_FEATURE_BELLS_TASKS:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_BELLS_TASKS_COUNT);
+            p_reg->FEATURE.BELLS.PROCESSOR[index].TASKS[subindex] =
+                ((p_reg->FEATURE.BELLS.PROCESSOR[index].TASKS[subindex] &
+                  ~SPU_FEATURE_BELLS_PROCESSOR_TASKS_BLOCK_Msk) |
+                 (SPU_FEATURE_BELLS_PROCESSOR_TASKS_BLOCK_Blocked
+                  << SPU_FEATURE_BELLS_PROCESSOR_TASKS_BLOCK_Pos));
+            break;
+
+        case NRF_SPU_FEATURE_BELLS_EVENTS:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_BELLS_EVENTS_COUNT);
+            p_reg->FEATURE.BELLS.PROCESSOR[index].EVENTS[subindex] =
+                ((p_reg->FEATURE.BELLS.PROCESSOR[index].EVENTS[subindex] &
+                  ~SPU_FEATURE_BELLS_PROCESSOR_EVENTS_BLOCK_Msk) |
+                 (SPU_FEATURE_BELLS_PROCESSOR_EVENTS_BLOCK_Blocked
+                  << SPU_FEATURE_BELLS_PROCESSOR_EVENTS_BLOCK_Pos));
+            break;
+
+        case NRF_SPU_FEATURE_BELLS_INTERRUPT:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_BELLS_INTERRUPT_COUNT);
+            p_reg->FEATURE.BELLS.PROCESSOR[index].INTERRUPT[subindex] =
+                ((p_reg->FEATURE.BELLS.PROCESSOR[index].INTERRUPT[subindex] &
+                  ~SPU_FEATURE_BELLS_PROCESSOR_INTERRUPT_BLOCK_Msk) |
+                 (SPU_FEATURE_BELLS_PROCESSOR_INTERRUPT_BLOCK_Blocked
+                  << SPU_FEATURE_BELLS_PROCESSOR_INTERRUPT_BLOCK_Pos));
+            break;
+#endif
+
+        default:
+            NRFX_ASSERT(0);
+            break;
+    }
+}
+
+NRF_STATIC_INLINE void nrf_spu_feature_ownerid_set(NRF_SPU_Type *    p_reg,
+                                                   nrf_spu_feature_t feature,
+                                                   uint8_t           index,
+                                                   uint8_t           subindex,
+                                                   nrf_owner_t       owner_id)
+{
+    switch (feature)
+    {
+        case NRF_SPU_FEATURE_IPCT_CHANNEL:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_IPCT_CHANNEL_COUNT);
+            p_reg->FEATURE.IPCT.CH[index] =
+                ((p_reg->FEATURE.IPCT.CH[index] &
+                  ~SPU_FEATURE_IPCT_CH_OWNERID_Msk) |
+                 ((owner_id
+                   << SPU_FEATURE_IPCT_CH_OWNERID_Pos) &
+                  SPU_FEATURE_IPCT_CH_OWNERID_Msk));
+            break;
+
+        case NRF_SPU_FEATURE_IPCT_INTERRUPT:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_IPCT_INTERRUPT_COUNT);
+            p_reg->FEATURE.IPCT.INTERRUPT[index] =
+                ((p_reg->FEATURE.IPCT.INTERRUPT[index] &
+                  ~SPU_FEATURE_IPCT_INTERRUPT_OWNERID_Msk) |
+                 ((owner_id
+                   << SPU_FEATURE_IPCT_INTERRUPT_OWNERID_Pos) &
+                  SPU_FEATURE_IPCT_INTERRUPT_OWNERID_Msk));
+            break;
+
+        case NRF_SPU_FEATURE_DPPI_CHANNEL:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_DPPI_CHANNEL_COUNT);
+            p_reg->FEATURE.DPPIC.CH[index] =
+                ((p_reg->FEATURE.DPPIC.CH[index] &
+                  ~SPU_FEATURE_DPPIC_CH_OWNERID_Msk) |
+                 ((owner_id
+                   << SPU_FEATURE_DPPIC_CH_OWNERID_Pos) &
+                  SPU_FEATURE_DPPIC_CH_OWNERID_Msk));
+            break;
+
+        case NRF_SPU_FEATURE_DPPI_CHANNEL_GROUP:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_DPPI_CHANNEL_GROUP_COUNT);
+            p_reg->FEATURE.DPPIC.CHG[index] =
+                ((p_reg->FEATURE.DPPIC.CHG[index] &
+                  ~SPU_FEATURE_DPPIC_CHG_OWNERID_Msk) |
+                 ((owner_id
+                   << SPU_FEATURE_DPPIC_CHG_OWNERID_Pos) &
+                  SPU_FEATURE_DPPIC_CHG_OWNERID_Msk));
+            break;
+
+        case NRF_SPU_FEATURE_GPIOTE_CHANNEL:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_GPIOTE_COUNT);
+            NRFX_ASSERT(subindex < NRF_SPU_FEATURE_GPIOTE_CHANNEL_COUNT);
+            p_reg->FEATURE.GPIOTE[index].CH[subindex] =
+                ((p_reg->FEATURE.GPIOTE[index].CH[subindex] &
+                  ~SPU_FEATURE_GPIOTE_CH_OWNERID_Msk) |
+                 ((owner_id
+                   << SPU_FEATURE_GPIOTE_CH_OWNERID_Pos) &
+                  SPU_FEATURE_GPIOTE_CH_OWNERID_Msk));
+            break;
+
+        case NRF_SPU_FEATURE_GPIOTE_INTERRUPT:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_GPIOTE_COUNT);
+            NRFX_ASSERT(subindex < NRF_SPU_FEATURE_GPIOTE_INTERRUPT_COUNT);
+            p_reg->FEATURE.GPIOTE[index].INTERRUPT[subindex] =
+                ((p_reg->FEATURE.GPIOTE[index].INTERRUPT[subindex] &
+                  ~SPU_FEATURE_GPIOTE_INTERRUPT_OWNERID_Msk) |
+                 ((owner_id
+                   << SPU_FEATURE_GPIOTE_INTERRUPT_OWNERID_Pos) &
+                  SPU_FEATURE_GPIOTE_INTERRUPT_OWNERID_Msk));
+            break;
+
+        case NRF_SPU_FEATURE_GPIO_PIN:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_GPIO_COUNT);
+            NRFX_ASSERT(subindex < NRF_SPU_FEATURE_GPIO_PIN_COUNT);
+            p_reg->FEATURE.GPIO[index].PIN[subindex] =
+                ((p_reg->FEATURE.GPIO[index].PIN[subindex] &
+                  ~SPU_FEATURE_GPIO_PIN_OWNERID_Msk) |
+                 ((owner_id
+                   << SPU_FEATURE_GPIO_PIN_OWNERID_Pos) &
+                  SPU_FEATURE_GPIO_PIN_OWNERID_Msk));
+            break;
+
+        case NRF_SPU_FEATURE_GRTC_CC:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_GRTC_CC_COUNT);
+            p_reg->FEATURE.GRTC.CC[index] =
+                ((p_reg->FEATURE.GRTC.CC[index] &
+                  ~SPU_FEATURE_GRTC_CC_OWNERID_Msk) |
+                 ((owner_id
+                   << SPU_FEATURE_GRTC_CC_OWNERID_Pos) &
+                  SPU_FEATURE_GRTC_CC_OWNERID_Msk));
+            break;
+
+        case NRF_SPU_FEATURE_GRTC_SYSCOUNTER:
+            p_reg->FEATURE.GRTC.SYSCOUNTER =
+                ((p_reg->FEATURE.GRTC.SYSCOUNTER &
+                  ~SPU_FEATURE_GRTC_SYSCOUNTER_OWNERID_Msk) |
+                 ((owner_id
+                   << SPU_FEATURE_GRTC_SYSCOUNTER_OWNERID_Pos) &
+                  SPU_FEATURE_GRTC_SYSCOUNTER_OWNERID_Msk));
+            break;
+
+        case NRF_SPU_FEATURE_GRTC_INTERRUPT:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_GRTC_INTERRUPT_COUNT);
+            p_reg->FEATURE.GRTC.INTERRUPT[index] =
+                ((p_reg->FEATURE.GRTC.INTERRUPT[index] &
+                  ~SPU_FEATURE_GRTC_INTERRUPT_OWNERID_Msk) |
+                 ((owner_id
+                   << SPU_FEATURE_GRTC_INTERRUPT_OWNERID_Pos) &
+                  SPU_FEATURE_GRTC_INTERRUPT_OWNERID_Msk));
+            break;
+
+#if NRF_SPU_HAS_DOMAIN
+        case NRF_SPU_FEATURE_BELLS_BELL:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_BELL_BELL_COUNT);
+            p_reg->FEATURE.BELLS.DOMAIN[index].BELL[subindex] =
+                ((p_reg->FEATURE.BELLS.DOMAIN[index].BELL[subindex] &
+                  ~SPU_FEATURE_BELLS_DOMAIN_BELL_OWNERID_Msk) |
+                 ((owner_id
+                   << SPU_FEATURE_BELLS_DOMAIN_BELL_OWNERID_Pos) &
+                  SPU_FEATURE_BELLS_DOMAIN_BELL_OWNERID_Msk));
+            break;
+#else
+        case NRF_SPU_FEATURE_BELLS_TASKS:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_BELLS_TASKS_COUNT);
+            p_reg->FEATURE.BELLS.PROCESSOR[index].TASKS[subindex] =
+                ((p_reg->FEATURE.BELLS.PROCESSOR[index].TASKS[subindex] &
+                  ~SPU_FEATURE_BELLS_PROCESSOR_TASKS_OWNERID_Msk) |
+                 ((owner_id
+                   << SPU_FEATURE_BELLS_PROCESSOR_TASKS_OWNERID_Pos) &
+                  SPU_FEATURE_BELLS_PROCESSOR_TASKS_OWNERID_Msk));
+            break;
+
+        case NRF_SPU_FEATURE_BELLS_EVENTS:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_BELLS_EVENTS_COUNT);
+            p_reg->FEATURE.BELLS.PROCESSOR[index].EVENTS[subindex] =
+                ((p_reg->FEATURE.BELLS.PROCESSOR[index].EVENTS[subindex] &
+                  ~SPU_FEATURE_BELLS_PROCESSOR_EVENTS_OWNERID_Msk) |
+                 ((owner_id
+                   << SPU_FEATURE_BELLS_PROCESSOR_EVENTS_OWNERID_Pos) &
+                  SPU_FEATURE_BELLS_PROCESSOR_EVENTS_OWNERID_Msk));
+            break;
+
+        case NRF_SPU_FEATURE_BELLS_INTERRUPT:
+            NRFX_ASSERT(index < NRF_SPU_FEATURE_BELLS_INTERRUPT_COUNT);
+            p_reg->FEATURE.BELLS.PROCESSOR[index].INTERRUPT[subindex] =
+                ((p_reg->FEATURE.BELLS.PROCESSOR[index].INTERRUPT[subindex] &
+                  ~SPU_FEATURE_BELLS_PROCESSOR_INTERRUPT_OWNERID_Msk) |
+                 ((owner_id
+                   << SPU_FEATURE_BELLS_PROCESSOR_INTERRUPT_OWNERID_Pos) &
+                  SPU_FEATURE_BELLS_PROCESSOR_INTERRUPT_OWNERID_Msk));
+            break;
+#endif
+
+        default:
+            NRFX_ASSERT(0);
+            break;
+    }
+}
+
+#endif
 
 #endif // NRF_DECLARE_ONLY
 

--- a/nrfx/hal/nrf_timer.h
+++ b/nrfx/hal/nrf_timer.h
@@ -98,11 +98,19 @@ extern "C" {
 #define NRF_TIMER_HAS_ONE_SHOT 0
 #endif
 
-/** @brief Base frequency value 16 MHz for timer. */
-#define NRF_TIMER_BASE_FREQUENCY_16MHZ (16000000UL)
+/** @brief Base frequency value 320 MHz for TIMER. */
+#define NRF_TIMER_BASE_FREQUENCY_320MHZ (NRFX_MHZ_TO_HZ(320UL))
+/** @brief Base frequency value 64 MHz for TIMER. */
+#define NRF_TIMER_BASE_FREQUENCY_64MHZ  (NRFX_MHZ_TO_HZ(64UL))
+/** @brief Base frequency value 32 MHz for TIMER. */
+#define NRF_TIMER_BASE_FREQUENCY_32MHZ  (NRFX_MHZ_TO_HZ(32UL))
+/** @brief Base frequency value 16 MHz for TIMER. */
+#define NRF_TIMER_BASE_FREQUENCY_16MHZ  (NRFX_MHZ_TO_HZ(16UL))
 
+#if !defined(NRF_TIMER_PRESCALER_MAX)
 /** @brief Maximum value of PRESCALER register. */
 #define NRF_TIMER_PRESCALER_MAX 9
+#endif
 
 /**
  * @brief Macro for getting the maximum bit resolution of the specified timer instance.
@@ -144,26 +152,48 @@ extern "C" {
  * @retval true  Timer instance supports the specified bit width resolution value.
  * @retval false Timer instance does not support the specified bit width resolution value.
  */
-#if (TIMER_COUNT == 3) || defined(__NRFX_DOXYGEN__)
-    #define NRF_TIMER_IS_BIT_WIDTH_VALID(p_reg, bit_width) (              \
-           ((p_reg == NRF_TIMER0) && TIMER_BIT_WIDTH_MAX(0, bit_width))   \
-        || ((p_reg == NRF_TIMER1) && TIMER_BIT_WIDTH_MAX(1, bit_width))   \
-        || ((p_reg == NRF_TIMER2) && TIMER_BIT_WIDTH_MAX(2, bit_width)))
-#elif (TIMER_COUNT == 4)
-    #define NRF_TIMER_IS_BIT_WIDTH_VALID(p_reg, bit_width) (              \
-           ((p_reg == NRF_TIMER0) && TIMER_BIT_WIDTH_MAX(0, bit_width))   \
-        || ((p_reg == NRF_TIMER1) && TIMER_BIT_WIDTH_MAX(1, bit_width))   \
-        || ((p_reg == NRF_TIMER2) && TIMER_BIT_WIDTH_MAX(2, bit_width))   \
-        || ((p_reg == NRF_TIMER3) && TIMER_BIT_WIDTH_MAX(3, bit_width)))
-#elif (TIMER_COUNT == 5)
-    #define NRF_TIMER_IS_BIT_WIDTH_VALID(p_reg, bit_width) (              \
-           ((p_reg == NRF_TIMER0) && TIMER_BIT_WIDTH_MAX(0, bit_width))   \
-        || ((p_reg == NRF_TIMER1) && TIMER_BIT_WIDTH_MAX(1, bit_width))   \
-        || ((p_reg == NRF_TIMER2) && TIMER_BIT_WIDTH_MAX(2, bit_width))   \
-        || ((p_reg == NRF_TIMER3) && TIMER_BIT_WIDTH_MAX(3, bit_width))   \
-        || ((p_reg == NRF_TIMER4) && TIMER_BIT_WIDTH_MAX(4, bit_width)))
-#else
-    #error "Not supported timer count"
+#if !defined(NRF_TIMER_IS_BIT_WIDTH_VALID)
+    #if (TIMER_COUNT == 3) || defined(__NRFX_DOXYGEN__)
+        #define NRF_TIMER_IS_BIT_WIDTH_VALID(p_reg, bit_width) (            \
+               ((p_reg == NRF_TIMER0) && TIMER_BIT_WIDTH_MAX(0, bit_width)) \
+            || ((p_reg == NRF_TIMER1) && TIMER_BIT_WIDTH_MAX(1, bit_width)) \
+            || ((p_reg == NRF_TIMER2) && TIMER_BIT_WIDTH_MAX(2, bit_width)))
+    #elif (TIMER_COUNT == 4)
+        #define NRF_TIMER_IS_BIT_WIDTH_VALID(p_reg, bit_width) (            \
+               ((p_reg == NRF_TIMER0) && TIMER_BIT_WIDTH_MAX(0, bit_width)) \
+            || ((p_reg == NRF_TIMER1) && TIMER_BIT_WIDTH_MAX(1, bit_width)) \
+            || ((p_reg == NRF_TIMER2) && TIMER_BIT_WIDTH_MAX(2, bit_width)) \
+            || ((p_reg == NRF_TIMER3) && TIMER_BIT_WIDTH_MAX(3, bit_width)))
+    #elif (TIMER_COUNT == 5)
+        #define NRF_TIMER_IS_BIT_WIDTH_VALID(p_reg, bit_width) (            \
+               ((p_reg == NRF_TIMER0) && TIMER_BIT_WIDTH_MAX(0, bit_width)) \
+            || ((p_reg == NRF_TIMER1) && TIMER_BIT_WIDTH_MAX(1, bit_width)) \
+            || ((p_reg == NRF_TIMER2) && TIMER_BIT_WIDTH_MAX(2, bit_width)) \
+            || ((p_reg == NRF_TIMER3) && TIMER_BIT_WIDTH_MAX(3, bit_width)) \
+            || ((p_reg == NRF_TIMER4) && TIMER_BIT_WIDTH_MAX(4, bit_width)))
+    #else
+        #error "Not supported timer count"
+    #endif
+#endif
+
+#if !defined(NRF_TIMER_IS_320MHZ_TIMER)
+/** @brief Macro for checking whether the base frequency for the specified timer is 320 MHz. */
+#define NRF_TIMER_IS_320MHZ_TIMER(p_reg) false
+#endif
+
+#if !defined(NRF_TIMER_IS_64MHZ_TIMER)
+/** @brief Macro for checking whether the base frequency for the specified timer is 64 MHz. */
+#define NRF_TIMER_IS_64MHZ_TIMER(p_reg) false
+#endif
+
+#if !defined(NRF_TIMER_IS_32MHZ_TIMER)
+/** @brief Macro for checking whether the base frequency for the specified timer is 32 MHz. */
+#define NRF_TIMER_IS_32MHZ_TIMER(p_reg) false
+#endif
+
+#if !defined(NRF_TIMER_IS_16MHZ_TIMER)
+/** @brief Macro for checking whether the base frequency for the specified timer is 16 MHz. */
+#define NRF_TIMER_IS_16MHZ_TIMER(p_reg) true
 #endif
 
 /**
@@ -171,7 +201,11 @@ extern "C" {
  *
  * @param[in] p_reg Pointer to the structure of registers of the peripheral.
  */
-#define NRF_TIMER_BASE_FREQUENCY_GET(p_reg) NRF_TIMER_BASE_FREQUENCY_16MHZ
+#define NRF_TIMER_BASE_FREQUENCY_GET(p_reg)                                  \
+    ((NRF_TIMER_IS_320MHZ_TIMER(p_reg)) ? (NRF_TIMER_BASE_FREQUENCY_320MHZ): \
+    ((NRF_TIMER_IS_64MHZ_TIMER(p_reg))  ? (NRF_TIMER_BASE_FREQUENCY_64MHZ): \
+    ((NRF_TIMER_IS_16MHZ_TIMER(p_reg))  ? (NRF_TIMER_BASE_FREQUENCY_16MHZ) : \
+    (NRF_TIMER_BASE_FREQUENCY_32MHZ))))
 
 /**
  * @brief Macro for computing prescaler value for given base frequency and desired frequency.
@@ -185,12 +219,28 @@ extern "C" {
         NRF_CTZ((uint32_t)(base_freq) / (uint32_t)(frequency))
 
 /**
+ * @brief Macro for checking whether specified frequency can be achived for given timer instance.
+ *
+ * @note Macro is using compile time assertion.
+ *
+ * @param[in] p_reg     Pointer to the structure of registers of the peripheral.
+ * @param[in] frequency Desired frequency value in Hz.
+ */
+#define NRF_TIMER_FREQUENCY_STATIC_CHECK(p_reg, frequency)                                       \
+    NRFX_STATIC_ASSERT(                                                                          \
+        (NRF_TIMER_BASE_FREQUENCY_GET(p_reg) == frequency) ||                                    \
+        ((NRF_TIMER_BASE_FREQUENCY_GET(p_reg) % frequency == 0) &&                               \
+         NRFX_IS_POWER_OF_TWO(NRF_TIMER_BASE_FREQUENCY_GET(p_reg) / (uint32_t)frequency) &&      \
+         ((NRF_TIMER_BASE_FREQUENCY_GET(p_reg) / frequency) <= (1 << NRF_TIMER_PRESCALER_MAX))), \
+        "Specified frequency can not be achived with given TIMER instance.")
+
+/**
  * @brief Macro for getting the number of capture/compare channels available
  *        in a given timer instance.
  *
  * @param[in] id Index of the specified timer instance.
  */
-#define NRF_TIMER_CC_CHANNEL_COUNT(id)  NRFX_CONCAT_3(TIMER, id, _CC_NUM)
+#define NRF_TIMER_CC_CHANNEL_COUNT(id) NRFX_CONCAT_3(TIMER, id, _CC_NUM)
 
 /** @brief Symbol specifying maximum number of available compare channels. */
 #define NRF_TIMER_CC_COUNT_MAX NRFX_ARRAY_SIZE(((NRF_TIMER_Type*)0)->EVENTS_COMPARE)
@@ -587,28 +637,6 @@ NRF_STATIC_INLINE void nrf_timer_bit_width_set(NRF_TIMER_Type *      p_reg,
 NRF_STATIC_INLINE nrf_timer_bit_width_t nrf_timer_bit_width_get(NRF_TIMER_Type const * p_reg);
 
 /**
- * @brief Function for setting the timer frequency.
- *
- * @note This function is deprecated. Use @ref nrf_timer_prescaler_set instead.
- *
- * @param[in] p_reg     Pointer to the structure of registers of the peripheral.
- * @param[in] frequency Timer frequency.
- */
-NRF_STATIC_INLINE void nrf_timer_frequency_set(NRF_TIMER_Type *      p_reg,
-                                               nrf_timer_frequency_t frequency);
-
-/**
- * @brief Function for retrieving the timer frequency.
- *
- * @note This function is deprecated. Use @ref nrf_timer_prescaler_get instead.
- *
- * @param[in] p_reg Pointer to the structure of registers of the peripheral.
- *
- * @return Timer frequency.
- */
-NRF_STATIC_INLINE nrf_timer_frequency_t nrf_timer_frequency_get(NRF_TIMER_Type const * p_reg);
-
-/**
  * @brief Function for setting the capture/compare register for the specified channel.
  *
  * @param[in] p_reg      Pointer to the structure of registers of the peripheral.
@@ -637,7 +665,7 @@ NRF_STATIC_INLINE uint32_t nrf_timer_cc_get(NRF_TIMER_Type const * p_reg,
  *
  * @return Capture task.
  */
-NRF_STATIC_INLINE nrf_timer_task_t nrf_timer_capture_task_get(uint32_t channel);
+NRF_STATIC_INLINE nrf_timer_task_t nrf_timer_capture_task_get(uint8_t channel);
 
 /**
  * @brief Function for getting the specified timer compare event.
@@ -646,7 +674,7 @@ NRF_STATIC_INLINE nrf_timer_task_t nrf_timer_capture_task_get(uint32_t channel);
  *
  * @return Compare event.
  */
-NRF_STATIC_INLINE nrf_timer_event_t nrf_timer_compare_event_get(uint32_t channel);
+NRF_STATIC_INLINE nrf_timer_event_t nrf_timer_compare_event_get(uint8_t channel);
 
 /**
  * @brief Function for getting the specified timer compare interrupt.
@@ -655,7 +683,7 @@ NRF_STATIC_INLINE nrf_timer_event_t nrf_timer_compare_event_get(uint32_t channel
  *
  * @return Compare interrupt.
  */
-NRF_STATIC_INLINE nrf_timer_int_mask_t nrf_timer_compare_int_get(uint32_t channel);
+NRF_STATIC_INLINE nrf_timer_int_mask_t nrf_timer_compare_int_get(uint8_t channel);
 
 /**
  * @brief Function for calculating the number of timer ticks for a given time
@@ -786,7 +814,7 @@ NRF_STATIC_INLINE void nrf_timer_subscribe_set(NRF_TIMER_Type * p_reg,
                                                uint8_t          channel)
 {
     *((volatile uint32_t *) ((uint8_t *) p_reg + (uint32_t) task + 0x80uL)) =
-            ((uint32_t)channel | TIMER_SUBSCRIBE_START_EN_Msk);
+            ((uint32_t)channel | NRF_SUBSCRIBE_PUBLISH_ENABLE);
 }
 
 NRF_STATIC_INLINE void nrf_timer_subscribe_clear(NRF_TIMER_Type * p_reg,
@@ -800,7 +828,7 @@ NRF_STATIC_INLINE void nrf_timer_publish_set(NRF_TIMER_Type *  p_reg,
                                              uint8_t           channel)
 {
     *((volatile uint32_t *) ((uint8_t *) p_reg + (uint32_t) event + 0x80uL)) =
-            ((uint32_t)channel | TIMER_PUBLISH_COMPARE_EN_Msk);
+            ((uint32_t)channel | NRF_SUBSCRIBE_PUBLISH_ENABLE);
 }
 
 NRF_STATIC_INLINE void nrf_timer_publish_clear(NRF_TIMER_Type *  p_reg,
@@ -835,19 +863,6 @@ NRF_STATIC_INLINE nrf_timer_bit_width_t nrf_timer_bit_width_get(NRF_TIMER_Type c
     return (nrf_timer_bit_width_t)(p_reg->BITMODE);
 }
 
-NRF_STATIC_INLINE void nrf_timer_frequency_set(NRF_TIMER_Type *      p_reg,
-                                               nrf_timer_frequency_t frequency)
-{
-    p_reg->PRESCALER = (p_reg->PRESCALER & ~TIMER_PRESCALER_PRESCALER_Msk) |
-                         ((frequency << TIMER_PRESCALER_PRESCALER_Pos) &
-                              TIMER_PRESCALER_PRESCALER_Msk);
-}
-
-NRF_STATIC_INLINE nrf_timer_frequency_t nrf_timer_frequency_get(NRF_TIMER_Type const * p_reg)
-{
-    return (nrf_timer_frequency_t)(p_reg->PRESCALER);
-}
-
 NRF_STATIC_INLINE void nrf_timer_prescaler_set(NRF_TIMER_Type * p_reg, uint32_t prescaler_factor)
 {
     NRFX_ASSERT(prescaler_factor <= NRF_TIMER_PRESCALER_MAX);
@@ -872,17 +887,17 @@ NRF_STATIC_INLINE uint32_t nrf_timer_cc_get(NRF_TIMER_Type const * p_reg,
     return (uint32_t)p_reg->CC[cc_channel];
 }
 
-NRF_STATIC_INLINE nrf_timer_task_t nrf_timer_capture_task_get(uint32_t channel)
+NRF_STATIC_INLINE nrf_timer_task_t nrf_timer_capture_task_get(uint8_t channel)
 {
     return (nrf_timer_task_t)NRFX_OFFSETOF(NRF_TIMER_Type, TASKS_CAPTURE[channel]);
 }
 
-NRF_STATIC_INLINE nrf_timer_event_t nrf_timer_compare_event_get(uint32_t channel)
+NRF_STATIC_INLINE nrf_timer_event_t nrf_timer_compare_event_get(uint8_t channel)
 {
     return (nrf_timer_event_t)NRFX_OFFSETOF(NRF_TIMER_Type, EVENTS_COMPARE[channel]);
 }
 
-NRF_STATIC_INLINE nrf_timer_int_mask_t nrf_timer_compare_int_get(uint32_t channel)
+NRF_STATIC_INLINE nrf_timer_int_mask_t nrf_timer_compare_int_get(uint8_t channel)
 {
     return (nrf_timer_int_mask_t)
         ((uint32_t)NRF_TIMER_INT_COMPARE0_MASK << channel);

--- a/nrfx/hal/nrf_twim.h
+++ b/nrfx/hal/nrf_twim.h
@@ -63,60 +63,160 @@ extern "C" {
 #define NRF_TWIM_HAS_1000_KHZ_FREQ 0
 #endif
 
+#if defined(TWIM_TXD_LIST_LIST_ArrayList) || defined(__NRFX_DOXYGEN__)
+/** @brief Symbol indicating whether EasyDMA array list feature is present. */
+#define NRF_TWIM_HAS_ARRAY_LIST 1
+#else
+#define NRF_TWIM_HAS_ARRAY_LIST 0
+#endif
+
+#if defined(TWIM_DMA_RX_PTR_PTR_Msk) || defined(__NRFX_DOXYGEN__)
+/** @brief Symbol indicating whether dedicated DMA register is present. */
+#define NRF_TWIM_HAS_DMA_REG 1
+#else
+#define NRF_TWIM_HAS_DMA_REG 0
+#endif
+
+#if (defined(TWIM_TASKS_DMA_RX_START_START_Msk) && defined(TWIM_EVENTS_DMA_RX_END_END_Msk)) || \
+    defined(__NRFX_DOXYGEN__)
+/** @brief Symbol indicating whether TWIM DMA tasks and events are present. */
+#define NRF_TWIM_HAS_DMA_TASKS_EVENTS 1
+#else
+#define NRF_TWIM_HAS_DMA_TASKS_EVENTS 0
+#endif
+
+#if NRF_TWIM_HAS_DMA_REG
+/** @brief Max number of RX patterns. */
+#define NRF_TWIM_DMA_RX_PATTERN_MAX_COUNT TWIM_DMA_RX_MATCH_CANDIDATE_MaxCount
+#endif
+
 /** @brief TWIM tasks. */
 typedef enum
 {
-    NRF_TWIM_TASK_STARTRX = offsetof(NRF_TWIM_Type, TASKS_STARTRX), ///< Start TWI receive sequence.
-    NRF_TWIM_TASK_STARTTX = offsetof(NRF_TWIM_Type, TASKS_STARTTX), ///< Start TWI transmit sequence.
-    NRF_TWIM_TASK_STOP    = offsetof(NRF_TWIM_Type, TASKS_STOP),    ///< Stop TWI transaction.
-    NRF_TWIM_TASK_SUSPEND = offsetof(NRF_TWIM_Type, TASKS_SUSPEND), ///< Suspend TWI transaction.
-    NRF_TWIM_TASK_RESUME  = offsetof(NRF_TWIM_Type, TASKS_RESUME)   ///< Resume TWI transaction.
+#if NRF_TWIM_HAS_DMA_TASKS_EVENTS
+    NRF_TWIM_TASK_STARTRX         = offsetof(NRF_TWIM_Type, TASKS_DMA.RX.START),           ///< Start TWI receive sequence.
+    NRF_TWIM_TASK_STARTTX         = offsetof(NRF_TWIM_Type, TASKS_DMA.TX.START),           ///< Start TWI transmit sequence.
+    NRF_TWIM_TASK_ENABLERXMATCH0  = offsetof(NRF_TWIM_Type, TASKS_DMA.RX.ENABLEMATCH[0]),  ///< Enable TWI pattern matching functionality for pattern 0.
+    NRF_TWIM_TASK_ENABLERXMATCH1  = offsetof(NRF_TWIM_Type, TASKS_DMA.RX.ENABLEMATCH[1]),  ///< Enable TWI pattern matching functionality for pattern 1.
+    NRF_TWIM_TASK_ENABLERXMATCH2  = offsetof(NRF_TWIM_Type, TASKS_DMA.RX.ENABLEMATCH[2]),  ///< Enable TWI pattern matching functionality for pattern 2.
+    NRF_TWIM_TASK_ENABLERXMATCH3  = offsetof(NRF_TWIM_Type, TASKS_DMA.RX.ENABLEMATCH[3]),  ///< Enable TWI pattern matching functionality for pattern 3.
+    NRF_TWIM_TASK_DISABLERXMATCH0 = offsetof(NRF_TWIM_Type, TASKS_DMA.RX.DISABLEMATCH[0]), ///< Disable TWI pattern matching functionality for pattern 0.
+    NRF_TWIM_TASK_DISABLERXMATCH1 = offsetof(NRF_TWIM_Type, TASKS_DMA.RX.DISABLEMATCH[1]), ///< Disable TWI pattern matching functionality for pattern 1.
+    NRF_TWIM_TASK_DISABLERXMATCH2 = offsetof(NRF_TWIM_Type, TASKS_DMA.RX.DISABLEMATCH[2]), ///< Disable TWI pattern matching functionality for pattern 2.
+    NRF_TWIM_TASK_DISABLERXMATCH3 = offsetof(NRF_TWIM_Type, TASKS_DMA.RX.DISABLEMATCH[3]), ///< Disable TWI pattern matching functionality for pattern 3.
+#else
+    NRF_TWIM_TASK_STARTRX         = offsetof(NRF_TWIM_Type, TASKS_STARTRX),                ///< Start TWI receive sequence.
+    NRF_TWIM_TASK_STARTTX         = offsetof(NRF_TWIM_Type, TASKS_STARTTX),                ///< Start TWI transmit sequence.
+#endif
+    NRF_TWIM_TASK_STOP            = offsetof(NRF_TWIM_Type, TASKS_STOP),                   ///< Stop TWI transaction.
+    NRF_TWIM_TASK_SUSPEND         = offsetof(NRF_TWIM_Type, TASKS_SUSPEND),                ///< Suspend TWI transaction.
+    NRF_TWIM_TASK_RESUME          = offsetof(NRF_TWIM_Type, TASKS_RESUME)                  ///< Resume TWI transaction.
 } nrf_twim_task_t;
 
 /** @brief TWIM events. */
 typedef enum
 {
-    NRF_TWIM_EVENT_STOPPED   = offsetof(NRF_TWIM_Type, EVENTS_STOPPED),   ///< TWI stopped.
-    NRF_TWIM_EVENT_ERROR     = offsetof(NRF_TWIM_Type, EVENTS_ERROR),     ///< TWI error.
-    NRF_TWIM_EVENT_SUSPENDED = offsetof(NRF_TWIM_Type, EVENTS_SUSPENDED), ///< TWI suspended.
-    NRF_TWIM_EVENT_RXSTARTED = offsetof(NRF_TWIM_Type, EVENTS_RXSTARTED), ///< Receive sequence started.
-    NRF_TWIM_EVENT_TXSTARTED = offsetof(NRF_TWIM_Type, EVENTS_TXSTARTED), ///< Transmit sequence started.
-    NRF_TWIM_EVENT_LASTRX    = offsetof(NRF_TWIM_Type, EVENTS_LASTRX),    ///< Byte boundary, starting to receive the last byte.
-    NRF_TWIM_EVENT_LASTTX    = offsetof(NRF_TWIM_Type, EVENTS_LASTTX)     ///< Byte boundary, starting to transmit the last byte.
+    NRF_TWIM_EVENT_STOPPED    = offsetof(NRF_TWIM_Type, EVENTS_STOPPED),         ///< TWI stopped.
+    NRF_TWIM_EVENT_ERROR      = offsetof(NRF_TWIM_Type, EVENTS_ERROR),           ///< TWI error.
+    NRF_TWIM_EVENT_SUSPENDED  = offsetof(NRF_TWIM_Type, EVENTS_SUSPENDED),       ///< TWI suspended.
+#if NRF_TWIM_HAS_DMA_TASKS_EVENTS
+    NRF_TWIM_EVENT_ENDRX      = offsetof(NRF_TWIM_Type, EVENTS_DMA.RX.END),      ///< Receive sequence finished.
+    NRF_TWIM_EVENT_RXSTARTED  = offsetof(NRF_TWIM_Type, EVENTS_DMA.RX.READY),    ///< Receive sequence started.
+    NRF_TWIM_EVENT_RXBUSERROR = offsetof(NRF_TWIM_Type, EVENTS_DMA.RX.BUSERROR), ///< Memory bus error occurred during the RX transfer.
+    NRF_TWIM_EVENT_RXMATCH0   = offsetof(NRF_TWIM_Type, EVENTS_DMA.RX.MATCH[0]), ///< Pattern match for pattern 0 detected.
+    NRF_TWIM_EVENT_RXMATCH1   = offsetof(NRF_TWIM_Type, EVENTS_DMA.RX.MATCH[1]), ///< Pattern match for pattern 1 detected.
+    NRF_TWIM_EVENT_RXMATCH2   = offsetof(NRF_TWIM_Type, EVENTS_DMA.RX.MATCH[2]), ///< Pattern match for pattern 2 detected.
+    NRF_TWIM_EVENT_RXMATCH3   = offsetof(NRF_TWIM_Type, EVENTS_DMA.RX.MATCH[3]), ///< Pattern match for pattern 3 detected.
+    NRF_TWIM_EVENT_ENDTX      = offsetof(NRF_TWIM_Type, EVENTS_DMA.TX.END),      ///< Transmit sequence finished.
+    NRF_TWIM_EVENT_TXSTARTED  = offsetof(NRF_TWIM_Type, EVENTS_DMA.TX.READY),    ///< Transmit sequence started.
+    NRF_TWIM_EVENT_TXBUSERROR = offsetof(NRF_TWIM_Type, EVENTS_DMA.TX.BUSERROR), ///< Memory bus error occurred during the TX transfer.
+#else
+    NRF_TWIM_EVENT_RXSTARTED  = offsetof(NRF_TWIM_Type, EVENTS_RXSTARTED),       ///< Receive sequence started.
+    NRF_TWIM_EVENT_TXSTARTED  = offsetof(NRF_TWIM_Type, EVENTS_TXSTARTED),       ///< Transmit sequence started.
+#endif
+    NRF_TWIM_EVENT_LASTRX     = offsetof(NRF_TWIM_Type, EVENTS_LASTRX),          ///< Byte boundary, starting to receive the last byte.
+    NRF_TWIM_EVENT_LASTTX     = offsetof(NRF_TWIM_Type, EVENTS_LASTTX)           ///< Byte boundary, starting to transmit the last byte.
 } nrf_twim_event_t;
 
 /** @brief TWIM shortcuts. */
 typedef enum
 {
-    NRF_TWIM_SHORT_LASTTX_STARTRX_MASK = TWIM_SHORTS_LASTTX_STARTRX_Msk,  ///< Shortcut between LASTTX event and STARTRX task.
-    NRF_TWIM_SHORT_LASTTX_SUSPEND_MASK = TWIM_SHORTS_LASTTX_SUSPEND_Msk,  ///< Shortcut between LASTTX event and SUSPEND task.
-    NRF_TWIM_SHORT_LASTTX_STOP_MASK    = TWIM_SHORTS_LASTTX_STOP_Msk,     ///< Shortcut between LASTTX event and STOP task.
-    NRF_TWIM_SHORT_LASTRX_STARTTX_MASK = TWIM_SHORTS_LASTRX_STARTTX_Msk,  ///< Shortcut between LASTRX event and STARTTX task.
-    NRF_TWIM_SHORT_LASTRX_STOP_MASK    = TWIM_SHORTS_LASTRX_STOP_Msk,     ///< Shortcut between LASTRX event and STOP task.
-    NRF_TWIM_ALL_SHORTS_MASK           = TWIM_SHORTS_LASTTX_STARTRX_Msk |
-                                         TWIM_SHORTS_LASTTX_SUSPEND_Msk |
-                                         TWIM_SHORTS_LASTTX_STOP_Msk    |
-                                         TWIM_SHORTS_LASTRX_STARTTX_Msk |
-                                         TWIM_SHORTS_LASTRX_STOP_Msk      ///< All TWIM shortcuts.
+    NRF_TWIM_SHORT_LASTTX_STARTRX_MASK           = TWIM_SHORTS_LASTTX_STARTRX_Msk,                     ///< Shortcut between LASTTX event and STARTRX task.
+    NRF_TWIM_SHORT_LASTTX_SUSPEND_MASK           = TWIM_SHORTS_LASTTX_SUSPEND_Msk,                     ///< Shortcut between LASTTX event and SUSPEND task.
+    NRF_TWIM_SHORT_LASTTX_STOP_MASK              = TWIM_SHORTS_LASTTX_STOP_Msk,                        ///< Shortcut between LASTTX event and STOP task.
+#if NRF_TWIM_HAS_DMA_TASKS_EVENTS
+    NRF_TWIM_SHORT_RXMATCH0_ENABLERXMATCH1_MASK  = TWIM_SHORTS_DMA_RX_MATCH0_DMA_RX_ENABLEMATCH1_Msk,  ///< Shortcut between DMA.RX.MATCH0 event and DMA.RX.ENABLEMATCH1 task.
+    NRF_TWIM_SHORT_RXMATCH1_ENABLERXMATCH2_MASK  = TWIM_SHORTS_DMA_RX_MATCH1_DMA_RX_ENABLEMATCH2_Msk,  ///< Shortcut between DMA.RX.MATCH1 event and DMA.RX.ENABLEMATCH2 task.
+    NRF_TWIM_SHORT_RXMATCH2_ENABLERXMATCH0_MASK  = TWIM_SHORTS_DMA_RX_MATCH2_DMA_RX_ENABLEMATCH0_Msk,  ///< Shortcut between DMA.RX.MATCH2 event and DMA.RX.ENABLEMATCH0 task.
+    NRF_TWIM_SHORT_RXMATCH3_ENABLERXMATCH1_MASK  = TWIM_SHORTS_DMA_RX_MATCH3_DMA_RX_ENABLEMATCH1_Msk,  ///< Shortcut between DMA.RX.MATCH3 event and DMA.RX.ENABLEMATCH1 task.
+    NRF_TWIM_SHORT_RXMATCH0_DISABLERXMATCH0_MASK = TWIM_SHORTS_DMA_RX_MATCH0_DMA_RX_DISABLEMATCH0_Msk, ///< Shortcut between DMA.RX.MATCH0 event and DMA.RX.DISABLEMATCH0 task.
+    NRF_TWIM_SHORT_RXMATCH1_DISABLERXMATCH1_MASK = TWIM_SHORTS_DMA_RX_MATCH1_DMA_RX_DISABLEMATCH1_Msk, ///< Shortcut between DMA.RX.MATCH1 event and DMA.RX.DISABLEMATCH1 task.
+    NRF_TWIM_SHORT_RXMATCH2_DISABLERXMATCH2_MASK = TWIM_SHORTS_DMA_RX_MATCH2_DMA_RX_DISABLEMATCH2_Msk, ///< Shortcut between DMA.RX.MATCH2 event and DMA.RX.DISABLEMATCH2 task.
+    NRF_TWIM_SHORT_RXMATCH3_DISABLERXMATCH3_MASK = TWIM_SHORTS_DMA_RX_MATCH3_DMA_RX_DISABLEMATCH3_Msk, ///< Shortcut between DMA.RX.MATCH3 event and DMA.RX.DISABLEMATCH3 task.
+#endif
+    NRF_TWIM_SHORT_LASTRX_STARTTX_MASK           = TWIM_SHORTS_LASTRX_STARTTX_Msk,                     ///< Shortcut between LASTRX event and STARTTX task.
+    NRF_TWIM_SHORT_LASTRX_STOP_MASK              = TWIM_SHORTS_LASTRX_STOP_Msk,                        ///< Shortcut between LASTRX event and STOP task.
+    NRF_TWIM_ALL_SHORTS_MASK                     = TWIM_SHORTS_LASTTX_STARTRX_Msk                     |
+                                                   TWIM_SHORTS_LASTTX_SUSPEND_Msk                     |
+                                                   TWIM_SHORTS_LASTTX_STOP_Msk                        |
+#if NRF_TWIM_HAS_DMA_TASKS_EVENTS
+                                                   TWIM_SHORTS_DMA_RX_MATCH0_DMA_RX_ENABLEMATCH1_Msk  |
+                                                   TWIM_SHORTS_DMA_RX_MATCH1_DMA_RX_ENABLEMATCH2_Msk  |
+                                                   TWIM_SHORTS_DMA_RX_MATCH2_DMA_RX_ENABLEMATCH0_Msk  |
+                                                   TWIM_SHORTS_DMA_RX_MATCH3_DMA_RX_ENABLEMATCH1_Msk  |
+                                                   TWIM_SHORTS_DMA_RX_MATCH0_DMA_RX_DISABLEMATCH0_Msk |
+                                                   TWIM_SHORTS_DMA_RX_MATCH1_DMA_RX_DISABLEMATCH1_Msk |
+                                                   TWIM_SHORTS_DMA_RX_MATCH2_DMA_RX_DISABLEMATCH2_Msk |
+                                                   TWIM_SHORTS_DMA_RX_MATCH3_DMA_RX_DISABLEMATCH3_Msk |
+#endif
+                                                   TWIM_SHORTS_LASTRX_STARTTX_Msk                     |
+                                                   TWIM_SHORTS_LASTRX_STOP_Msk                         ///< All TWIM shortcuts.
 } nrf_twim_short_mask_t;
 
 /** @brief TWIM interrupts. */
 typedef enum
 {
-    NRF_TWIM_INT_STOPPED_MASK   = TWIM_INTENSET_STOPPED_Msk,   ///< Interrupt on STOPPED event.
-    NRF_TWIM_INT_ERROR_MASK     = TWIM_INTENSET_ERROR_Msk,     ///< Interrupt on ERROR event.
-    NRF_TWIM_INT_SUSPENDED_MASK = TWIM_INTENSET_SUSPENDED_Msk, ///< Interrupt on SUSPENDED event.
-    NRF_TWIM_INT_RXSTARTED_MASK = TWIM_INTENSET_RXSTARTED_Msk, ///< Interrupt on RXSTARTED event.
-    NRF_TWIM_INT_TXSTARTED_MASK = TWIM_INTENSET_TXSTARTED_Msk, ///< Interrupt on TXSTARTED event.
-    NRF_TWIM_INT_LASTRX_MASK    = TWIM_INTENSET_LASTRX_Msk,    ///< Interrupt on LASTRX event.
-    NRF_TWIM_INT_LASTTX_MASK    = TWIM_INTENSET_LASTTX_Msk,    ///< Interrupt on LASTTX event.
-    NRF_TWIM_ALL_INTS_MASK      = TWIM_INTENSET_STOPPED_Msk   |
-                                  TWIM_INTENSET_ERROR_Msk     |
-                                  TWIM_INTENSET_SUSPENDED_Msk |
-                                  TWIM_INTENSET_RXSTARTED_Msk |
-                                  TWIM_INTENSET_TXSTARTED_Msk |
-                                  TWIM_INTENSET_LASTRX_Msk    |
-                                  TWIM_INTENSET_LASTTX_Msk     ///< All TWIM interrupts.
+    NRF_TWIM_INT_STOPPED_MASK    = TWIM_INTENSET_STOPPED_Msk,       ///< Interrupt on STOPPED event.
+    NRF_TWIM_INT_ERROR_MASK      = TWIM_INTENSET_ERROR_Msk,         ///< Interrupt on ERROR event.
+    NRF_TWIM_INT_SUSPENDED_MASK  = TWIM_INTENSET_SUSPENDED_Msk,     ///< Interrupt on SUSPENDED event.
+#if NRF_TWIM_HAS_DMA_TASKS_EVENTS
+    NRF_TWIM_INT_RXSTARTED_MASK  = TWIM_INTENSET_DMARXREADY_Msk,    ///< Interrupt on RXSTARTED event.
+    NRF_TWIM_INT_TXSTARTED_MASK  = TWIM_INTENSET_DMATXREADY_Msk,    ///< Interrupt on TXSTARTED event.
+    NRF_TWIM_INT_ENDRX_MASK      = TWIM_INTENSET_DMARXEND_Msk,      ///< Interrupt on DMA.RX.END event.
+    NRF_TWIM_INT_RXREADY_MASK    = TWIM_INTENSET_DMARXREADY_Msk,    ///< Interrupt on DMA.RX.READY event.
+    NRF_TWIM_INT_RXBUSERROR_MASK = TWIM_INTENSET_DMARXBUSERROR_Msk, ///< Interrupt on DMA.RX.BUSERROR event.
+    NRF_TWIM_INT_RXMATCH0_MASK   = TWIM_INTENSET_DMARXMATCH0_Msk,   ///< Interrupt on DMA.RX.MATCH0 event.
+    NRF_TWIM_INT_RXMATCH1_MASK   = TWIM_INTENSET_DMARXMATCH1_Msk,   ///< Interrupt on DMA.RX.MATCH1 event.
+    NRF_TWIM_INT_RXMATCH2_MASK   = TWIM_INTENSET_DMARXMATCH2_Msk,   ///< Interrupt on DMA.RX.MATCH2 event.
+    NRF_TWIM_INT_RXMATCH3_MASK   = TWIM_INTENSET_DMARXMATCH3_Msk,   ///< Interrupt on DMA.RX.MATCH3 event.
+    NRF_TWIM_INT_ENDTX_MASK      = TWIM_INTENSET_DMATXEND_Msk,      ///< Interrupt on DMA.TX.END event.
+    NRF_TWIM_INT_TXREADY_MASK    = TWIM_INTENSET_DMATXREADY_Msk,    ///< Interrupt on DMA.TX.READY event.
+    NRF_TWIM_INT_TXBUSERROR_MASK = TWIM_INTENSET_DMATXBUSERROR_Msk, ///< Interrupt on DMA.TX.BUSERROR event.
+#else
+    NRF_TWIM_INT_RXSTARTED_MASK  = TWIM_INTENSET_RXSTARTED_Msk,     ///< Interrupt on RXSTARTED event.
+    NRF_TWIM_INT_TXSTARTED_MASK  = TWIM_INTENSET_TXSTARTED_Msk,     ///< Interrupt on TXSTARTED event.
+#endif
+    NRF_TWIM_INT_LASTRX_MASK     = TWIM_INTENSET_LASTRX_Msk,        ///< Interrupt on LASTRX event.
+    NRF_TWIM_INT_LASTTX_MASK     = TWIM_INTENSET_LASTTX_Msk,        ///< Interrupt on LASTTX event.
+    NRF_TWIM_ALL_INTS_MASK       = NRF_TWIM_INT_STOPPED_MASK    |
+                                   NRF_TWIM_INT_ERROR_MASK      |
+                                   NRF_TWIM_INT_SUSPENDED_MASK  |
+                                   NRF_TWIM_INT_RXSTARTED_MASK  |
+                                   NRF_TWIM_INT_TXSTARTED_MASK  |
+#if NRF_TWIM_HAS_DMA_TASKS_EVENTS
+                                   NRF_TWIM_INT_ENDRX_MASK      |
+                                   NRF_TWIM_INT_RXREADY_MASK    |
+                                   NRF_TWIM_INT_RXBUSERROR_MASK |
+                                   NRF_TWIM_INT_RXMATCH0_MASK   |
+                                   NRF_TWIM_INT_RXMATCH1_MASK   |
+                                   NRF_TWIM_INT_RXMATCH2_MASK   |
+                                   NRF_TWIM_INT_RXMATCH3_MASK   |
+                                   NRF_TWIM_INT_ENDTX_MASK      |
+                                   NRF_TWIM_INT_TXREADY_MASK    |
+                                   NRF_TWIM_INT_TXBUSERROR_MASK |
+#endif
+                                   NRF_TWIM_INT_LASTRX_MASK     |
+                                   NRF_TWIM_INT_LASTTX_MASK         ///< All TWIM interrupts.
 } nrf_twim_int_mask_t;
 
 /** @brief TWIM master clock frequency. */
@@ -358,6 +458,15 @@ NRF_STATIC_INLINE void nrf_twim_address_set(NRF_TWIM_Type * p_reg,
                                             uint8_t         address);
 
 /**
+ * @brief Function for getting the address to be used in TWI transfers.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ *
+ * @return Address to be used in TWI transfers.
+ */
+NRF_STATIC_INLINE uint8_t nrf_twim_address_get(NRF_TWIM_Type const * p_reg);
+
+/**
  * @brief Function for setting the transmit buffer.
  *
  * @param[in] p_reg    Pointer to the structure of registers of the peripheral.
@@ -415,6 +524,7 @@ NRF_STATIC_INLINE size_t nrf_twim_txd_amount_get(NRF_TWIM_Type const * p_reg);
  */
 NRF_STATIC_INLINE size_t nrf_twim_rxd_amount_get(NRF_TWIM_Type const * p_reg);
 
+#if NRF_TWIM_HAS_ARRAY_LIST
 /**
  * @brief Function for enabling the TX list feature.
  *
@@ -442,7 +552,85 @@ NRF_STATIC_INLINE void nrf_twim_rx_list_enable(NRF_TWIM_Type * p_reg);
  * @param[in] p_reg Pointer to the structure of registers of the peripheral.
  */
 NRF_STATIC_INLINE void nrf_twim_rx_list_disable(NRF_TWIM_Type * p_reg);
+#endif
 
+#if NRF_TWIM_HAS_DMA_REG
+/**
+ * @brief Function for enabling individual pattern match filters.
+ *
+ * @param[in] p_reg  Pointer to the structure of registers of the peripheral.
+ * @param[in] index  Index of pattern match filter.
+ * @param[in] enable True if pattern match filter is to be enabled, false otherwise.
+ */
+NRF_STATIC_INLINE void nrf_twim_rx_pattern_match_enable_set(NRF_TWIM_Type * p_reg,
+                                                            uint8_t         index,
+                                                            bool            enable);
+
+/**
+ * @brief Function for checking if the specified pattern match filter is enabled.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ * @param[in] index Index of pattern match filter.
+ *
+ * @retval true  Pattern match filter is enabled.
+ * @retval false Pattern match filter is disabled.
+ */
+NRF_STATIC_INLINE bool nrf_twim_rx_pattern_match_enable_check(NRF_TWIM_Type const * p_reg,
+                                                              uint8_t               index);
+
+/**
+ * @brief Function for enabling one-shot operation for the specified match filter.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ * @param[in] index Index of pattern match filter.
+ */
+NRF_STATIC_INLINE void nrf_twim_rx_pattern_match_one_shot_enable(NRF_TWIM_Type * p_reg,
+                                                                 uint8_t         index);
+
+/**
+ * @brief Function for disabling one-shot operation for the specified match filter.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ * @param[in] index Index of pattern match filter.
+ */
+NRF_STATIC_INLINE void nrf_twim_rx_pattern_match_one_shot_disable(NRF_TWIM_Type * p_reg,
+                                                                  uint8_t         index);
+
+/**
+ * @brief Function for checking if specified pattern match filter is configured as one-shot.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ * @param[in] index Index of pattern match filter.
+ *
+ * @retval true  Pattern match filter is configured as one-shot.
+ * @retval false Pattern match filter is configured as continuous.
+ */
+NRF_STATIC_INLINE bool nrf_twim_rx_pattern_match_one_shot_check(NRF_TWIM_Type const * p_reg,
+                                                                uint8_t               index);
+
+/**
+ * @brief Function for setting the pattern to be looked for by the specified match filter.
+ *
+ * @param[in] p_reg   Pointer to the structure of registers of the peripheral.
+ * @param[in] index   Index of pattern match filter.
+ * @param[in] pattern Pattern to be looked for.
+ *                    Match will trigger the corresponding event, if enabled.
+ */
+NRF_STATIC_INLINE void nrf_twim_rx_pattern_match_candidate_set(NRF_TWIM_Type * p_reg,
+                                                               uint8_t         index,
+                                                               uint32_t        pattern);
+
+/**
+ * @brief Function for getting the pattern that the specified match filter is looking for.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ * @param[in] index Index of pattern match filter.
+ *
+ * @return Pattern that the specified match filter is looking for.
+ */
+NRF_STATIC_INLINE uint32_t nrf_twim_rx_pattern_match_candidate_get(NRF_TWIM_Type const * p_reg,
+                                                                   uint8_t               index);
+#endif // NRF_TWIM_HAS_DMA_REG
 
 #ifndef NRF_DECLARE_ONLY
 
@@ -512,7 +700,7 @@ NRF_STATIC_INLINE void nrf_twim_subscribe_set(NRF_TWIM_Type * p_reg,
                                               uint8_t        channel)
 {
     *((volatile uint32_t *) ((uint8_t *) p_reg + (uint32_t) task + 0x80uL)) =
-            ((uint32_t)channel | TWIM_SUBSCRIBE_STARTRX_EN_Msk);
+            ((uint32_t)channel | NRF_SUBSCRIBE_PUBLISH_ENABLE);
 }
 
 NRF_STATIC_INLINE void nrf_twim_subscribe_clear(NRF_TWIM_Type * p_reg,
@@ -526,7 +714,7 @@ NRF_STATIC_INLINE void nrf_twim_publish_set(NRF_TWIM_Type *  p_reg,
                                             uint8_t         channel)
 {
     *((volatile uint32_t *) ((uint8_t *) p_reg + (uint32_t) event + 0x80uL)) =
-            ((uint32_t)channel | TWIM_PUBLISH_STOPPED_EN_Msk);
+            ((uint32_t)channel | NRF_SUBSCRIBE_PUBLISH_ENABLE);
 }
 
 NRF_STATIC_INLINE void nrf_twim_publish_clear(NRF_TWIM_Type *  p_reg,
@@ -586,20 +774,35 @@ NRF_STATIC_INLINE void nrf_twim_address_set(NRF_TWIM_Type * p_reg,
     p_reg->ADDRESS = address;
 }
 
+NRF_STATIC_INLINE uint8_t nrf_twim_address_get(NRF_TWIM_Type const * p_reg)
+{
+    return (uint8_t)(p_reg->ADDRESS & TWIM_ADDRESS_ADDRESS_Msk);
+}
+
 NRF_STATIC_INLINE void nrf_twim_tx_buffer_set(NRF_TWIM_Type * p_reg,
                                               uint8_t const * p_buffer,
                                               size_t          length)
 {
+#if NRF_TWIM_HAS_DMA_REG
+    p_reg->DMA.TX.PTR    = (uint32_t)p_buffer;
+    p_reg->DMA.TX.MAXCNT = length;
+#else
     p_reg->TXD.PTR    = (uint32_t)p_buffer;
     p_reg->TXD.MAXCNT = length;
+#endif
 }
 
 NRF_STATIC_INLINE void nrf_twim_rx_buffer_set(NRF_TWIM_Type * p_reg,
                                               uint8_t * p_buffer,
                                               size_t    length)
 {
+#if NRF_TWIM_HAS_DMA_REG
+    p_reg->DMA.RX.PTR    = (uint32_t)p_buffer;
+    p_reg->DMA.RX.MAXCNT = length;
+#else
     p_reg->RXD.PTR    = (uint32_t)p_buffer;
     p_reg->RXD.MAXCNT = length;
+#endif
 }
 
 NRF_STATIC_INLINE void nrf_twim_shorts_set(NRF_TWIM_Type * p_reg,
@@ -615,14 +818,23 @@ NRF_STATIC_INLINE uint32_t nrf_twim_shorts_get(NRF_TWIM_Type const * p_reg)
 
 NRF_STATIC_INLINE size_t nrf_twim_txd_amount_get(NRF_TWIM_Type const * p_reg)
 {
+#if NRF_TWIM_HAS_DMA_REG
+    return p_reg->DMA.TX.AMOUNT;
+#else
     return p_reg->TXD.AMOUNT;
+#endif
 }
 
 NRF_STATIC_INLINE size_t nrf_twim_rxd_amount_get(NRF_TWIM_Type const * p_reg)
 {
+#if NRF_TWIM_HAS_DMA_REG
+    return p_reg->DMA.RX.AMOUNT;
+#else
     return p_reg->RXD.AMOUNT;
+#endif
 }
 
+#if NRF_TWIM_HAS_ARRAY_LIST
 NRF_STATIC_INLINE void nrf_twim_tx_list_enable(NRF_TWIM_Type * p_reg)
 {
     p_reg->TXD.LIST = TWIM_TXD_LIST_LIST_ArrayList << TWIM_TXD_LIST_LIST_Pos;
@@ -642,6 +854,174 @@ NRF_STATIC_INLINE void nrf_twim_rx_list_disable(NRF_TWIM_Type * p_reg)
 {
     p_reg->RXD.LIST = TWIM_RXD_LIST_LIST_Disabled << TWIM_RXD_LIST_LIST_Pos;
 }
+#endif
+
+#if NRF_TWIM_HAS_DMA_REG
+NRF_STATIC_INLINE void nrf_twim_rx_pattern_match_enable_set(NRF_TWIM_Type * p_reg,
+                                                            uint8_t         index,
+                                                            bool            enable)
+{
+    NRFX_ASSERT(index < NRF_TWIM_DMA_RX_PATTERN_MAX_COUNT);
+    switch (index)
+    {
+        case 0:
+            p_reg->DMA.RX.MATCH.CONFIG = ((p_reg->DMA.RX.MATCH.CONFIG &
+                                         ~TWIM_DMA_RX_MATCH_CONFIG_ENABLE0_Msk) |
+                                         ((enable ?
+                                           TWIM_DMA_RX_MATCH_CONFIG_ENABLE0_Enabled :
+                                           TWIM_DMA_RX_MATCH_CONFIG_ENABLE0_Disabled)
+                                           << TWIM_DMA_RX_MATCH_CONFIG_ENABLE0_Pos));
+            break;
+        case 1:
+            p_reg->DMA.RX.MATCH.CONFIG = ((p_reg->DMA.RX.MATCH.CONFIG &
+                                         ~TWIM_DMA_RX_MATCH_CONFIG_ENABLE1_Msk) |
+                                         ((enable ?
+                                           TWIM_DMA_RX_MATCH_CONFIG_ENABLE1_Enabled :
+                                           TWIM_DMA_RX_MATCH_CONFIG_ENABLE1_Disabled)
+                                           << TWIM_DMA_RX_MATCH_CONFIG_ENABLE1_Pos));
+            break;
+        case 2:
+            p_reg->DMA.RX.MATCH.CONFIG = ((p_reg->DMA.RX.MATCH.CONFIG &
+                                         ~TWIM_DMA_RX_MATCH_CONFIG_ENABLE2_Msk) |
+                                         ((enable ?
+                                           TWIM_DMA_RX_MATCH_CONFIG_ENABLE2_Enabled :
+                                           TWIM_DMA_RX_MATCH_CONFIG_ENABLE2_Disabled)
+                                           << TWIM_DMA_RX_MATCH_CONFIG_ENABLE2_Pos));
+            break;
+        case 3:
+            p_reg->DMA.RX.MATCH.CONFIG = ((p_reg->DMA.RX.MATCH.CONFIG &
+                                         ~TWIM_DMA_RX_MATCH_CONFIG_ENABLE3_Msk) |
+                                         ((enable ?
+                                           TWIM_DMA_RX_MATCH_CONFIG_ENABLE3_Enabled :
+                                           TWIM_DMA_RX_MATCH_CONFIG_ENABLE3_Disabled)
+                                           << TWIM_DMA_RX_MATCH_CONFIG_ENABLE3_Pos));
+            break;
+        default:
+            NRFX_ASSERT(false);
+            break;
+    }
+}
+
+NRF_STATIC_INLINE bool nrf_twim_rx_pattern_match_enable_check(NRF_TWIM_Type const * p_reg,
+                                                              uint8_t               index)
+{
+    NRFX_ASSERT(index < NRF_TWIM_DMA_RX_PATTERN_MAX_COUNT);
+    switch (index)
+    {
+        case 0:
+            return ((p_reg->DMA.RX.MATCH.CONFIG & TWIM_DMA_RX_MATCH_CONFIG_ENABLE0_Msk)
+                    >> TWIM_DMA_RX_MATCH_CONFIG_ENABLE0_Pos) ==
+                    TWIM_DMA_RX_MATCH_CONFIG_ENABLE0_Enabled;
+        case 1:
+            return ((p_reg->DMA.RX.MATCH.CONFIG & TWIM_DMA_RX_MATCH_CONFIG_ENABLE1_Msk)
+                    >> TWIM_DMA_RX_MATCH_CONFIG_ENABLE1_Pos) ==
+                    TWIM_DMA_RX_MATCH_CONFIG_ENABLE1_Enabled;
+        case 2:
+            return ((p_reg->DMA.RX.MATCH.CONFIG & TWIM_DMA_RX_MATCH_CONFIG_ENABLE2_Msk)
+                    >> TWIM_DMA_RX_MATCH_CONFIG_ENABLE2_Pos) ==
+                    TWIM_DMA_RX_MATCH_CONFIG_ENABLE2_Enabled;
+        case 3:
+            return ((p_reg->DMA.RX.MATCH.CONFIG & TWIM_DMA_RX_MATCH_CONFIG_ENABLE3_Msk)
+                    >> TWIM_DMA_RX_MATCH_CONFIG_ENABLE3_Pos) ==
+                    TWIM_DMA_RX_MATCH_CONFIG_ENABLE3_Enabled;
+        default:
+            NRFX_ASSERT(false);
+            return 0;
+    }
+}
+
+NRF_STATIC_INLINE void nrf_twim_rx_pattern_match_one_shot_enable(NRF_TWIM_Type * p_reg,
+                                                                 uint8_t         index)
+{
+    NRFX_ASSERT(index < NRF_TWIM_DMA_RX_PATTERN_MAX_COUNT);
+    switch (index)
+    {
+        case 0:
+            p_reg->DMA.RX.MATCH.CONFIG |= TWIM_DMA_RX_MATCH_CONFIG_ONESHOT0_Msk;
+            break;
+        case 1:
+            p_reg->DMA.RX.MATCH.CONFIG |= TWIM_DMA_RX_MATCH_CONFIG_ONESHOT1_Msk;
+            break;
+        case 2:
+            p_reg->DMA.RX.MATCH.CONFIG |= TWIM_DMA_RX_MATCH_CONFIG_ONESHOT2_Msk;
+            break;
+        case 3:
+            p_reg->DMA.RX.MATCH.CONFIG |= TWIM_DMA_RX_MATCH_CONFIG_ONESHOT3_Msk;
+            break;
+        default:
+            NRFX_ASSERT(false);
+            break;
+    }
+}
+
+NRF_STATIC_INLINE void nrf_twim_rx_pattern_match_one_shot_disable(NRF_TWIM_Type * p_reg,
+                                                                  uint8_t         index)
+{
+    NRFX_ASSERT(index < NRF_TWIM_DMA_RX_PATTERN_MAX_COUNT);
+    switch (index)
+    {
+        case 0:
+            p_reg->DMA.RX.MATCH.CONFIG &= ~(TWIM_DMA_RX_MATCH_CONFIG_ONESHOT0_Msk);
+            break;
+        case 1:
+            p_reg->DMA.RX.MATCH.CONFIG &= ~(TWIM_DMA_RX_MATCH_CONFIG_ONESHOT1_Msk);
+            break;
+        case 2:
+            p_reg->DMA.RX.MATCH.CONFIG &= ~(TWIM_DMA_RX_MATCH_CONFIG_ONESHOT2_Msk);
+            break;
+        case 3:
+            p_reg->DMA.RX.MATCH.CONFIG &= ~(TWIM_DMA_RX_MATCH_CONFIG_ONESHOT3_Msk);
+            break;
+        default:
+            NRFX_ASSERT(false);
+            break;
+    }
+}
+
+NRF_STATIC_INLINE bool nrf_twim_rx_pattern_match_one_shot_check(NRF_TWIM_Type const * p_reg,
+                                                                uint8_t               index)
+{
+    NRFX_ASSERT(index < NRF_TWIM_DMA_RX_PATTERN_MAX_COUNT);
+    switch (index)
+    {
+        case 0:
+            return ((p_reg->DMA.RX.MATCH.CONFIG & TWIM_DMA_RX_MATCH_CONFIG_ONESHOT0_Msk)
+                    >> TWIM_DMA_RX_MATCH_CONFIG_ONESHOT0_Pos) ==
+                    TWIM_DMA_RX_MATCH_CONFIG_ONESHOT0_Oneshot;
+        case 1:
+            return ((p_reg->DMA.RX.MATCH.CONFIG & TWIM_DMA_RX_MATCH_CONFIG_ONESHOT1_Msk)
+                    >> TWIM_DMA_RX_MATCH_CONFIG_ONESHOT1_Pos) ==
+                    TWIM_DMA_RX_MATCH_CONFIG_ONESHOT1_Oneshot;
+        case 2:
+            return ((p_reg->DMA.RX.MATCH.CONFIG & TWIM_DMA_RX_MATCH_CONFIG_ONESHOT2_Msk)
+                    >> TWIM_DMA_RX_MATCH_CONFIG_ONESHOT2_Pos) ==
+                    TWIM_DMA_RX_MATCH_CONFIG_ONESHOT2_Oneshot;
+        case 3:
+            return ((p_reg->DMA.RX.MATCH.CONFIG & TWIM_DMA_RX_MATCH_CONFIG_ONESHOT3_Msk)
+                    >> TWIM_DMA_RX_MATCH_CONFIG_ONESHOT3_Pos) ==
+                    TWIM_DMA_RX_MATCH_CONFIG_ONESHOT3_Oneshot;
+        default:
+            NRFX_ASSERT(false);
+            return 0;
+    }
+}
+
+NRF_STATIC_INLINE void nrf_twim_rx_pattern_match_candidate_set(NRF_TWIM_Type * p_reg,
+                                                               uint8_t         index,
+                                                               uint32_t        pattern)
+{
+    NRFX_ASSERT(index < NRF_TWIM_DMA_RX_PATTERN_MAX_COUNT);
+    p_reg->DMA.RX.MATCH.CANDIDATE[index] = pattern;
+}
+
+NRF_STATIC_INLINE uint32_t nrf_twim_rx_pattern_match_candidate_get(NRF_TWIM_Type const * p_reg,
+                                                                   uint8_t               index)
+{
+    NRFX_ASSERT(index < NRF_TWIM_DMA_RX_PATTERN_MAX_COUNT);
+    return p_reg->DMA.RX.MATCH.CANDIDATE[index];
+}
+#endif // NRF_TWIM_HAS_DMA_REG
+
 #endif // NRF_DECLARE_ONLY
 
 /** @} */

--- a/nrfx/hal/nrf_uart.h
+++ b/nrfx/hal/nrf_uart.h
@@ -496,7 +496,7 @@ NRF_STATIC_INLINE void nrf_uart_hwfc_pins_disconnect(NRF_UART_Type * p_reg)
 
 NRF_STATIC_INLINE uint8_t nrf_uart_rxd_get(NRF_UART_Type const * p_reg)
 {
-    return p_reg->RXD;
+    return (uint8_t)p_reg->RXD;
 }
 
 NRF_STATIC_INLINE void nrf_uart_txd_set(NRF_UART_Type * p_reg, uint8_t txd)

--- a/nrfx/hal/nrf_uarte.h
+++ b/nrfx/hal/nrf_uarte.h
@@ -58,30 +58,59 @@ extern "C" {
  */
 #define NRF_UARTE_INST_GET(idx) NRFX_CONCAT_2(NRF_UARTE, idx)
 
+#if defined(UARTE_DMA_RX_PTR_PTR_Msk) || defined(__NRFX_DOXYGEN__)
+/** @brief Symbol indicating whether dedicated DMA register is present. */
+#define NRF_UARTE_HAS_DMA_REG 1
+#else
+#define NRF_UARTE_HAS_DMA_REG 0
+#endif
+
+#if (defined(UARTE_TASKS_DMA_RX_START_START_Msk) && defined(UARTE_EVENTS_DMA_RX_END_END_Msk)) || \
+    defined(__NRFX_DOXYGEN__)
+/** @brief Symbol indicating whether UARTE DMA tasks and events are present. */
+#define NRF_UARTE_HAS_DMA_TASKS_EVENTS 1
+#else
+#define NRF_UARTE_HAS_DMA_TASKS_EVENTS 0
+#endif
+
 /** @brief UARTE tasks. */
 typedef enum
 {
-    NRF_UARTE_TASK_STARTRX   = offsetof(NRF_UARTE_Type, TASKS_STARTRX), ///< Start UART receiver.
-    NRF_UARTE_TASK_STOPRX    = offsetof(NRF_UARTE_Type, TASKS_STOPRX),  ///< Stop UART receiver.
-    NRF_UARTE_TASK_STARTTX   = offsetof(NRF_UARTE_Type, TASKS_STARTTX), ///< Start UART transmitter.
-    NRF_UARTE_TASK_STOPTX    = offsetof(NRF_UARTE_Type, TASKS_STOPTX),  ///< Stop UART transmitter.
-    NRF_UARTE_TASK_FLUSHRX   = offsetof(NRF_UARTE_Type, TASKS_FLUSHRX)  ///< Flush RX FIFO in RX buffer.
+#if NRF_UARTE_HAS_DMA_TASKS_EVENTS
+    NRF_UARTE_TASK_STARTRX   = offsetof(NRF_UARTE_Type, TASKS_DMA.RX.START), ///< Start UART receiver.
+    NRF_UARTE_TASK_STOPRX    = offsetof(NRF_UARTE_Type, TASKS_DMA.RX.STOP),  ///< Stop UART receiver.
+    NRF_UARTE_TASK_STARTTX   = offsetof(NRF_UARTE_Type, TASKS_DMA.TX.START), ///< Start UART transmitter.
+    NRF_UARTE_TASK_STOPTX    = offsetof(NRF_UARTE_Type, TASKS_DMA.TX.STOP),  ///< Stop UART transmitter.
+#else
+    NRF_UARTE_TASK_STARTRX   = offsetof(NRF_UARTE_Type, TASKS_STARTRX),      ///< Start UART receiver.
+    NRF_UARTE_TASK_STOPRX    = offsetof(NRF_UARTE_Type, TASKS_STOPRX),       ///< Stop UART receiver.
+    NRF_UARTE_TASK_STARTTX   = offsetof(NRF_UARTE_Type, TASKS_STARTTX),      ///< Start UART transmitter.
+    NRF_UARTE_TASK_STOPTX    = offsetof(NRF_UARTE_Type, TASKS_STOPTX),       ///< Stop UART transmitter.
+#endif
+    NRF_UARTE_TASK_FLUSHRX   = offsetof(NRF_UARTE_Type, TASKS_FLUSHRX)       ///< Flush RX FIFO in RX buffer.
 } nrf_uarte_task_t;
 
 /** @brief UARTE events. */
 typedef enum
 {
-    NRF_UARTE_EVENT_CTS       = offsetof(NRF_UARTE_Type, EVENTS_CTS),       ///< CTS is activated.
-    NRF_UARTE_EVENT_NCTS      = offsetof(NRF_UARTE_Type, EVENTS_NCTS),      ///< CTS is deactivated.
-    NRF_UARTE_EVENT_RXDRDY    = offsetof(NRF_UARTE_Type, EVENTS_RXDRDY),    ///< Data received in RXD (but potentially not yet transferred to Data RAM).
-    NRF_UARTE_EVENT_ENDRX     = offsetof(NRF_UARTE_Type, EVENTS_ENDRX),     ///< Receive buffer is filled up.
-    NRF_UARTE_EVENT_TXDRDY    = offsetof(NRF_UARTE_Type, EVENTS_TXDRDY),    ///< Data sent from TXD.
-    NRF_UARTE_EVENT_ENDTX     = offsetof(NRF_UARTE_Type, EVENTS_ENDTX),     ///< Last TX byte transmitted.
-    NRF_UARTE_EVENT_ERROR     = offsetof(NRF_UARTE_Type, EVENTS_ERROR),     ///< Error detected.
-    NRF_UARTE_EVENT_RXTO      = offsetof(NRF_UARTE_Type, EVENTS_RXTO),      ///< Receiver timeout.
-    NRF_UARTE_EVENT_RXSTARTED = offsetof(NRF_UARTE_Type, EVENTS_RXSTARTED), ///< Receiver has started.
-    NRF_UARTE_EVENT_TXSTARTED = offsetof(NRF_UARTE_Type, EVENTS_TXSTARTED), ///< Transmitter has started.
-    NRF_UARTE_EVENT_TXSTOPPED = offsetof(NRF_UARTE_Type, EVENTS_TXSTOPPED)  ///< Transmitted stopped.
+    NRF_UARTE_EVENT_CTS       = offsetof(NRF_UARTE_Type, EVENTS_CTS),          ///< CTS is activated.
+    NRF_UARTE_EVENT_NCTS      = offsetof(NRF_UARTE_Type, EVENTS_NCTS),         ///< CTS is deactivated.
+    NRF_UARTE_EVENT_RXDRDY    = offsetof(NRF_UARTE_Type, EVENTS_RXDRDY),       ///< Data received in RXD (but potentially not yet transferred to Data RAM).
+    NRF_UARTE_EVENT_TXDRDY    = offsetof(NRF_UARTE_Type, EVENTS_TXDRDY),       ///< Data sent from TXD.
+    NRF_UARTE_EVENT_ERROR     = offsetof(NRF_UARTE_Type, EVENTS_ERROR),        ///< Error detected.
+    NRF_UARTE_EVENT_RXTO      = offsetof(NRF_UARTE_Type, EVENTS_RXTO),         ///< Receiver timeout.
+    NRF_UARTE_EVENT_TXSTOPPED = offsetof(NRF_UARTE_Type, EVENTS_TXSTOPPED),    ///< Transmitted stopped.
+#if NRF_UARTE_HAS_DMA_TASKS_EVENTS
+    NRF_UARTE_EVENT_ENDRX     = offsetof(NRF_UARTE_Type, EVENTS_DMA.RX.END),   ///< Receive buffer is filled up.
+    NRF_UARTE_EVENT_ENDTX     = offsetof(NRF_UARTE_Type, EVENTS_DMA.TX.END),   ///< Last TX byte transmitted.
+    NRF_UARTE_EVENT_RXSTARTED = offsetof(NRF_UARTE_Type, EVENTS_DMA.RX.READY), ///< Receiver has started.
+    NRF_UARTE_EVENT_TXSTARTED = offsetof(NRF_UARTE_Type, EVENTS_DMA.TX.READY), ///< Transmitter has started.
+#else
+    NRF_UARTE_EVENT_ENDRX     = offsetof(NRF_UARTE_Type, EVENTS_ENDRX),        ///< Receive buffer is filled up.
+    NRF_UARTE_EVENT_ENDTX     = offsetof(NRF_UARTE_Type, EVENTS_ENDTX),        ///< Last TX byte transmitted.
+    NRF_UARTE_EVENT_RXSTARTED = offsetof(NRF_UARTE_Type, EVENTS_RXSTARTED),    ///< Receiver has started.
+    NRF_UARTE_EVENT_TXSTARTED = offsetof(NRF_UARTE_Type, EVENTS_TXSTARTED),    ///< Transmitter has started.
+#endif
 } nrf_uarte_event_t;
 
 /** @brief Types of UARTE shortcuts. */
@@ -95,17 +124,24 @@ typedef enum
 /** @brief UARTE interrupts. */
 typedef enum
 {
-    NRF_UARTE_INT_CTS_MASK       = UARTE_INTENSET_CTS_Msk,       ///< Interrupt on CTS event.
-    NRF_UARTE_INT_NCTS_MASK      = UARTE_INTENSET_NCTS_Msk,      ///< Interrupt on NCTS event.
-    NRF_UARTE_INT_RXDRDY_MASK    = UARTE_INTENSET_RXDRDY_Msk,    ///< Interrupt on RXDRDY event.
-    NRF_UARTE_INT_ENDRX_MASK     = UARTE_INTENSET_ENDRX_Msk,     ///< Interrupt on ENDRX event.
-    NRF_UARTE_INT_TXDRDY_MASK    = UARTE_INTENSET_TXDRDY_Msk,    ///< Interrupt on TXDRDY event.
-    NRF_UARTE_INT_ENDTX_MASK     = UARTE_INTENSET_ENDTX_Msk,     ///< Interrupt on ENDTX event.
-    NRF_UARTE_INT_ERROR_MASK     = UARTE_INTENSET_ERROR_Msk,     ///< Interrupt on ERROR event.
-    NRF_UARTE_INT_RXTO_MASK      = UARTE_INTENSET_RXTO_Msk,      ///< Interrupt on RXTO event.
-    NRF_UARTE_INT_RXSTARTED_MASK = UARTE_INTENSET_RXSTARTED_Msk, ///< Interrupt on RXSTARTED event.
-    NRF_UARTE_INT_TXSTARTED_MASK = UARTE_INTENSET_TXSTARTED_Msk, ///< Interrupt on TXSTARTED event.
-    NRF_UARTE_INT_TXSTOPPED_MASK = UARTE_INTENSET_TXSTOPPED_Msk  ///< Interrupt on TXSTOPPED event.
+    NRF_UARTE_INT_CTS_MASK       = UARTE_INTENSET_CTS_Msk,        ///< Interrupt on CTS event.
+    NRF_UARTE_INT_NCTS_MASK      = UARTE_INTENSET_NCTS_Msk,       ///< Interrupt on NCTS event.
+    NRF_UARTE_INT_RXDRDY_MASK    = UARTE_INTENSET_RXDRDY_Msk,     ///< Interrupt on RXDRDY event.
+    NRF_UARTE_INT_TXDRDY_MASK    = UARTE_INTENSET_TXDRDY_Msk,     ///< Interrupt on TXDRDY event.
+    NRF_UARTE_INT_ERROR_MASK     = UARTE_INTENSET_ERROR_Msk,      ///< Interrupt on ERROR event.
+    NRF_UARTE_INT_RXTO_MASK      = UARTE_INTENSET_RXTO_Msk,       ///< Interrupt on RXTO event.
+    NRF_UARTE_INT_TXSTOPPED_MASK = UARTE_INTENSET_TXSTOPPED_Msk,  ///< Interrupt on TXSTOPPED event.
+#if NRF_UARTE_HAS_DMA_TASKS_EVENTS
+    NRF_UARTE_INT_ENDRX_MASK     = UARTE_INTENSET_DMARXEND_Msk,   ///< Interrupt on ENDRX event.
+    NRF_UARTE_INT_ENDTX_MASK     = UARTE_INTENSET_DMATXEND_Msk,   ///< Interrupt on ENDTX event.
+    NRF_UARTE_INT_RXSTARTED_MASK = UARTE_INTENSET_DMARXREADY_Msk, ///< Interrupt on RXSTARTED event.
+    NRF_UARTE_INT_TXSTARTED_MASK = UARTE_INTENSET_DMATXREADY_Msk, ///< Interrupt on TXSTARTED event.
+#else
+    NRF_UARTE_INT_ENDRX_MASK     = UARTE_INTENSET_ENDRX_Msk,      ///< Interrupt on ENDRX event.
+    NRF_UARTE_INT_ENDTX_MASK     = UARTE_INTENSET_ENDTX_Msk,      ///< Interrupt on ENDTX event.
+    NRF_UARTE_INT_RXSTARTED_MASK = UARTE_INTENSET_RXSTARTED_Msk,  ///< Interrupt on RXSTARTED event.
+    NRF_UARTE_INT_TXSTARTED_MASK = UARTE_INTENSET_TXSTARTED_Msk,  ///< Interrupt on TXSTARTED event.
+#endif
 } nrf_uarte_int_mask_t;
 
 /** @brief Baudrates supported by UARTE. */
@@ -526,7 +562,7 @@ NRF_STATIC_INLINE void nrf_uarte_subscribe_set(NRF_UARTE_Type * p_reg,
                                                uint8_t          channel)
 {
     *((volatile uint32_t *) ((uint8_t *) p_reg + (uint32_t) task + 0x80uL)) =
-            ((uint32_t)channel | UARTE_SUBSCRIBE_STARTRX_EN_Msk);
+            ((uint32_t)channel | NRF_SUBSCRIBE_PUBLISH_ENABLE);
 }
 
 NRF_STATIC_INLINE void nrf_uarte_subscribe_clear(NRF_UARTE_Type * p_reg,
@@ -540,7 +576,7 @@ NRF_STATIC_INLINE void nrf_uarte_publish_set(NRF_UARTE_Type *  p_reg,
                                              uint8_t           channel)
 {
     *((volatile uint32_t *) ((uint8_t *) p_reg + (uint32_t) event + 0x80uL)) =
-            ((uint32_t)channel | UARTE_PUBLISH_CTS_EN_Msk);
+            ((uint32_t)channel | NRF_SUBSCRIBE_PUBLISH_ENABLE);
 }
 
 NRF_STATIC_INLINE void nrf_uarte_publish_clear(NRF_UARTE_Type *  p_reg,
@@ -646,26 +682,44 @@ NRF_STATIC_INLINE void nrf_uarte_tx_buffer_set(NRF_UARTE_Type * p_reg,
                                                uint8_t  const * p_buffer,
                                                size_t           length)
 {
+#if NRF_UARTE_HAS_DMA_REG
+    p_reg->DMA.TX.PTR    = (uint32_t)p_buffer;
+    p_reg->DMA.TX.MAXCNT = length;
+#else
     p_reg->TXD.PTR    = (uint32_t)p_buffer;
     p_reg->TXD.MAXCNT = length;
+#endif
 }
 
 NRF_STATIC_INLINE uint32_t nrf_uarte_tx_amount_get(NRF_UARTE_Type const * p_reg)
 {
+#if NRF_UARTE_HAS_DMA_REG
+    return p_reg->DMA.TX.AMOUNT;
+#else
     return p_reg->TXD.AMOUNT;
+#endif
 }
 
 NRF_STATIC_INLINE void nrf_uarte_rx_buffer_set(NRF_UARTE_Type * p_reg,
                                                uint8_t *        p_buffer,
                                                size_t           length)
 {
+#if NRF_UARTE_HAS_DMA_REG
+    p_reg->DMA.RX.PTR    = (uint32_t)p_buffer;
+    p_reg->DMA.RX.MAXCNT = length;
+#else
     p_reg->RXD.PTR    = (uint32_t)p_buffer;
     p_reg->RXD.MAXCNT = length;
+#endif
 }
 
 NRF_STATIC_INLINE uint32_t nrf_uarte_rx_amount_get(NRF_UARTE_Type const * p_reg)
 {
+#if NRF_UARTE_HAS_DMA_REG
+    return p_reg->DMA.RX.AMOUNT;
+#else
     return p_reg->RXD.AMOUNT;
+#endif
 }
 #endif // NRF_DECLARE_ONLY
 

--- a/nrfx/hal/nrf_wdt.h
+++ b/nrfx/hal/nrf_wdt.h
@@ -40,7 +40,7 @@
 extern "C" {
 #endif
 
-#ifndef NRF_WDT0
+#if !defined(NRF_WDT0) && defined(NRF_WDT)
 #define NRF_WDT0 NRF_WDT
 #endif
 
@@ -60,6 +60,20 @@ extern "C" {
  */
 #define NRF_WDT_INST_GET(idx) NRFX_CONCAT_2(NRF_WDT, idx)
 
+#if defined(WDT_TASKS_STOP_TASKS_STOP_Msk) || defined (__NRFX_DOXYGEN__)
+/** @brief Presence of Task STOP functionality. */
+#define NRF_WDT_HAS_STOP 1
+#else
+#define NRF_WDT_HAS_STOP 0
+#endif
+
+#if defined(WDT_NMIENSET_TIMEOUT_Msk) || defined (__NRFX_DOXYGEN__)
+/** @brief Presence of non-maskable interrupt configuration. */
+#define NRF_WDT_HAS_NMI 1
+#else
+#define NRF_WDT_HAS_NMI 0
+#endif
+
 /** @brief Number of WDT channels. */
 #define NRF_WDT_CHANNEL_NUMBER 0x8UL
 
@@ -71,22 +85,29 @@ extern "C" {
 typedef enum
 {
     NRF_WDT_TASK_START = offsetof(NRF_WDT_Type, TASKS_START), /**< Task for starting WDT. */
+#if NRF_WDT_HAS_STOP
+    NRF_WDT_TASK_STOP  = offsetof(NRF_WDT_Type, TASKS_STOP),  /**< Task for stopping WDT. */
+#endif
 } nrf_wdt_task_t;
 
 /** @brief WDT events. */
 typedef enum
 {
     NRF_WDT_EVENT_TIMEOUT = offsetof(NRF_WDT_Type, EVENTS_TIMEOUT), /**< Event from WDT time-out. */
+#if NRF_WDT_HAS_STOP
+    NRF_WDT_EVENT_STOPPED = offsetof(NRF_WDT_Type, EVENTS_STOPPED), /**< Event from WDT stop. */
+#endif
 } nrf_wdt_event_t;
 
 /** @brief WDT behavior in the SLEEP or HALT CPU modes. */
 typedef enum
 {
-    NRF_WDT_BEHAVIOUR_RUN_SLEEP        = WDT_CONFIG_SLEEP_Msk,                       /**< WDT will run when CPU is in SLEEP mode. */
-    NRF_WDT_BEHAVIOUR_RUN_HALT         = WDT_CONFIG_HALT_Msk,                        /**< WDT will run when CPU is in HALT mode. */
-    NRF_WDT_BEHAVIOUR_RUN_SLEEP_HALT   = WDT_CONFIG_SLEEP_Msk | WDT_CONFIG_HALT_Msk, /**< WDT will run when CPU is in SLEEP or HALT mode. */
-    NRF_WDT_BEHAVIOUR_PAUSE_SLEEP_HALT = 0,                                          /**< WDT will be paused when CPU is in SLEEP or HALT mode. */
-} nrf_wdt_behaviour_t;
+    NRF_WDT_BEHAVIOUR_RUN_SLEEP_MASK     = WDT_CONFIG_SLEEP_Msk,  /**< WDT will run when CPU is in SLEEP mode. */
+    NRF_WDT_BEHAVIOUR_RUN_HALT_MASK      = WDT_CONFIG_HALT_Msk,   /**< WDT will run when CPU is in HALT mode. */
+#if defined(WDT_CONFIG_STOPEN_Msk)
+    NRF_WDT_BEHAVIOUR_STOP_ENABLE_MASK   = WDT_CONFIG_STOPEN_Msk, /**< WDT allows stopping. */
+#endif
+} nrf_wdt_behaviour_mask_t;
 
 /** @brief WDT reload request registers. */
 typedef enum
@@ -101,20 +122,35 @@ typedef enum
     NRF_WDT_RR7      /**< Reload request register 7. */
 } nrf_wdt_rr_register_t;
 
+/** @brief WDT reload request registers mask. */
+typedef enum
+{
+    NRF_WDT_RR0_MASK = (1UL << NRF_WDT_RR0), /**< Mask for reload request register 0. */
+    NRF_WDT_RR1_MASK = (1UL << NRF_WDT_RR1), /**< Mask for reload request register 1. */
+    NRF_WDT_RR2_MASK = (1UL << NRF_WDT_RR2), /**< Mask for reload request register 2. */
+    NRF_WDT_RR3_MASK = (1UL << NRF_WDT_RR3), /**< Mask for reload request register 3. */
+    NRF_WDT_RR4_MASK = (1UL << NRF_WDT_RR4), /**< Mask for reload request register 4. */
+    NRF_WDT_RR5_MASK = (1UL << NRF_WDT_RR5), /**< Mask for reload request register 5. */
+    NRF_WDT_RR6_MASK = (1UL << NRF_WDT_RR6), /**< Mask for reload request register 6. */
+    NRF_WDT_RR7_MASK = (1UL << NRF_WDT_RR7), /**< Mask for reload request register 7. */
+} nrf_wdt_rr_register_mask_t;
+
 /** @brief WDT interrupts. */
 typedef enum
 {
     NRF_WDT_INT_TIMEOUT_MASK = WDT_INTENSET_TIMEOUT_Msk, /**< WDT interrupt from time-out event. */
+#if NRF_WDT_HAS_STOP
+    NRF_WDT_INT_STOPPED_MASK = WDT_INTENSET_STOPPED_Msk, /**< WDT interrupt from stop event. */
+#endif
 } nrf_wdt_int_mask_t;
 
-
 /**
- * @brief Function for configuring the watchdog behavior when the CPU is sleeping or halted.
+ * @brief Function for configuring the watchdog behaviour when the CPU is sleeping or halted.
  *
- * @param[in] p_reg     Pointer to the structure of registers of the peripheral.
- * @param[in] behaviour Watchdog behavior when CPU is in SLEEP or HALT mode.
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ * @param[in] mask  Watchdog behaviour mask, created using @ref nrf_wdt_behaviour_mask_t.
  */
-NRF_STATIC_INLINE void nrf_wdt_behaviour_set(NRF_WDT_Type * p_reg, nrf_wdt_behaviour_t behaviour);
+NRF_STATIC_INLINE void nrf_wdt_behaviour_set(NRF_WDT_Type * p_reg, uint32_t mask);
 
 /**
  * @brief Function for starting the WDT task.
@@ -144,7 +180,7 @@ NRF_STATIC_INLINE void nrf_wdt_event_clear(NRF_WDT_Type * p_reg, nrf_wdt_event_t
 NRF_STATIC_INLINE bool nrf_wdt_event_check(NRF_WDT_Type const * p_reg, nrf_wdt_event_t event);
 
 /**
- * @brief Function for enabling the specified interrupt.
+ * @brief Function for enabling the specified interrupts.
  *
  * @param[in] p_reg Pointer to the structure of registers of the peripheral.
  * @param[in] mask  Mask of interrupts to be enabled.
@@ -162,12 +198,40 @@ NRF_STATIC_INLINE void nrf_wdt_int_enable(NRF_WDT_Type * p_reg, uint32_t mask);
 NRF_STATIC_INLINE uint32_t nrf_wdt_int_enable_check(NRF_WDT_Type const * p_reg, uint32_t mask);
 
 /**
- * @brief Function for disabling a specific interrupt.
+ * @brief Function for disabling the specified interrupts.
  *
  * @param[in] p_reg Pointer to the structure of registers of the peripheral.
  * @param[in] mask  Mask of interrupts to be disabled.
  */
 NRF_STATIC_INLINE void nrf_wdt_int_disable(NRF_WDT_Type * p_reg, uint32_t mask);
+
+#if NRF_WDT_HAS_NMI
+/**
+ * @brief Function for enabling the specified non-maskable interrupts.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ * @param[in] mask  Mask of interrupts to be enabled.
+ */
+NRF_STATIC_INLINE void nrf_wdt_nmi_int_enable(NRF_WDT_Type * p_reg, uint32_t mask);
+
+/**
+ * @brief Function for checking if the specified non-maskable interrupts are enabled.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ * @param[in] mask  Mask of interrupts to be checked.
+ *
+ * @return Mask of enabled interrupts.
+ */
+NRF_STATIC_INLINE uint32_t nrf_wdt_nmi_int_enable_check(NRF_WDT_Type const * p_reg, uint32_t mask);
+
+/**
+ * @brief Function for disabling a specified non-maskable interrupts.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ * @param[in] mask  Mask of interrupts to be disabled.
+ */
+NRF_STATIC_INLINE void nrf_wdt_nmi_int_disable(NRF_WDT_Type * p_reg, uint32_t mask);
+#endif
 
 #if defined(DPPI_PRESENT) || defined(__NRFX_DOXYGEN__)
 /**
@@ -219,7 +283,7 @@ NRF_STATIC_INLINE void nrf_wdt_publish_clear(NRF_WDT_Type * p_reg, nrf_wdt_event
  * @param[in] p_reg Pointer to the structure of registers of the peripheral.
  * @param[in] task  Task.
  *
- * @return Address of requested task register
+ * @return Address of requested task register.
  */
 NRF_STATIC_INLINE uint32_t nrf_wdt_task_address_get(NRF_WDT_Type const * p_reg,
                                                     nrf_wdt_task_t       task);
@@ -230,7 +294,7 @@ NRF_STATIC_INLINE uint32_t nrf_wdt_task_address_get(NRF_WDT_Type const * p_reg,
  * @param[in] p_reg Pointer to the structure of registers of the peripheral.
  * @param[in] event Event.
  *
- * @return Address of requested event register
+ * @return Address of requested event register.
  */
 NRF_STATIC_INLINE uint32_t nrf_wdt_event_address_get(NRF_WDT_Type const * p_reg,
                                                      nrf_wdt_event_t      event);
@@ -243,10 +307,10 @@ NRF_STATIC_INLINE uint32_t nrf_wdt_event_address_get(NRF_WDT_Type const * p_reg,
  * @retval true  The watchdog is started.
  * @retval false The watchdog is not started.
  */
-NRF_STATIC_INLINE bool nrf_wdt_started(NRF_WDT_Type const * p_reg);
+NRF_STATIC_INLINE bool nrf_wdt_started_check(NRF_WDT_Type const * p_reg);
 
 /**
- * @brief Function for retrieving the watchdog reload request status.
+ * @brief Function for retrieving the watchdog reload request status for specified register.
  *
  * @param[in] p_reg       Pointer to the structure of registers of the peripheral.
  * @param[in] rr_register Reload request register to be checked.
@@ -254,8 +318,17 @@ NRF_STATIC_INLINE bool nrf_wdt_started(NRF_WDT_Type const * p_reg);
  * @retval true  Reload request is running.
  * @retval false No reload requests are running.
  */
-NRF_STATIC_INLINE bool nrf_wdt_request_status(NRF_WDT_Type const *  p_reg,
-                                              nrf_wdt_rr_register_t rr_register);
+NRF_STATIC_INLINE bool nrf_wdt_request_status_check(NRF_WDT_Type const *  p_reg,
+                                                    nrf_wdt_rr_register_t rr_register);
+
+/**
+ * @brief Function for retrieving the watchdog reload requests status mask.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ *
+ * @return Running reload requests mask, constructed with @ref nrf_wdt_rr_register_mask_t.
+ */
+NRF_STATIC_INLINE uint32_t nrf_wdt_request_status_get(NRF_WDT_Type const * p_reg);
 
 /**
  * @brief Function for setting the watchdog reload value.
@@ -301,8 +374,8 @@ NRF_STATIC_INLINE void nrf_wdt_reload_request_disable(NRF_WDT_Type *        p_re
  * @retval true  The reload request register is enabled.
  * @retval false The reload request register is not enabled.
  */
-NRF_STATIC_INLINE bool nrf_wdt_reload_request_is_enabled(NRF_WDT_Type const *  p_reg,
-                                                         nrf_wdt_rr_register_t rr_register);
+NRF_STATIC_INLINE bool nrf_wdt_reload_request_enable_check(NRF_WDT_Type const *  p_reg,
+                                                           nrf_wdt_rr_register_t rr_register);
 
 /**
  * @brief Function for setting a specific reload request register.
@@ -313,11 +386,20 @@ NRF_STATIC_INLINE bool nrf_wdt_reload_request_is_enabled(NRF_WDT_Type const *  p
 NRF_STATIC_INLINE void nrf_wdt_reload_request_set(NRF_WDT_Type *        p_reg,
                                                   nrf_wdt_rr_register_t rr_register);
 
+#if defined(WDT_TSEN_TSEN_Msk)
+/**
+ * @brief Function for enabling task stop.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ */
+NRF_STATIC_INLINE void nrf_wdt_task_stop_enable(NRF_WDT_Type * p_reg);
+#endif
+
 #ifndef NRF_DECLARE_ONLY
 
-NRF_STATIC_INLINE void nrf_wdt_behaviour_set(NRF_WDT_Type * p_reg, nrf_wdt_behaviour_t behaviour)
+NRF_STATIC_INLINE void nrf_wdt_behaviour_set(NRF_WDT_Type * p_reg, uint32_t mask)
 {
-    p_reg->CONFIG = behaviour;
+    p_reg->CONFIG = mask;
 }
 
 NRF_STATIC_INLINE void nrf_wdt_task_trigger(NRF_WDT_Type * p_reg, nrf_wdt_task_t task)
@@ -351,13 +433,30 @@ NRF_STATIC_INLINE void nrf_wdt_int_disable(NRF_WDT_Type * p_reg, uint32_t mask)
     p_reg->INTENCLR = mask;
 }
 
+#if NRF_WDT_HAS_NMI
+NRF_STATIC_INLINE void nrf_wdt_nmi_int_enable(NRF_WDT_Type * p_reg, uint32_t mask)
+{
+    p_reg->NMIENSET = mask;
+}
+
+NRF_STATIC_INLINE uint32_t nrf_wdt_nmi_int_enable_check(NRF_WDT_Type const * p_reg, uint32_t mask)
+{
+    return p_reg->NMIENSET & mask;
+}
+
+NRF_STATIC_INLINE void nrf_wdt_nmi_int_disable(NRF_WDT_Type * p_reg, uint32_t mask)
+{
+    p_reg->NMIENCLR = mask;
+}
+#endif
+
 #if defined(DPPI_PRESENT)
 NRF_STATIC_INLINE void nrf_wdt_subscribe_set(NRF_WDT_Type * p_reg,
                                              nrf_wdt_task_t task,
                                              uint8_t        channel)
 {
     *((volatile uint32_t *) ((uint8_t *) p_reg + (uint32_t) task + 0x80uL)) =
-            ((uint32_t)channel | WDT_SUBSCRIBE_START_EN_Msk);
+            ((uint32_t)channel | NRF_SUBSCRIBE_PUBLISH_ENABLE);
 }
 
 NRF_STATIC_INLINE void nrf_wdt_subscribe_clear(NRF_WDT_Type * p_reg, nrf_wdt_task_t task)
@@ -370,7 +469,7 @@ NRF_STATIC_INLINE void nrf_wdt_publish_set(NRF_WDT_Type *  p_reg,
                                            uint8_t         channel)
 {
     *((volatile uint32_t *) ((uint8_t *) p_reg + (uint32_t) event + 0x80uL)) =
-            ((uint32_t)channel | WDT_PUBLISH_TIMEOUT_EN_Msk);
+            ((uint32_t)channel | NRF_SUBSCRIBE_PUBLISH_ENABLE);
 }
 
 NRF_STATIC_INLINE void nrf_wdt_publish_clear(NRF_WDT_Type * p_reg, nrf_wdt_event_t event)
@@ -391,15 +490,24 @@ NRF_STATIC_INLINE uint32_t nrf_wdt_event_address_get(NRF_WDT_Type const * p_reg,
     return ((uint32_t)p_reg + (uint32_t)event);
 }
 
-NRF_STATIC_INLINE bool nrf_wdt_started(NRF_WDT_Type const * p_reg)
+NRF_STATIC_INLINE bool nrf_wdt_started_check(NRF_WDT_Type const * p_reg)
 {
-    return (bool)(p_reg->RUNSTATUS);
+#if defined(WDT_RUNSTATUS_RUNSTATUS_Msk)
+    return (bool)(p_reg->RUNSTATUS & WDT_RUNSTATUS_RUNSTATUS_Msk);
+#else
+    return (bool)(p_reg->RUNSTATUS & WDT_RUNSTATUS_RUNSTATUSWDT_Msk);
+#endif
 }
 
-NRF_STATIC_INLINE bool nrf_wdt_request_status(NRF_WDT_Type const *  p_reg,
-                                              nrf_wdt_rr_register_t rr_register)
+NRF_STATIC_INLINE bool nrf_wdt_request_status_check(NRF_WDT_Type const *  p_reg,
+                                                    nrf_wdt_rr_register_t rr_register)
 {
     return (bool)(((p_reg->REQSTATUS) >> rr_register) & 0x1UL);
+}
+
+NRF_STATIC_INLINE uint32_t nrf_wdt_request_status_get(NRF_WDT_Type const * p_reg)
+{
+    return p_reg->REQSTATUS;
 }
 
 NRF_STATIC_INLINE void nrf_wdt_reload_value_set(NRF_WDT_Type * p_reg, uint32_t reload_value)
@@ -424,8 +532,8 @@ NRF_STATIC_INLINE void nrf_wdt_reload_request_disable(NRF_WDT_Type *        p_re
     p_reg->RREN &= ~(0x1UL << rr_register);
 }
 
-NRF_STATIC_INLINE bool nrf_wdt_reload_request_is_enabled(NRF_WDT_Type const *  p_reg,
-                                                         nrf_wdt_rr_register_t rr_register)
+NRF_STATIC_INLINE bool nrf_wdt_reload_request_enable_check(NRF_WDT_Type const *  p_reg,
+                                                           nrf_wdt_rr_register_t rr_register)
 {
     return (bool)(p_reg->RREN & (0x1UL << rr_register));
 }
@@ -435,6 +543,13 @@ NRF_STATIC_INLINE void nrf_wdt_reload_request_set(NRF_WDT_Type *        p_reg,
 {
     p_reg->RR[rr_register] = NRF_WDT_RR_VALUE;
 }
+
+#if defined(WDT_TSEN_TSEN_Msk)
+NRF_STATIC_INLINE void nrf_wdt_task_stop_enable(NRF_WDT_Type * p_reg)
+{
+    p_reg->TSEN = NRF_WDT_RR_VALUE;
+}
+#endif
 
 #endif // NRF_DECLARE_ONLY
 

--- a/nrfx/haly/nrfy_common.h
+++ b/nrfx/haly/nrfy_common.h
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2021 - 2023, Nordic Semiconductor ASA
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef NRFY_COMMON_H__
+#define NRFY_COMMON_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @defgroup nrfy_common Common nrfy module
+ * @{
+ * @ingroup nrfx
+ * @brief Common nrfy module.
+ */
+
+/**
+ * @brief Macro for calculating interrupt bit position associated with the specified event.
+ *
+ * @param[in] event Event.
+ *
+ * @return Interrupt bit position.
+ */
+#define NRFY_EVENT_TO_INT_BITPOS(event) ((((uint32_t)event) - 0x100) >> 2)
+
+/**
+ * @brief Macro for calculating interrupt bitmask associated with the specified event.
+ *
+ * @param[in] event Event.
+ *
+ * @return Interrupt bitmask.
+ */
+#define NRFY_EVENT_TO_INT_BITMASK(event) (1 << NRFY_EVENT_TO_INT_BITPOS(event))
+
+/** @sa NRFX_IRQ_PRIORITY_SET */
+#define NRFY_IRQ_PRIORITY_SET(irq_number, priority) NRFX_IRQ_PRIORITY_SET(irq_number, priority)
+
+/** @sa NRFX_IRQ_ENABLE */
+#define NRFY_IRQ_ENABLE(irq_number) NRFX_IRQ_ENABLE(irq_number)
+
+/** @sa NRFX_IRQ_IS_ENABLED */
+#define NRFY_IRQ_IS_ENABLED(irq_number) NRFX_IRQ_IS_ENABLED(irq_number)
+
+/** @sa NRFX_IRQ_DISABLE */
+#define NRFY_IRQ_DISABLE(irq_number) NRFX_IRQ_DISABLE(irq_number)
+
+/** @sa NRFX_IRQ_PENDING_SET */
+#define NRFY_IRQ_PENDING_SET(irq_number) NRFX_IRQ_PENDING_SET(irq_number)
+
+/** @sa NRFX_IRQ_PENDING_CLEAR */
+#define NRFY_IRQ_PENDING_CLEAR(irq_number) NRFX_IRQ_PENDING_CLEAR(irq_number)
+
+/** @sa NRFX_IRQ_IS_PENDING */
+#define NRFY_IRQ_IS_PENDING(irq_number) NRFX_IRQ_IS_PENDING(irq_number)
+
+/** @sa NRFX_CRITICAL_SECTION_ENTER */
+#define NRFY_CRITICAL_SECTION_ENTER() NRFX_CRITICAL_SECTION_ENTER()
+
+/** @sa NRFX_CRITICAL_SECTION_EXIT */
+#define NRFY_CRITICAL_SECTION_EXIT() NRFX_CRITICAL_SECTION_EXIT()
+
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // NRFY_COMMON_H__

--- a/nrfx/haly/nrfy_comp.h
+++ b/nrfx/haly/nrfy_comp.h
@@ -1,0 +1,408 @@
+/*
+ * Copyright (c) 2021 - 2023, Nordic Semiconductor ASA
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef NRFY_COMP_H__
+#define NRFY_COMP_H__
+
+#include <nrfx.h>
+#include <hal/nrf_comp.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+NRFY_STATIC_INLINE void __nrfy_internal_comp_event_enabled_clear(NRF_COMP_Type *  p_reg,
+                                                                 uint32_t         mask,
+                                                                 nrf_comp_event_t event);
+
+NRFY_STATIC_INLINE bool __nrfy_internal_comp_event_handle(NRF_COMP_Type *  p_reg,
+                                                          uint32_t         mask,
+                                                          nrf_comp_event_t event,
+                                                          uint32_t *       p_evt_mask);
+
+NRFY_STATIC_INLINE uint32_t __nrfy_internal_comp_events_process(NRF_COMP_Type * p_reg,
+                                                                uint32_t        mask);
+
+/**
+ * @defgroup nrfy_comp COMP HALY
+ * @{
+ * @ingroup nrf_comp
+ * @brief   Hardware access layer with cache and barrier support for managing the COMP peripheral.
+ */
+
+#if NRF_COMP_HAS_ISOURCE || defined(__NRFX_DOXYGEN__)
+/** @refhal{NRF_COMP_HAS_ISOURCE} */
+#define NRFY_COMP_HAS_ISOURCE 1
+#else
+#define NRFY_COMP_HAS_ISOURCE 0
+#endif
+
+/** @brief COMP configuration structure. */
+typedef struct
+{
+    nrf_comp_ref_t       reference;  ///< Reference selection.
+    nrf_comp_ext_ref_t   ext_ref;    ///< External analog reference selection.
+    nrf_comp_main_mode_t main_mode;  ///< Main operation mode.
+    nrf_comp_th_t        threshold;  ///< Structure holding THDOWN and THUP values needed by the COMP_TH register.
+    nrf_comp_sp_mode_t   speed_mode; ///< Speed and power mode.
+    nrf_comp_hyst_t      hyst;       ///< Comparator hysteresis.
+#if NRFY_COMP_HAS_ISOURCE
+    nrf_isource_t        isource;    ///< Current source selected on analog input.
+#endif
+    nrf_comp_input_t     input;      ///< Input to be monitored.
+} nrfy_comp_config_t;
+
+/**
+ * @brief Function for configuring the COMP.
+ *
+ * @param[in] p_reg    Pointer to the structure of registers of the peripheral.
+ * @param[in] p_config Pointer to the peripheral configuration structure.
+ */
+NRFY_STATIC_INLINE void nrfy_comp_periph_configure(NRF_COMP_Type *            p_reg,
+                                                   nrfy_comp_config_t const * p_config)
+{
+    nrf_comp_ref_set(p_reg, p_config->reference);
+    if (p_config->reference == NRF_COMP_REF_AREF)
+    {
+        nrf_comp_ext_ref_set(p_reg, p_config->ext_ref);
+    }
+    nrf_comp_th_set(p_reg, p_config->threshold);
+    nrf_comp_main_mode_set(p_reg, p_config->main_mode);
+    nrf_comp_speed_mode_set(p_reg, p_config->speed_mode);
+    nrf_comp_hysteresis_set(p_reg, p_config->hyst);
+#if NRF_COMP_HAS_ISOURCE
+    nrf_comp_isource_set(p_reg, p_config->isource);
+#endif
+    nrf_comp_input_select(p_reg, p_config->input);
+    nrf_barrier_w();
+}
+
+/**
+ * @brief Function for initializing the specified COMP interrupts.
+ *
+ * @param[in] p_reg        Pointer to the structure of registers of the peripheral.
+ * @param[in] mask         Mask of interrupts to be initialized.
+ * @param[in] irq_priority Interrupt priority.
+ * @param[in] enable       True if the interrupts are to be enabled, false otherwise.
+ */
+NRFY_STATIC_INLINE void nrfy_comp_int_init(NRF_COMP_Type * p_reg,
+                                           uint32_t        mask,
+                                           uint8_t         irq_priority,
+                                           bool            enable)
+{
+
+    __nrfy_internal_comp_event_enabled_clear(p_reg, mask, NRF_COMP_EVENT_READY);
+    __nrfy_internal_comp_event_enabled_clear(p_reg, mask, NRF_COMP_EVENT_DOWN);
+    __nrfy_internal_comp_event_enabled_clear(p_reg, mask, NRF_COMP_EVENT_UP);
+    __nrfy_internal_comp_event_enabled_clear(p_reg, mask, NRF_COMP_EVENT_CROSS);
+    nrf_barrier_w();
+
+    NRFY_IRQ_PRIORITY_SET(nrfx_get_irq_number(p_reg), irq_priority);
+    NRFY_IRQ_ENABLE(nrfx_get_irq_number(p_reg));
+    if (enable)
+    {
+        nrf_comp_int_enable(p_reg, mask);
+    }
+    nrf_barrier_w();
+}
+
+/**
+ * @brief Function for uninitializing the COMP interrupts.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ */
+ NRFY_STATIC_INLINE void nrfy_comp_int_uninit(NRF_COMP_Type * p_reg)
+ {
+    NRFY_IRQ_DISABLE(nrfx_get_irq_number(p_reg));
+    nrf_barrier_w();
+ }
+
+/**
+ * @brief Function for processing the specified COMP events.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ * @param[in] mask  Mask of events to be processed, created by @ref NRFY_EVENT_TO_INT_BITMASK().
+ *
+ * @return Mask of events that were generated and processed.
+ *         To be checked against the result of @ref NRFY_EVENT_TO_INT_BITMASK().
+ */
+NRFY_STATIC_INLINE uint32_t nrfy_comp_events_process(NRF_COMP_Type * p_reg,
+                                                     uint32_t        mask)
+{
+    uint32_t evt_mask = __nrfy_internal_comp_events_process(p_reg, mask);
+    nrf_barrier_w();
+    return evt_mask;
+}
+
+/**
+ * @brief Function for reading the current state of the COMP.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ *
+ * @retval 0 The input voltage is below the threshold.
+ * @retval 1 The input voltage is above the threshold.
+ */
+NRFY_STATIC_INLINE uint32_t nrfy_comp_sample(NRF_COMP_Type * p_reg)
+{
+    nrf_comp_task_trigger(p_reg, NRF_COMP_TASK_SAMPLE);
+    nrf_barrier_rw();
+    uint32_t sample = nrf_comp_result_get(p_reg);
+    nrf_barrier_r();
+    return sample;
+}
+
+/** @refhal{nrf_comp_enable} */
+NRFY_STATIC_INLINE void nrfy_comp_enable(NRF_COMP_Type * p_reg)
+{
+    nrf_comp_enable(p_reg);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_comp_disable} */
+NRFY_STATIC_INLINE void nrfy_comp_disable(NRF_COMP_Type * p_reg)
+{
+    nrf_comp_disable(p_reg);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_comp_enable_check} */
+NRFY_STATIC_INLINE bool nrfy_comp_enable_check(NRF_COMP_Type const * p_reg)
+{
+    nrf_barrier_rw();
+    bool check = nrf_comp_enable_check(p_reg);
+    nrf_barrier_r();
+    return check;
+}
+
+/** @refhal{nrf_comp_ref_set} */
+NRFY_STATIC_INLINE void nrfy_comp_ref_set(NRF_COMP_Type * p_reg, nrf_comp_ref_t reference)
+{
+    nrf_comp_ref_set(p_reg, reference);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_comp_ext_ref_set} */
+NRFY_STATIC_INLINE void nrfy_comp_ext_ref_set(NRF_COMP_Type * p_reg, nrf_comp_ext_ref_t ext_ref)
+{
+    nrf_comp_ext_ref_set(p_reg, ext_ref);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_comp_th_set} */
+NRFY_STATIC_INLINE void nrfy_comp_th_set(NRF_COMP_Type * p_reg, nrf_comp_th_t threshold)
+{
+    nrf_comp_th_set(p_reg, threshold);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_comp_main_mode_set} */
+NRFY_STATIC_INLINE void nrfy_comp_main_mode_set(NRF_COMP_Type *      p_reg,
+                                                nrf_comp_main_mode_t main_mode)
+{
+    nrf_comp_main_mode_set(p_reg, main_mode);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_comp_speed_mode_set} */
+NRFY_STATIC_INLINE void nrfy_comp_speed_mode_set(NRF_COMP_Type *    p_reg,
+                                                 nrf_comp_sp_mode_t speed_mode)
+{
+    nrf_comp_speed_mode_set(p_reg, speed_mode);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_comp_hysteresis_set} */
+NRFY_STATIC_INLINE void nrfy_comp_hysteresis_set(NRF_COMP_Type * p_reg, nrf_comp_hyst_t hyst)
+{
+    nrf_comp_hysteresis_set(p_reg, hyst);
+    nrf_barrier_w();
+}
+
+#if NRFY_COMP_HAS_ISOURCE
+/** @refhal{nrf_comp_isource_set} */
+NRFY_STATIC_INLINE void nrfy_comp_isource_set(NRF_COMP_Type * p_reg, nrf_isource_t isource)
+{
+    nrf_comp_isource_set(p_reg, isource);
+    nrf_barrier_w();
+}
+#endif
+
+/** @refhal{nrf_comp_input_select} */
+NRFY_STATIC_INLINE void nrfy_comp_input_select(NRF_COMP_Type * p_reg, nrf_comp_input_t input)
+{
+    nrf_comp_input_select(p_reg, input);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_comp_result_get} */
+NRFY_STATIC_INLINE uint32_t nrfy_comp_result_get(NRF_COMP_Type const * p_reg)
+{
+    nrf_barrier_rw();
+    uint32_t result = nrf_comp_result_get(p_reg);
+    nrf_barrier_r();
+    return result;
+}
+
+/** @refhal{nrf_comp_int_enable} */
+NRFY_STATIC_INLINE void nrfy_comp_int_enable(NRF_COMP_Type * p_reg, uint32_t mask)
+{
+    nrf_comp_int_enable(p_reg, mask);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_comp_int_disable} */
+NRFY_STATIC_INLINE void nrfy_comp_int_disable(NRF_COMP_Type * p_reg, uint32_t mask)
+{
+    nrf_comp_int_disable(p_reg, mask);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_comp_int_enable_check} */
+NRFY_STATIC_INLINE uint32_t nrfy_comp_int_enable_check(NRF_COMP_Type const * p_reg, uint32_t mask)
+{
+    nrf_barrier_rw();
+    uint32_t check = nrf_comp_int_enable_check(p_reg, mask);
+    nrf_barrier_r();
+    return check;
+}
+
+/** @refhal{nrf_comp_task_address_get} */
+NRFY_STATIC_INLINE uint32_t nrfy_comp_task_address_get(NRF_COMP_Type const * p_reg,
+                                                       nrf_comp_task_t       task)
+{
+    return nrf_comp_task_address_get(p_reg, task);
+}
+
+/** @refhal{nrf_comp_event_address_get} */
+NRFY_STATIC_INLINE uint32_t nrfy_comp_event_address_get(NRF_COMP_Type const * p_reg,
+                                                        nrf_comp_event_t      event)
+{
+    return nrf_comp_event_address_get(p_reg, event);
+}
+
+/** @refhal{nrf_comp_shorts_enable} */
+NRFY_STATIC_INLINE void nrfy_comp_shorts_enable(NRF_COMP_Type * p_reg, uint32_t mask)
+{
+    nrf_comp_shorts_enable(p_reg, mask);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_comp_shorts_disable} */
+NRFY_STATIC_INLINE void nrfy_comp_shorts_disable(NRF_COMP_Type * p_reg, uint32_t mask)
+{
+    nrf_comp_shorts_disable(p_reg, mask);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_comp_task_trigger} */
+NRFY_STATIC_INLINE void nrfy_comp_task_trigger(NRF_COMP_Type * p_reg, nrf_comp_task_t task)
+{
+    nrf_comp_task_trigger(p_reg, task);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_comp_event_clear} */
+NRFY_STATIC_INLINE void nrfy_comp_event_clear(NRF_COMP_Type * p_reg, nrf_comp_event_t event)
+{
+    nrf_comp_event_clear(p_reg, event);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_comp_event_check} */
+NRFY_STATIC_INLINE bool nrfy_comp_event_check(NRF_COMP_Type const * p_reg, nrf_comp_event_t event)
+{
+    nrf_barrier_rw();
+    bool check = nrf_comp_event_check(p_reg, event);
+    nrf_barrier_r();
+    return check;
+}
+
+/** @} */
+
+NRFY_STATIC_INLINE void __nrfy_internal_comp_event_enabled_clear(NRF_COMP_Type *  p_reg,
+                                                                 uint32_t         mask,
+                                                                 nrf_comp_event_t event)
+{
+    if (mask & NRFY_EVENT_TO_INT_BITMASK(event))
+    {
+        nrf_comp_event_clear(p_reg, event);
+    }
+}
+
+NRFY_STATIC_INLINE bool __nrfy_internal_comp_event_handle(NRF_COMP_Type *  p_reg,
+                                                          uint32_t         mask,
+                                                          nrf_comp_event_t event,
+                                                          uint32_t *       p_evt_mask)
+{
+    if ((mask & NRFY_EVENT_TO_INT_BITMASK(event)) && nrf_comp_event_check(p_reg, event))
+    {
+        nrf_comp_event_clear(p_reg, event);
+        if (p_evt_mask)
+        {
+            *p_evt_mask |= NRFY_EVENT_TO_INT_BITMASK(event);
+        }
+        return true;
+    }
+    return false;
+}
+
+NRFY_STATIC_INLINE uint32_t __nrfy_internal_comp_events_process(NRF_COMP_Type * p_reg,
+                                                                uint32_t        mask)
+{
+    uint32_t event_mask = 0;
+
+    nrf_barrier_r();
+    (void)__nrfy_internal_comp_event_handle(p_reg,
+                                            mask,
+                                            NRF_COMP_EVENT_READY,
+                                            &event_mask);
+    (void)__nrfy_internal_comp_event_handle(p_reg,
+                                            mask,
+                                            NRF_COMP_EVENT_DOWN,
+                                            &event_mask);
+    (void)__nrfy_internal_comp_event_handle(p_reg,
+                                            mask,
+                                            NRF_COMP_EVENT_UP,
+                                            &event_mask);
+    (void)__nrfy_internal_comp_event_handle(p_reg,
+                                            mask,
+                                            NRF_COMP_EVENT_CROSS,
+                                            &event_mask);
+    return event_mask;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // NRFY_COMP_H__

--- a/nrfx/haly/nrfy_dppi.h
+++ b/nrfx/haly/nrfy_dppi.h
@@ -1,0 +1,208 @@
+/*
+ * Copyright (c) 2021 - 2023, Nordic Semiconductor ASA
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef NRFY_DPPI_H__
+#define NRFY_DPPI_H__
+
+#include <nrfx.h>
+#include <hal/nrf_dppi.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @defgroup nrfy_dppi DPPI HALY
+ * @{
+ * @ingroup nrf_dppi
+ * @brief   Hardware access layer with cache and barrier support for managing the DPPI peripheral.
+ */
+
+/**
+ * @brief Function for enabling or disabling multiple DPPI channels.
+ *
+ * The bits in @c mask value correspond to particular channels. It means that
+ * writing 1 to bit 0 enables or disables channel 0,
+ * writing 1 to bit 1 enables or disables channel 1 etc.
+ *
+ * @param[in] p_reg  Pointer to the structure of registers of the peripheral.
+ * @param[in] mask   Channel mask.
+ * @param[in] enable True if specified channels are to be enabled, false otherwise.
+ */
+NRFY_STATIC_INLINE void nrfy_dppi_channels_set(NRF_DPPIC_Type * p_reg, uint32_t mask, bool enable)
+{
+    if (enable == true)
+    {
+        nrf_dppi_channels_enable(p_reg, mask);
+    }
+    else
+    {
+        nrf_dppi_channels_disable(p_reg, mask);
+    }
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_dppi_channel_number_get} */
+NRF_STATIC_INLINE uint8_t nrfy_dppi_channel_number_get(NRF_DPPIC_Type const * p_reg)
+{
+    return nrf_dppi_channel_number_get(p_reg);
+}
+
+/** @refhal{nrf_dppi_group_number_get} */
+NRF_STATIC_INLINE uint8_t nrfy_dppi_group_number_get(NRF_DPPIC_Type const * p_reg)
+{
+    return nrf_dppi_group_number_get(p_reg);
+}
+
+/** @refhal{nrf_dppi_task_trigger} */
+NRFY_STATIC_INLINE void nrfy_dppi_task_trigger(NRF_DPPIC_Type * p_reg, nrf_dppi_task_t dppi_task)
+{
+    nrf_dppi_task_trigger(p_reg, dppi_task);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_dppi_task_address_get} */
+NRFY_STATIC_INLINE uint32_t nrfy_dppi_task_address_get(NRF_DPPIC_Type const * p_reg,
+                                                       nrf_dppi_task_t        task)
+{
+    return nrf_dppi_task_address_get(p_reg, task);
+}
+
+/** @refhal{nrf_dppi_channel_check} */
+NRFY_STATIC_INLINE bool nrfy_dppi_channel_check(NRF_DPPIC_Type const * p_reg, uint8_t channel)
+{
+    nrf_barrier_rw();
+    bool check = nrf_dppi_channel_check(p_reg, channel);
+    nrf_barrier_r();
+    return check;
+}
+
+/** @refhal{nrf_dppi_channels_enable} */
+NRFY_STATIC_INLINE void nrfy_dppi_channels_enable(NRF_DPPIC_Type * p_reg, uint32_t mask)
+{
+    nrf_dppi_channels_enable(p_reg, mask);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_dppi_channels_disable} */
+NRFY_STATIC_INLINE void nrfy_dppi_channels_disable(NRF_DPPIC_Type * p_reg, uint32_t mask)
+{
+    nrf_dppi_channels_disable(p_reg, mask);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_dppi_channels_disable_all} */
+NRFY_STATIC_INLINE void nrfy_dppi_channels_disable_all(NRF_DPPIC_Type * p_reg)
+{
+    nrf_dppi_channels_disable_all(p_reg);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_dppi_subscribe_set} */
+NRFY_STATIC_INLINE void nrfy_dppi_subscribe_set(NRF_DPPIC_Type * p_reg,
+                                                nrf_dppi_task_t  task,
+                                                uint8_t          channel)
+{
+    nrf_dppi_subscribe_set(p_reg, task, channel);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_dppi_subscribe_clear} */
+NRFY_STATIC_INLINE void nrfy_dppi_subscribe_clear(NRF_DPPIC_Type * p_reg, nrf_dppi_task_t task)
+{
+    nrf_dppi_subscribe_clear(p_reg, task);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_dppi_channels_include_in_group} */
+NRFY_STATIC_INLINE void nrfy_dppi_channels_include_in_group(NRF_DPPIC_Type *         p_reg,
+                                                            uint32_t                 channel_mask,
+                                                            nrf_dppi_channel_group_t channel_group)
+{
+    nrf_dppi_channels_include_in_group(p_reg, channel_mask, channel_group);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_dppi_channels_remove_from_group} */
+NRFY_STATIC_INLINE
+void nrfy_dppi_channels_remove_from_group(NRF_DPPIC_Type *         p_reg,
+                                          uint32_t                 channel_mask,
+                                          nrf_dppi_channel_group_t channel_group)
+{
+    nrf_dppi_channels_remove_from_group(p_reg, channel_mask, channel_group);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_dppi_group_clear} */
+NRFY_STATIC_INLINE void nrfy_dppi_group_clear(NRF_DPPIC_Type *         p_reg,
+                                              nrf_dppi_channel_group_t group)
+{
+    nrf_dppi_group_clear(p_reg, group);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_dppi_group_enable} */
+NRFY_STATIC_INLINE void nrfy_dppi_group_enable(NRF_DPPIC_Type *         p_reg,
+                                               nrf_dppi_channel_group_t group)
+{
+    nrf_dppi_group_enable(p_reg, group);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_dppi_group_disable} */
+NRFY_STATIC_INLINE void nrfy_dppi_group_disable(NRF_DPPIC_Type *         p_reg,
+                                                nrf_dppi_channel_group_t group)
+{
+    nrf_dppi_group_disable(p_reg, group);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_dppi_group_enable_task_get} */
+NRFY_STATIC_INLINE nrf_dppi_task_t nrfy_dppi_group_enable_task_get(uint8_t index)
+{
+    return nrf_dppi_group_enable_task_get(index);
+}
+
+/** @refhal{nrf_dppi_group_disable_task_get} */
+NRFY_STATIC_INLINE nrf_dppi_task_t nrfy_dppi_group_disable_task_get(uint8_t index)
+{
+    return nrf_dppi_group_disable_task_get(index);
+}
+
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // NRFY_DPPI_H__

--- a/nrfx/haly/nrfy_gpio.h
+++ b/nrfx/haly/nrfy_gpio.h
@@ -1,0 +1,399 @@
+/*
+ * Copyright (c) 2021 - 2023, Nordic Semiconductor ASA
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef NRFY_GPIO_H__
+#define NRFY_GPIO_H__
+
+#include <nrfx.h>
+#include <hal/nrf_gpio.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @defgroup nrfy_gpio GPIO HALY
+ * @{
+ * @ingroup nrf_gpio
+ * @brief   Hardware access layer with cache and barrier support for managing the GPIO peripheral.
+ */
+
+/** @refhal{nrf_gpio_range_cfg_output} */
+NRFY_STATIC_INLINE void nrfy_gpio_range_cfg_output(uint32_t pin_range_start,
+                                                   uint32_t pin_range_end)
+{
+    nrf_gpio_range_cfg_output(pin_range_start, pin_range_end);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_gpio_range_cfg_input} */
+NRFY_STATIC_INLINE void nrfy_gpio_range_cfg_input(uint32_t            pin_range_start,
+                                                  uint32_t            pin_range_end,
+                                                  nrf_gpio_pin_pull_t pull_config)
+{
+    nrf_gpio_range_cfg_input(pin_range_start, pin_range_end, pull_config);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_gpio_cfg} */
+NRFY_STATIC_INLINE void nrfy_gpio_cfg(uint32_t             pin_number,
+                                      nrf_gpio_pin_dir_t   dir,
+                                      nrf_gpio_pin_input_t input,
+                                      nrf_gpio_pin_pull_t  pull,
+                                      nrf_gpio_pin_drive_t drive,
+                                      nrf_gpio_pin_sense_t sense)
+{
+    nrf_gpio_cfg(pin_number, dir, input, pull, drive, sense);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_gpio_reconfigure} */
+NRFY_STATIC_INLINE void nrfy_gpio_reconfigure(uint32_t                     pin_number,
+                                              const nrf_gpio_pin_dir_t *   p_dir,
+                                              const nrf_gpio_pin_input_t * p_input,
+                                              const nrf_gpio_pin_pull_t *  p_pull,
+                                              const nrf_gpio_pin_drive_t * p_drive,
+                                              const nrf_gpio_pin_sense_t * p_sense)
+{
+    nrf_gpio_reconfigure(pin_number, p_dir, p_input, p_pull, p_drive, p_sense);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_gpio_cfg_output} */
+NRFY_STATIC_INLINE void nrfy_gpio_cfg_output(uint32_t pin_number)
+{
+    nrf_gpio_cfg_output(pin_number);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_gpio_cfg_input} */
+NRFY_STATIC_INLINE void nrfy_gpio_cfg_input(uint32_t pin_number, nrf_gpio_pin_pull_t pull_config)
+{
+    nrf_gpio_cfg_input(pin_number, pull_config);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_gpio_cfg_default} */
+NRFY_STATIC_INLINE void nrfy_gpio_cfg_default(uint32_t pin_number)
+{
+    nrf_gpio_cfg_default(pin_number);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_gpio_cfg_watcher} */
+NRFY_STATIC_INLINE void nrfy_gpio_cfg_watcher(uint32_t pin_number)
+{
+    nrf_barrier_r();
+    nrf_gpio_cfg_watcher(pin_number);
+    nrf_barrier_rw();
+}
+
+/** @refhal{nrf_gpio_input_disconnect} */
+NRFY_STATIC_INLINE void nrfy_gpio_input_disconnect(uint32_t pin_number)
+{
+    nrf_barrier_r();
+    nrf_gpio_input_disconnect(pin_number);
+    nrf_barrier_rw();
+}
+
+/** @refhal{nrf_gpio_cfg_sense_input} */
+NRFY_STATIC_INLINE void nrfy_gpio_cfg_sense_input(uint32_t             pin_number,
+                                                  nrf_gpio_pin_pull_t  pull_config,
+                                                  nrf_gpio_pin_sense_t sense_config)
+{
+    nrf_gpio_cfg_sense_input(pin_number, pull_config, sense_config);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_gpio_cfg_sense_set} */
+NRFY_STATIC_INLINE void nrfy_gpio_cfg_sense_set(uint32_t             pin_number,
+                                                nrf_gpio_pin_sense_t sense_config)
+{
+    nrf_barrier_r();
+    nrf_gpio_cfg_sense_set(pin_number, sense_config);
+    nrf_barrier_rw();
+}
+
+/** @refhal{nrf_gpio_pin_dir_set} */
+NRFY_STATIC_INLINE void nrfy_gpio_pin_dir_set(uint32_t pin_number, nrf_gpio_pin_dir_t direction)
+{
+    nrf_gpio_pin_dir_set(pin_number, direction);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_gpio_pin_set} */
+NRFY_STATIC_INLINE void nrfy_gpio_pin_set(uint32_t pin_number)
+{
+    nrf_gpio_pin_set(pin_number);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_gpio_pin_clear} */
+NRFY_STATIC_INLINE void nrfy_gpio_pin_clear(uint32_t pin_number)
+{
+    nrf_gpio_pin_clear(pin_number);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_gpio_pin_toggle} */
+NRFY_STATIC_INLINE void nrfy_gpio_pin_toggle(uint32_t pin_number)
+{
+    nrf_gpio_pin_toggle(pin_number);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_gpio_pin_write} */
+NRFY_STATIC_INLINE void nrfy_gpio_pin_write(uint32_t pin_number, uint32_t value)
+{
+    nrf_gpio_pin_write(pin_number, value);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_gpio_pin_read} */
+NRFY_STATIC_INLINE uint32_t nrfy_gpio_pin_read(uint32_t pin_number)
+{
+    nrf_barrier_r();
+    uint32_t pin = nrf_gpio_pin_read(pin_number);
+    nrf_barrier_r();
+    return pin;
+}
+
+/** @refhal{nrf_gpio_pin_out_read} */
+NRFY_STATIC_INLINE uint32_t nrfy_gpio_pin_out_read(uint32_t pin_number)
+{
+    nrf_barrier_rw();
+    uint32_t pin = nrf_gpio_pin_out_read(pin_number);
+    nrf_barrier_r();
+    return pin;
+}
+
+/** @refhal{nrf_gpio_pin_sense_get} */
+NRFY_STATIC_INLINE nrf_gpio_pin_sense_t nrfy_gpio_pin_sense_get(uint32_t pin_number)
+{
+    nrf_barrier_rw();
+    nrf_gpio_pin_sense_t pin_sense = nrf_gpio_pin_sense_get(pin_number);
+    nrf_barrier_r();
+    return pin_sense;
+}
+
+/** @refhal{nrf_gpio_pin_dir_get} */
+NRFY_STATIC_INLINE nrf_gpio_pin_dir_t nrfy_gpio_pin_dir_get(uint32_t pin_number)
+{
+    nrf_barrier_rw();
+    nrf_gpio_pin_dir_t pin_dir = nrf_gpio_pin_dir_get(pin_number);
+    nrf_barrier_r();
+    return pin_dir;
+}
+
+/** @refhal{nrf_gpio_pin_input_get} */
+NRFY_STATIC_INLINE nrf_gpio_pin_input_t nrfy_gpio_pin_input_get(uint32_t pin_number)
+{
+    nrf_barrier_rw();
+    nrf_gpio_pin_input_t pin_input = nrf_gpio_pin_input_get(pin_number);
+    nrf_barrier_r();
+    return pin_input;
+}
+
+/** @refhal{nrf_gpio_pin_pull_get} */
+NRFY_STATIC_INLINE nrf_gpio_pin_pull_t nrfy_gpio_pin_pull_get(uint32_t pin_number)
+{
+    nrf_barrier_rw();
+    nrf_gpio_pin_pull_t pin_pull = nrf_gpio_pin_pull_get(pin_number);
+    nrf_barrier_r();
+    return pin_pull;
+}
+
+/** @refhal{nrf_gpio_port_dir_output_set} */
+NRFY_STATIC_INLINE void nrfy_gpio_port_dir_output_set(NRF_GPIO_Type * p_reg, uint32_t out_mask)
+{
+    nrf_gpio_port_dir_output_set(p_reg, out_mask);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_gpio_port_dir_input_set} */
+NRFY_STATIC_INLINE void nrfy_gpio_port_dir_input_set(NRF_GPIO_Type * p_reg, uint32_t in_mask)
+{
+    nrf_gpio_port_dir_input_set(p_reg, in_mask);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_gpio_port_dir_write} */
+NRFY_STATIC_INLINE void nrfy_gpio_port_dir_write(NRF_GPIO_Type * p_reg, uint32_t dir_mask)
+{
+    nrf_gpio_port_dir_write(p_reg, dir_mask);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_gpio_port_dir_read} */
+NRFY_STATIC_INLINE uint32_t nrfy_gpio_port_dir_read(NRF_GPIO_Type const * p_reg)
+{
+    nrf_barrier_rw();
+    uint32_t port_dir = nrf_gpio_port_dir_read(p_reg);
+    nrf_barrier_r();
+    return port_dir;
+}
+
+/** @refhal{nrf_gpio_port_in_read} */
+NRFY_STATIC_INLINE uint32_t nrfy_gpio_port_in_read(NRF_GPIO_Type const * p_reg)
+{
+    nrf_barrier_rw();
+    uint32_t port_in = nrf_gpio_port_in_read(p_reg);
+    nrf_barrier_r();
+    return port_in;
+}
+
+/** @refhal{nrf_gpio_port_out_read} */
+NRFY_STATIC_INLINE uint32_t nrfy_gpio_port_out_read(NRF_GPIO_Type const * p_reg)
+{
+    nrf_barrier_rw();
+    uint32_t port_out = nrf_gpio_port_out_read(p_reg);
+    nrf_barrier_r();
+    return port_out;
+}
+
+/** @refhal{nrf_gpio_port_out_write} */
+NRFY_STATIC_INLINE void nrfy_gpio_port_out_write(NRF_GPIO_Type * p_reg, uint32_t value)
+{
+    nrf_gpio_port_out_write(p_reg, value);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_gpio_port_out_set} */
+NRFY_STATIC_INLINE void nrfy_gpio_port_out_set(NRF_GPIO_Type * p_reg, uint32_t set_mask)
+{
+    nrf_gpio_port_out_set(p_reg, set_mask);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_gpio_port_out_clear} */
+NRFY_STATIC_INLINE void nrfy_gpio_port_out_clear(NRF_GPIO_Type * p_reg, uint32_t clr_mask)
+{
+    nrf_gpio_port_out_clear(p_reg, clr_mask);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_gpio_ports_read} */
+NRFY_STATIC_INLINE void nrfy_gpio_ports_read(uint32_t   start_port,
+                                             uint32_t   length,
+                                             uint32_t * p_masks)
+{
+    nrf_barrier_r();
+    nrf_gpio_ports_read(start_port, length, p_masks);
+    nrf_barrier_r();
+}
+
+#if defined(NRF_GPIO_LATCH_PRESENT)
+/** @refhal{nrf_gpio_latches_read} */
+NRFY_STATIC_INLINE void nrfy_gpio_latches_read(uint32_t   start_port,
+                                               uint32_t   length,
+                                               uint32_t * p_masks)
+{
+    nrf_barrier_r();
+    nrf_gpio_latches_read(start_port, length, p_masks);
+    nrf_barrier_r();
+}
+
+/** @refhal{nrf_gpio_latches_read_and_clear} */
+NRFY_STATIC_INLINE void nrfy_gpio_latches_read_and_clear(uint32_t   start_port,
+                                                         uint32_t   length,
+                                                         uint32_t * p_masks)
+{
+    nrf_barrier_r();
+    nrf_gpio_latches_read_and_clear(start_port, length, p_masks);
+    nrf_barrier_rw();
+}
+
+/** @refhal{nrf_gpio_pin_latch_get} */
+NRFY_STATIC_INLINE uint32_t nrfy_gpio_pin_latch_get(uint32_t pin_number)
+{
+    nrf_barrier_r();
+    uint32_t pin_latch = nrf_gpio_pin_latch_get(pin_number);
+    nrf_barrier_r();
+    return pin_latch;
+}
+
+/** @refhal{nrf_gpio_pin_latch_clear} */
+NRFY_STATIC_INLINE void nrfy_gpio_pin_latch_clear(uint32_t pin_number)
+{
+    nrf_gpio_pin_latch_clear(pin_number);
+    nrf_barrier_w();
+}
+#endif // defined(NRF_GPIO_LATCH_PRESENT)
+
+#if NRF_GPIO_HAS_SEL
+/** @refhal{nrf_gpio_pin_control_select} */
+NRFY_STATIC_INLINE void nrfy_gpio_pin_control_select(uint32_t pin_number, nrf_gpio_pin_sel_t ctrl)
+{
+    nrf_barrier_r();
+    nrf_gpio_pin_control_select(pin_number, ctrl);
+    nrf_barrier_rw();
+}
+#endif
+
+#if NRF_GPIO_HAS_CLOCKPIN
+/** @refhal{nrf_gpio_pin_clock_set} */
+NRFY_STATIC_INLINE void nrfy_gpio_pin_clock_set(uint32_t pin_number, bool enable)
+{
+    nrf_gpio_pin_clock_set(pin_number, enable);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_gpio_pin_clock_check} */
+NRFY_STATIC_INLINE bool nrfy_gpio_pin_clock_check(uint32_t pin_number)
+{
+    nrf_barrier_rw();
+    bool pin_clock = nrf_gpio_pin_clock_check(pin_number);
+    nrf_barrier_r();
+    return pin_clock;
+}
+#endif
+
+/** @refhal{nrf_gpio_pin_present_check} */
+NRFY_STATIC_INLINE bool nrfy_gpio_pin_present_check(uint32_t pin_number)
+{
+    return nrf_gpio_pin_present_check(pin_number);
+}
+
+/** @refhal{nrf_gpio_pin_port_number_extract} */
+NRFY_STATIC_INLINE uint32_t nrfy_gpio_pin_port_number_extract(uint32_t * p_pin)
+{
+    return nrf_gpio_pin_port_number_extract(p_pin);
+}
+
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // NRFY_GPIO_H__

--- a/nrfx/haly/nrfy_gpiote.h
+++ b/nrfx/haly/nrfy_gpiote.h
@@ -1,0 +1,412 @@
+/*
+ * Copyright (c) 2021 - 2023, Nordic Semiconductor ASA
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef NRFY_GPIOTE_H__
+#define NRFY_GPIOTE_H__
+
+#include <nrfx.h>
+#include <hal/nrf_gpiote.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+NRFY_STATIC_INLINE void __nrfy_internal_gpiote_event_enabled_clear(NRF_GPIOTE_Type *  p_reg,
+                                                                   uint32_t           mask,
+                                                                   nrf_gpiote_event_t event);
+
+NRFY_STATIC_INLINE bool __nrfy_internal_gpiote_event_handle(NRF_GPIOTE_Type *  p_reg,
+                                                            uint32_t           mask,
+                                                            nrf_gpiote_event_t event,
+                                                            uint32_t *         p_evt_mask);
+
+NRFY_STATIC_INLINE uint32_t __nrfy_internal_gpiote_events_process(NRF_GPIOTE_Type * p_reg,
+                                                                  uint32_t          mask);
+
+/**
+ * @defgroup nrfy_gpiote GPIOTE HALY
+ * @{
+ * @ingroup nrf_gpiote
+ * @brief   Hardware access layer with cache and barrier support for managing the GPIOTE peripheral.
+ */
+
+#if NRF_GPIOTE_HAS_LATENCY || defined(__NRFX_DOXYGEN__)
+/** @refhal{NRF_GPIOTE_HAS_LATENCY} */
+#define NRFY_GPIOTE_HAS_LATENCY 1
+#else
+#define NRFY_GPIOTE_HAS_LATENCY 0
+#endif
+
+/**
+ * @brief Function for initializing the specified GPIOTE interrupts.
+ *
+ * @param[in] p_reg        Pointer to the structure of registers of the peripheral.
+ * @param[in] mask         Mask of interrupts to be initialized.
+ * @param[in] irq_priority Interrupt priority.
+ * @param[in] enable       True if the interrupts are to be enabled, false otherwise.
+ */
+NRFY_STATIC_INLINE void nrfy_gpiote_int_init(NRF_GPIOTE_Type * p_reg,
+                                             uint32_t          mask,
+                                             uint8_t           irq_priority,
+                                             bool              enable)
+{
+    for (uint8_t i = 0; i < GPIOTE_CH_NUM; i++)
+    {
+        __nrfy_internal_gpiote_event_enabled_clear(p_reg, mask, nrf_gpiote_in_event_get(i));
+    }
+
+    __nrfy_internal_gpiote_event_enabled_clear(p_reg, mask, NRF_GPIOTE_EVENT_PORT);
+
+#if defined(NRF_GPIOTE_IRQn_EXT)
+    IRQn_Type irqn = NRF_GPIOTE_IRQn_EXT;
+#else
+    IRQn_Type irqn = nrfx_get_irq_number(p_reg);
+#endif
+    NRFX_IRQ_PRIORITY_SET(irqn, irq_priority);
+    NRFX_IRQ_ENABLE(irqn);
+    if (enable)
+    {
+        nrf_gpiote_int_enable(p_reg, mask);
+    }
+    nrf_barrier_w();
+}
+
+/**
+ * @brief Function for processing the specified GPIOTE events.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ * @param[in] mask  Mask of events to be processed, created by @ref NRFY_EVENT_TO_INT_BITMASK().
+ *
+ * @return Mask of events that were generated and processed.
+ *         To be checked against the result of @ref NRFY_EVENT_TO_INT_BITMASK().
+ */
+NRFY_STATIC_INLINE uint32_t nrfy_gpiote_events_process(NRF_GPIOTE_Type * p_reg,
+                                                       uint32_t          mask)
+{
+    uint32_t evt_mask = __nrfy_internal_gpiote_events_process(p_reg, mask);
+    nrf_barrier_w();
+    return evt_mask;
+}
+
+/** @refhal{nrf_gpiote_task_trigger} */
+NRFY_STATIC_INLINE void nrfy_gpiote_task_trigger(NRF_GPIOTE_Type * p_reg, nrf_gpiote_task_t task)
+{
+    nrf_gpiote_task_trigger(p_reg, task);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_gpiote_task_address_get} */
+NRFY_STATIC_INLINE uint32_t nrfy_gpiote_task_address_get(NRF_GPIOTE_Type const * p_reg,
+                                                         nrf_gpiote_task_t       task)
+{
+    return nrf_gpiote_task_address_get(p_reg, task);
+}
+
+/** @refhal{nrf_gpiote_event_check} */
+NRFY_STATIC_INLINE bool nrfy_gpiote_event_check(NRF_GPIOTE_Type const * p_reg,
+                                                nrf_gpiote_event_t      event)
+{
+    nrf_barrier_r();
+    bool evt = nrf_gpiote_event_check(p_reg, event);
+    nrf_barrier_r();
+    return evt;
+}
+
+/** @refhal{nrf_gpiote_event_clear} */
+NRFY_STATIC_INLINE void nrfy_gpiote_event_clear(NRF_GPIOTE_Type * p_reg, nrf_gpiote_event_t event)
+{
+    nrf_gpiote_event_clear(p_reg, event);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_gpiote_event_address_get} */
+NRFY_STATIC_INLINE uint32_t nrfy_gpiote_event_address_get(NRF_GPIOTE_Type const * p_reg,
+                                                          nrf_gpiote_event_t      event)
+{
+    return nrf_gpiote_event_address_get(p_reg, event);
+}
+
+/** @refhal{nrf_gpiote_int_enable} */
+NRFY_STATIC_INLINE void nrfy_gpiote_int_enable(NRF_GPIOTE_Type * p_reg, uint32_t mask)
+{
+    nrf_gpiote_int_enable(p_reg, mask);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_gpiote_int_disable} */
+NRFY_STATIC_INLINE void nrfy_gpiote_int_disable(NRF_GPIOTE_Type * p_reg, uint32_t mask)
+{
+    nrf_gpiote_int_disable(p_reg, mask);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_gpiote_int_enable_check} */
+NRFY_STATIC_INLINE uint32_t nrfy_gpiote_int_enable_check(NRF_GPIOTE_Type const * p_reg,
+                                                         uint32_t                mask)
+{
+    nrf_barrier_rw();
+    uint32_t enable = nrf_gpiote_int_enable_check(p_reg, mask);
+    nrf_barrier_r();
+    return enable;
+}
+
+#if defined(DPPI_PRESENT) || defined(__NRFX_DOXYGEN__)
+/** @refhal{nrf_gpiote_subscribe_set} */
+NRFY_STATIC_INLINE void nrfy_gpiote_subscribe_set(NRF_GPIOTE_Type * p_reg,
+                                                  nrf_gpiote_task_t task,
+                                                  uint8_t           channel)
+{
+    nrf_gpiote_subscribe_set(p_reg, task, channel);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_gpiote_subscribe_clear} */
+NRFY_STATIC_INLINE void nrfy_gpiote_subscribe_clear(NRF_GPIOTE_Type * p_reg,
+                                                    nrf_gpiote_task_t task)
+{
+    nrf_gpiote_subscribe_clear(p_reg, task);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_gpiote_publish_set} */
+NRFY_STATIC_INLINE void nrfy_gpiote_publish_set(NRF_GPIOTE_Type *  p_reg,
+                                                nrf_gpiote_event_t event,
+                                                uint8_t            channel)
+{
+    nrf_gpiote_publish_set(p_reg, event, channel);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_gpiote_publish_clear} */
+NRFY_STATIC_INLINE void nrfy_gpiote_publish_clear(NRF_GPIOTE_Type *  p_reg,
+                                                  nrf_gpiote_event_t event)
+{
+    nrf_gpiote_publish_clear(p_reg, event);
+    nrf_barrier_w();
+}
+#endif
+
+/** @refhal{nrf_gpiote_event_enable} */
+NRFY_STATIC_INLINE void nrfy_gpiote_event_enable(NRF_GPIOTE_Type * p_reg, uint32_t idx)
+{
+    nrf_gpiote_event_enable(p_reg, idx);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_gpiote_event_disable} */
+NRFY_STATIC_INLINE void nrfy_gpiote_event_disable(NRF_GPIOTE_Type * p_reg, uint32_t idx)
+{
+    nrf_gpiote_event_disable(p_reg, idx);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_gpiote_event_configure} */
+NRFY_STATIC_INLINE void nrfy_gpiote_event_configure(NRF_GPIOTE_Type *     p_reg,
+                                                    uint32_t              idx,
+                                                    uint32_t              pin,
+                                                    nrf_gpiote_polarity_t polarity)
+{
+    nrf_gpiote_event_configure(p_reg, idx, pin, polarity);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_gpiote_event_pin_get} */
+NRFY_STATIC_INLINE uint32_t nrfy_gpiote_event_pin_get(NRF_GPIOTE_Type const * p_reg, uint32_t idx)
+{
+    nrf_barrier_rw();
+    uint32_t pin = nrf_gpiote_event_pin_get(p_reg, idx);
+    nrf_barrier_r();
+    return pin;
+}
+
+/** @refhal{nrf_gpiote_event_polarity_get} */
+NRFY_STATIC_INLINE
+nrf_gpiote_polarity_t nrfy_gpiote_event_polarity_get(NRF_GPIOTE_Type const * p_reg,
+                                                     uint32_t                idx)
+{
+    nrf_barrier_rw();
+    nrf_gpiote_polarity_t polarity = nrf_gpiote_event_polarity_get(p_reg, idx);
+    nrf_barrier_r();
+    return polarity;
+}
+
+/** @refhal{nrf_gpiote_task_enable} */
+NRFY_STATIC_INLINE void nrfy_gpiote_task_enable(NRF_GPIOTE_Type * p_reg, uint32_t idx)
+{
+    nrf_gpiote_task_enable(p_reg, idx);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_gpiote_task_disable} */
+NRFY_STATIC_INLINE void nrfy_gpiote_task_disable(NRF_GPIOTE_Type * p_reg, uint32_t idx)
+{
+    nrf_gpiote_task_disable(p_reg, idx);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_gpiote_task_configure} */
+NRFY_STATIC_INLINE void nrfy_gpiote_task_configure(NRF_GPIOTE_Type *     p_reg,
+                                                   uint32_t              idx,
+                                                   uint32_t              pin,
+                                                   nrf_gpiote_polarity_t polarity,
+                                                   nrf_gpiote_outinit_t  init_val)
+{
+    nrf_gpiote_task_configure(p_reg, idx, pin, polarity, init_val);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_gpiote_task_force} */
+NRFY_STATIC_INLINE void nrfy_gpiote_task_force(NRF_GPIOTE_Type *    p_reg,
+                                               uint32_t             idx,
+                                               nrf_gpiote_outinit_t init_val)
+{
+    nrf_gpiote_task_force(p_reg, idx, init_val);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_gpiote_te_default} */
+NRFY_STATIC_INLINE void nrfy_gpiote_te_default(NRF_GPIOTE_Type * p_reg, uint32_t idx)
+{
+    nrf_gpiote_te_default(p_reg, idx);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_gpiote_te_is_enabled} */
+NRFY_STATIC_INLINE bool nrfy_gpiote_te_is_enabled(NRF_GPIOTE_Type const * p_reg, uint32_t idx)
+{
+    nrf_barrier_rw();
+    bool enabled = nrf_gpiote_te_is_enabled(p_reg, idx);
+    nrf_barrier_r();
+    return enabled;
+}
+
+/** @refhal{nrf_gpiote_out_task_get} */
+NRFY_STATIC_INLINE nrf_gpiote_task_t nrfy_gpiote_out_task_get(uint8_t index)
+{
+    return nrf_gpiote_out_task_get(index);
+}
+
+#if defined(GPIOTE_FEATURE_SET_PRESENT) || defined(__NRFX_DOXYGEN__)
+/** @refhal{nrf_gpiote_set_task_get} */
+NRFY_STATIC_INLINE nrf_gpiote_task_t nrfy_gpiote_set_task_get(uint8_t index)
+{
+    return nrf_gpiote_set_task_get(index);
+}
+#endif
+
+#if defined(GPIOTE_FEATURE_CLR_PRESENT) || defined(__NRFX_DOXYGEN__)
+/** @refhal{nrf_gpiote_clr_task_get} */
+NRFY_STATIC_INLINE nrf_gpiote_task_t nrfy_gpiote_clr_task_get(uint8_t index)
+{
+    return nrf_gpiote_clr_task_get(index);
+}
+#endif
+
+/** @refhal{nrf_gpiote_in_event_get} */
+NRFY_STATIC_INLINE nrf_gpiote_event_t nrfy_gpiote_in_event_get(uint8_t index)
+{
+    return nrf_gpiote_in_event_get(index);
+}
+
+#if NRFY_GPIOTE_HAS_LATENCY
+/** @refhal{nrf_gpiote_latency_set} */
+NRFY_STATIC_INLINE void nrfy_gpiote_latency_set(NRF_GPIOTE_Type *    p_reg,
+                                                nrf_gpiote_latency_t latency)
+{
+    nrf_gpiote_latency_set(p_reg, latency);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_gpiote_latency_get} */
+NRFY_STATIC_INLINE nrf_gpiote_latency_t nrfy_gpiote_latency_get(NRF_GPIOTE_Type const * p_reg)
+{
+    nrf_barrier_rw();
+    nrf_gpiote_latency_t latency = nrf_gpiote_latency_get(p_reg);
+    nrf_barrier_r();
+    return latency;
+}
+#endif
+
+/** @} */
+
+NRFY_STATIC_INLINE void __nrfy_internal_gpiote_event_enabled_clear(NRF_GPIOTE_Type *  p_reg,
+                                                                   uint32_t           mask,
+                                                                   nrf_gpiote_event_t event)
+{
+    if (mask & NRFY_EVENT_TO_INT_BITMASK(event))
+    {
+        nrf_gpiote_event_clear(p_reg, event);
+    }
+}
+
+NRFY_STATIC_INLINE bool __nrfy_internal_gpiote_event_handle(NRF_GPIOTE_Type *  p_reg,
+                                                            uint32_t           mask,
+                                                            nrf_gpiote_event_t event,
+                                                            uint32_t *         p_evt_mask)
+{
+    if ((mask & NRFY_EVENT_TO_INT_BITMASK(event)) && nrf_gpiote_event_check(p_reg, event))
+    {
+        nrf_gpiote_event_clear(p_reg, event);
+        if (p_evt_mask)
+        {
+            *p_evt_mask |= NRFY_EVENT_TO_INT_BITMASK(event);
+        }
+        return true;
+    }
+    return false;
+}
+
+NRFY_STATIC_INLINE uint32_t __nrfy_internal_gpiote_events_process(NRF_GPIOTE_Type * p_reg,
+                                                                  uint32_t          mask)
+{
+    uint32_t event_mask = 0;
+
+    nrf_barrier_r();
+    for (uint8_t i = 0; i < GPIOTE_CH_NUM; i++)
+    {
+        (void)__nrfy_internal_gpiote_event_handle(p_reg,
+                                                  mask,
+                                                  nrf_gpiote_in_event_get(i),
+                                                  &event_mask);
+    }
+
+    (void)__nrfy_internal_gpiote_event_handle(p_reg, mask, NRF_GPIOTE_EVENT_PORT, &event_mask);
+
+    return event_mask;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // NRFY_GPIOTE_H__

--- a/nrfx/haly/nrfy_i2s.h
+++ b/nrfx/haly/nrfy_i2s.h
@@ -1,0 +1,575 @@
+/*
+ * Copyright (c) 2021 - 2023, Nordic Semiconductor ASA
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef NRFY_I2S_H__
+#define NRFY_I2S_H__
+
+#include <nrfx.h>
+#include <hal/nrf_i2s.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct nrfy_i2s_xfer_desc_t nrfy_i2s_xfer_desc_t;
+
+NRFY_STATIC_INLINE bool __nrfy_internal_i2s_event_handle(NRF_I2S_Type *  p_reg,
+                                                         uint32_t        mask,
+                                                         nrf_i2s_event_t event,
+                                                         uint32_t *      p_evt_mask);
+
+NRFY_STATIC_INLINE uint32_t __nrfy_internal_i2s_events_process(NRF_I2S_Type *               p_reg,
+                                                               uint32_t                     mask,
+                                                               nrfy_i2s_xfer_desc_t const * p_xfer);
+
+NRFY_STATIC_INLINE void __nrfy_internal_i2s_event_enabled_clear(NRF_I2S_Type *  p_reg,
+                                                                uint32_t        mask,
+                                                                nrf_i2s_event_t event);
+
+
+/**
+ * @defgroup nrfy_i2s I2S HALY
+ * @{
+ * @ingroup nrf_i2s
+ * @brief   Hardware access layer with cache and barrier support for managing the I2S peripheral.
+ */
+
+/** @brief Structure for I2S configuration. */
+typedef struct
+{
+    nrf_i2s_config_t config;        ///< Peripheral configuration.
+    nrf_i2s_pins_t   pins;          ///< Pins to be used.
+#if NRF_I2S_HAS_CLKCONFIG
+    nrf_i2s_clksrc_t clksrc;        ///< Clock source selection.
+    bool             enable_bypass; ///< Bypass clock generator. MCK will be equal to source input.
+#endif
+    bool             skip_psel_cfg; ///< Skip pin selection configuration.
+                                    /**< When set to true, the driver does not modify
+                                     *   pin select registers in the peripheral.
+                                     *   Those registers are supposed to be set up
+                                     *   externally before the driver is initialized.
+                                     *   @note When both GPIO configuration and pin
+                                     *   selection are to be skipped, the structure
+                                     *   fields that specify pins can be omitted,
+                                     *   as they are ignored anyway. */
+} nrfy_i2s_config_t;
+
+/** @brief I2S driver buffers structure. */
+typedef struct
+{
+    uint32_t       * p_rx_buffer; ///< Pointer to the buffer for received data.
+    uint32_t const * p_tx_buffer; ///< Pointer to the buffer with data to be sent.
+} nrfy_i2s_buffers_t;
+
+/** @brief Structure describing single I2S transfer. */
+struct nrfy_i2s_xfer_desc_t
+{
+    nrfy_i2s_buffers_t const * p_buffers;   ///< Pointer to the structure with I2S buffers.
+    uint16_t                   buffer_size; ///< Size of buffers.
+};
+
+/**
+ * @brief Function for configuring the I2S.
+ *
+ * @param[in] p_reg    Pointer to the structure of registers of the peripheral.
+ * @param[in] p_config Pointer to the peripheral configuration structure.
+ */
+NRFY_STATIC_INLINE void nrfy_i2s_periph_configure(NRF_I2S_Type *            p_reg,
+                                                  nrfy_i2s_config_t const * p_config)
+{
+    nrf_i2s_configure(p_reg, &p_config->config);
+
+#if NRF_I2S_HAS_CLKCONFIG
+    nrf_i2s_clk_configure(p_reg, p_config->clksrc, p_config->enable_bypass);
+#endif
+    if (!p_config->skip_psel_cfg)
+    {
+        nrf_i2s_pins_set(p_reg, &p_config->pins);
+    }
+    nrf_barrier_w();
+}
+
+/**
+ * @brief Function for initializing the specified I2S interrupts.
+ *
+ * @param[in] p_reg        Pointer to the structure of registers of the peripheral.
+ * @param[in] mask         Mask of interrupts to be initialized.
+ * @param[in] irq_priority Interrupt priority.
+ * @param[in] enable       True if interrupts are to be enabled, false otherwise.
+ */
+NRFY_STATIC_INLINE void nrfy_i2s_int_init(NRF_I2S_Type * p_reg,
+                                          uint32_t       mask,
+                                          uint8_t        irq_priority,
+                                          bool           enable)
+{
+    __nrfy_internal_i2s_event_enabled_clear(p_reg, mask, NRF_I2S_EVENT_RXPTRUPD);
+    __nrfy_internal_i2s_event_enabled_clear(p_reg, mask, NRF_I2S_EVENT_TXPTRUPD);
+    __nrfy_internal_i2s_event_enabled_clear(p_reg, mask, NRF_I2S_EVENT_STOPPED);
+#if NRF_I2S_HAS_FRAMESTART
+    __nrfy_internal_i2s_event_enabled_clear(p_reg, mask, NRF_I2S_EVENT_FRAMESTART);
+#endif
+    nrf_barrier_w();
+
+    NRFX_IRQ_PRIORITY_SET(nrfx_get_irq_number(p_reg), irq_priority);
+    NRFX_IRQ_ENABLE(nrfx_get_irq_number(p_reg));
+
+    if (enable)
+    {
+        nrf_i2s_int_enable(p_reg, mask);
+    }
+    nrf_barrier_w();
+}
+
+/**
+ * @brief Function for uninitializing the I2S interrupts.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ */
+NRFY_STATIC_INLINE void nrfy_i2s_int_uninit(NRF_I2S_Type * p_reg)
+{
+    NRFX_IRQ_DISABLE(nrfx_get_irq_number(p_reg));
+    nrf_barrier_w();
+}
+
+/**
+ * @brief Function for processing the specified I2S events.
+ *
+ * @param[in] p_reg  Pointer to the structure of registers of the peripheral.
+ * @param[in] mask   Mask of events to be processed,
+ *                   created by @ref NRFY_EVENT_TO_INT_BITMASK().
+ * @param[in] p_xfer Pointer to the structure containing buffers associated with the last transaction.
+ *                   Can be NULL.
+ *
+ * @return Mask of events that were generated and processed.
+ *         To be checked against the result of @ref NRFY_EVENT_TO_INT_BITMASK().
+ */
+NRFY_STATIC_INLINE uint32_t nrfy_i2s_events_process(NRF_I2S_Type *         p_reg,
+                                                    uint32_t               mask,
+                                                    nrfy_i2s_xfer_desc_t * p_xfer)
+{
+    uint32_t evt_mask = __nrfy_internal_i2s_events_process(p_reg, mask, p_xfer);
+    nrf_barrier_w();
+    return evt_mask;
+}
+
+/**
+ * @brief Function for setting the I2S transaction buffers.
+ *
+ * If the transfer in a given direction is not required, pass NULL instead of the pointer
+ * to the corresponding buffer.
+ *
+ * @param[in] p_reg  Pointer to the structure of registers of the peripheral.
+ * @param[in] p_xfer Pointer to the structure containing transaction buffers.
+ */
+NRFY_STATIC_INLINE void nrfy_i2s_buffers_set(NRF_I2S_Type *               p_reg,
+                                             nrfy_i2s_xfer_desc_t const * p_xfer)
+{
+    if (p_xfer->p_buffers->p_tx_buffer != NULL)
+    {
+        NRFY_CACHE_WB(p_xfer->p_buffers->p_tx_buffer, (p_xfer->buffer_size * sizeof(uint32_t)));
+    }
+
+    nrf_i2s_transfer_set(p_reg,
+                         p_xfer->buffer_size,
+                         p_xfer->p_buffers->p_rx_buffer,
+                         p_xfer->p_buffers->p_tx_buffer);
+
+    nrf_barrier_w();
+}
+
+/**
+ * @brief Function for starting the I2S transaction.
+ *
+ * If the transfer in a given direction is not required, pass NULL instead of the pointer
+ * to the corresponding buffer.
+ *
+ * @param[in] p_reg  Pointer to the structure of registers of the peripheral.
+ * @param[in] p_xfer Pointer to the structure containing transaction buffers
+ *                   if the transaction is to be blocking. NULL for non-blocking transactions.
+ */
+NRFY_STATIC_INLINE void nrfy_i2s_xfer_start(NRF_I2S_Type *               p_reg,
+                                            nrfy_i2s_xfer_desc_t const * p_xfer)
+{
+
+    nrf_i2s_task_trigger(p_reg, NRF_I2S_TASK_START);
+
+    if (p_xfer)
+    {
+        nrf_barrier_w();
+
+        bool tx_done = false, rx_done = false;
+
+        while (!((tx_done || (p_xfer->p_buffers->p_tx_buffer == NULL)) &&
+                 (rx_done || (p_xfer->p_buffers->p_rx_buffer == NULL))))
+        {
+            if (__nrfy_internal_i2s_events_process(p_reg,
+                    NRFY_EVENT_TO_INT_BITMASK(NRF_I2S_EVENT_TXPTRUPD),
+                    p_xfer))
+            {
+                tx_done = true;
+            }
+            if (__nrfy_internal_i2s_events_process(p_reg,
+                    NRFY_EVENT_TO_INT_BITMASK(NRF_I2S_EVENT_RXPTRUPD),
+                    p_xfer))
+            {
+                rx_done = true;
+            }
+        }
+    }
+
+    nrf_barrier_w();
+}
+
+/**
+ * @brief Function for aborting the ongoing I2S transaction.
+ *
+ * @param[in] p_reg  Pointer to the structure of registers of the peripheral.
+ * @param[in] p_xfer Pointer to the structure containing transaction buffers
+ *                   if the abort is to be blocking. NULL for non-blocking operation.
+ */
+NRFY_STATIC_INLINE void nrfy_i2s_abort(NRF_I2S_Type * p_reg, nrfy_i2s_xfer_desc_t const * p_xfer)
+{
+    nrf_i2s_task_trigger(p_reg, NRF_I2S_TASK_STOP);
+    if (p_xfer)
+    {
+        nrf_barrier_w();
+        uint32_t evt_mask = NRFY_EVENT_TO_INT_BITMASK(NRF_I2S_EVENT_STOPPED);
+        while (!__nrfy_internal_i2s_events_process(p_reg, evt_mask, p_xfer))
+        {}
+    }
+    nrf_barrier_w();
+}
+
+/**
+ * @brief Function for getting the pins selection.
+ *
+ * @param[in] p_reg  Pointer to the structure of registers of the peripheral.
+ * @param[in] p_pins Pointer to the I2S pin configuration structure.
+ *
+ */
+NRFY_STATIC_INLINE void nrfy_i2s_pins_get(NRF_I2S_Type const * p_reg,
+                                          nrf_i2s_pins_t *     p_pins)
+{
+    nrf_barrier_rw();
+
+    p_pins->sck_pin   = nrf_i2s_sck_pin_get(p_reg),
+    p_pins->lrck_pin  = nrf_i2s_lrck_pin_get(p_reg),
+    p_pins->mck_pin   = nrf_i2s_mck_pin_get(p_reg),
+    p_pins->sdout_pin = nrf_i2s_sdout_pin_get(p_reg),
+    p_pins->sdin_pin  = nrf_i2s_sdin_pin_get(p_reg),
+
+    nrf_barrier_r();
+}
+
+/** @refhal{nrf_i2s_task_trigger} */
+NRFY_STATIC_INLINE void nrfy_i2s_task_trigger(NRF_I2S_Type * p_reg, nrf_i2s_task_t task)
+{
+    nrf_i2s_task_trigger(p_reg, task);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_i2s_task_address_get} */
+NRFY_STATIC_INLINE uint32_t nrfy_i2s_task_address_get(NRF_I2S_Type const * p_reg,
+                                                      nrf_i2s_task_t       task)
+{
+    return nrf_i2s_task_address_get(p_reg, task);
+}
+
+/** @refhal{nrf_i2s_event_clear} */
+NRFY_STATIC_INLINE void nrfy_i2s_event_clear(NRF_I2S_Type *  p_reg,
+                                             nrf_i2s_event_t event)
+{
+    nrf_i2s_event_clear(p_reg, event);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_i2s_event_check} */
+NRFY_STATIC_INLINE bool nrfy_i2s_event_check(NRF_I2S_Type const * p_reg,
+                                             nrf_i2s_event_t      event)
+{
+    nrf_barrier_r();
+    bool check = nrf_i2s_event_check(p_reg, event);
+    nrf_barrier_r();
+    return check;
+}
+
+/** @refhal{nrf_i2s_event_address_get} */
+NRFY_STATIC_INLINE uint32_t nrfy_i2s_event_address_get(NRF_I2S_Type const * p_reg,
+                                                       nrf_i2s_event_t      event)
+{
+    return nrf_i2s_event_address_get(p_reg, event);
+}
+
+/** @refhal{nrf_i2s_int_enable} */
+NRFY_STATIC_INLINE void nrfy_i2s_int_enable(NRF_I2S_Type * p_reg, uint32_t mask)
+{
+    nrf_i2s_int_enable(p_reg, mask);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_i2s_int_disable} */
+NRFY_STATIC_INLINE void nrfy_i2s_int_disable(NRF_I2S_Type * p_reg, uint32_t mask)
+{
+    nrf_i2s_int_disable(p_reg, mask);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_i2s_int_enable_check} */
+NRFY_STATIC_INLINE uint32_t nrfy_i2s_int_enable_check(NRF_I2S_Type const * p_reg, uint32_t mask)
+{
+    nrf_barrier_rw();
+    uint32_t check = nrf_i2s_int_enable_check(p_reg, mask);
+    nrf_barrier_r();
+    return check;
+}
+
+/** @refhal{nrf_i2s_enable} */
+NRFY_STATIC_INLINE void nrfy_i2s_enable(NRF_I2S_Type * p_reg)
+{
+    nrf_i2s_enable(p_reg);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_i2s_disable} */
+NRFY_STATIC_INLINE void nrfy_i2s_disable(NRF_I2S_Type * p_reg)
+{
+    nrf_i2s_disable(p_reg);
+    nrf_barrier_w();
+}
+
+#if defined(DPPI_PRESENT) || defined(__NRFX_DOXYGEN__)
+/** @refhal{nrf_i2s_subscribe_set} */
+NRFY_STATIC_INLINE void nrfy_i2s_subscribe_set(NRF_I2S_Type * p_reg,
+                                               nrf_i2s_task_t task,
+                                               uint8_t        channel)
+{
+    nrf_i2s_subscribe_set(p_reg, task, channel);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_i2s_subscribe_clear} */
+NRFY_STATIC_INLINE void nrfy_i2s_subscribe_clear(NRF_I2S_Type * p_reg,
+                                                 nrf_i2s_task_t task)
+{
+    nrf_i2s_subscribe_clear(p_reg, task);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_i2s_publish_set} */
+NRFY_STATIC_INLINE void nrfy_i2s_publish_set(NRF_I2S_Type *  p_reg,
+                                             nrf_i2s_event_t event,
+                                             uint8_t         channel)
+{
+    nrf_i2s_publish_set(p_reg, event, channel);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_i2s_publish_clear} */
+NRFY_STATIC_INLINE void nrfy_i2s_publish_clear(NRF_I2S_Type *  p_reg,
+                                               nrf_i2s_event_t event)
+{
+    nrf_i2s_publish_clear(p_reg, event);
+    nrf_barrier_w();
+}
+#endif
+
+/** @refhal{nrf_i2s_pins_set} */
+NRFY_STATIC_INLINE void nrfy_i2s_pins_set(NRF_I2S_Type * p_reg, nrf_i2s_pins_t const * p_pins)
+{
+    nrf_i2s_pins_set(p_reg, p_pins);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_i2s_sck_pin_get} */
+NRFY_STATIC_INLINE uint32_t nrfy_i2s_sck_pin_get(NRF_I2S_Type const * p_reg)
+{
+    nrf_barrier_rw();
+    uint32_t pin = nrf_i2s_sck_pin_get(p_reg);
+    nrf_barrier_r();
+    return pin;
+}
+
+/** @refhal{nrf_i2s_lrck_pin_get} */
+NRFY_STATIC_INLINE uint32_t nrfy_i2s_lrck_pin_get(NRF_I2S_Type const * p_reg)
+{
+    nrf_barrier_rw();
+    uint32_t pin = nrf_i2s_lrck_pin_get(p_reg);
+    nrf_barrier_r();
+    return pin;
+}
+
+/** @refhal{nrf_i2s_mck_pin_get} */
+NRFY_STATIC_INLINE uint32_t nrfy_i2s_mck_pin_get(NRF_I2S_Type const * p_reg)
+{
+    nrf_barrier_rw();
+    uint32_t pin = nrf_i2s_mck_pin_get(p_reg);
+    nrf_barrier_r();
+    return pin;
+}
+
+/** @refhal{nrf_i2s_sdout_pin_get} */
+NRFY_STATIC_INLINE uint32_t nrfy_i2s_sdout_pin_get(NRF_I2S_Type const * p_reg)
+{
+    nrf_barrier_rw();
+    uint32_t pin = nrf_i2s_sdout_pin_get(p_reg);
+    nrf_barrier_r();
+    return pin;
+}
+
+/** @refhal{nrf_i2s_sdin_pin_get} */
+NRFY_STATIC_INLINE uint32_t nrfy_i2s_sdin_pin_get(NRF_I2S_Type const * p_reg)
+{
+    nrf_barrier_rw();
+    uint32_t pin = nrf_i2s_sdin_pin_get(p_reg);
+    nrf_barrier_r();
+    return pin;
+}
+
+/** @refhal{nrf_i2s_configure} */
+NRFY_STATIC_INLINE void nrfy_i2s_configure(NRF_I2S_Type * p_reg, nrf_i2s_config_t const * p_config)
+{
+    nrf_i2s_configure(p_reg, p_config);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_i2s_transfer_set} */
+NRFY_STATIC_INLINE void nrfy_i2s_transfer_set(NRF_I2S_Type *   p_reg,
+                                              uint16_t         size,
+                                              uint32_t *       p_rx_buffer,
+                                              uint32_t const * p_tx_buffer)
+{
+    nrf_i2s_transfer_set(p_reg, size, p_rx_buffer, p_tx_buffer);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_i2s_rx_buffer_set} */
+NRFY_STATIC_INLINE void nrfy_i2s_rx_buffer_set(NRF_I2S_Type * p_reg,
+                                               uint32_t *     p_buffer)
+{
+    nrf_i2s_rx_buffer_set(p_reg, p_buffer);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_i2s_rx_buffer_get} */
+NRFY_STATIC_INLINE uint32_t * nrfy_i2s_rx_buffer_get(NRF_I2S_Type const * p_reg)
+{
+    nrf_barrier_rw();
+    uint32_t * p_buffer = nrfy_i2s_rx_buffer_get(p_reg);
+    nrf_barrier_r();
+    return p_buffer;
+}
+
+/** @refhal{nrf_i2s_tx_buffer_set} */
+NRFY_STATIC_INLINE void nrfy_i2s_tx_buffer_set(NRF_I2S_Type *   p_reg,
+                                               uint32_t const * p_buffer)
+{
+    nrf_i2s_tx_buffer_set(p_reg, p_buffer);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_i2s_tx_buffer_get} */
+NRFY_STATIC_INLINE uint32_t * nrfy_i2s_tx_buffer_get(NRF_I2S_Type const * p_reg)
+{
+    nrf_barrier_rw();
+    uint32_t * p_buffer = nrfy_i2s_tx_buffer_get(p_reg);
+    nrf_barrier_r();
+    return p_buffer;
+}
+
+/** @} */
+
+NRFY_STATIC_INLINE bool __nrfy_internal_i2s_event_handle(NRF_I2S_Type *  p_reg,
+                                                         uint32_t        mask,
+                                                         nrf_i2s_event_t event,
+                                                         uint32_t *      p_event_mask)
+{
+    if ((mask & NRFY_EVENT_TO_INT_BITMASK(event)) && nrf_i2s_event_check(p_reg, event))
+    {
+        nrf_i2s_event_clear(p_reg, event);
+        if (p_event_mask)
+        {
+            *p_event_mask |= NRFY_EVENT_TO_INT_BITMASK(event);
+        }
+        return true;
+    }
+    return false;
+}
+
+NRFY_STATIC_INLINE uint32_t __nrfy_internal_i2s_events_process(NRF_I2S_Type *               p_reg,
+                                                               uint32_t                     mask,
+                                                               nrfy_i2s_xfer_desc_t const * p_xfer)
+{
+    uint32_t event_mask = 0;
+    bool invalidated = false;
+
+    nrf_barrier_r();
+#if NRF_I2S_HAS_FRAMESTART
+    (void)__nrfy_internal_i2s_event_handle(p_reg, mask, NRF_I2S_EVENT_FRAMESTART, &event_mask);
+#endif
+
+    (void)__nrfy_internal_i2s_event_handle(p_reg, mask, NRF_I2S_EVENT_TXPTRUPD, &event_mask);
+
+    if (__nrfy_internal_i2s_event_handle(p_reg, mask, NRF_I2S_EVENT_RXPTRUPD, &event_mask) &&
+        p_xfer)
+    {
+        NRFY_CACHE_INV(p_xfer->p_buffers->p_rx_buffer,
+                       (p_xfer->buffer_size * sizeof(uint32_t)));
+        invalidated = true;
+    }
+
+    if (__nrfy_internal_i2s_event_handle(p_reg, mask, NRF_I2S_EVENT_STOPPED, &event_mask) &&
+        p_xfer && !invalidated)
+    {
+        NRFY_CACHE_INV(p_xfer->p_buffers->p_rx_buffer,
+                       (p_xfer->buffer_size * sizeof(uint32_t)));
+    }
+
+    return event_mask;
+}
+
+
+NRFY_STATIC_INLINE void __nrfy_internal_i2s_event_enabled_clear(NRF_I2S_Type *  p_reg,
+                                                                uint32_t        mask,
+                                                                nrf_i2s_event_t event)
+{
+    if (mask & NRFY_EVENT_TO_INT_BITMASK(event))
+    {
+        nrf_i2s_event_clear(p_reg, event);
+    }
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // NRFY_I2S_H__

--- a/nrfx/haly/nrfy_lpcomp.h
+++ b/nrfx/haly/nrfy_lpcomp.h
@@ -1,0 +1,329 @@
+/*
+ * Copyright (c) 2021 - 2023, Nordic Semiconductor ASA
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef NRFY_LPCOMP_H__
+#define NRFY_LPCOMP_H__
+
+#include <nrfx.h>
+#include <hal/nrf_lpcomp.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+NRFY_STATIC_INLINE void __nrfy_internal_lpcomp_event_enabled_clear(NRF_LPCOMP_Type *  p_reg,
+                                                                   uint32_t           mask,
+                                                                   nrf_lpcomp_event_t event);
+
+NRFY_STATIC_INLINE bool __nrfy_internal_lpcomp_event_handle(NRF_LPCOMP_Type *  p_reg,
+                                                            uint32_t           mask,
+                                                            nrf_lpcomp_event_t event,
+                                                            uint32_t *         p_evt_mask);
+
+NRFY_STATIC_INLINE uint32_t __nrfy_internal_lpcomp_events_process(NRF_LPCOMP_Type * p_reg,
+                                                                  uint32_t          mask);
+
+/**
+ * @defgroup nrfy_lpcomp LPCOMP HALY
+ * @{
+ * @ingroup nrf_lpcomp
+ * @brief   Hardware access layer with cache and barrier support for managing the LPCOMP peripheral.
+ */
+
+/** @brief LPCOMP configuration structure. */
+typedef struct
+{
+    nrf_lpcomp_config_t config; ///< Peripheral configuration.
+    nrf_lpcomp_input_t  input;  ///< Input to be monitored.
+} nrfy_lpcomp_config_t;
+
+/**
+ * @brief Function for configuring the LPCOMP.
+ *
+ * @param[in] p_reg    Pointer to the structure of registers of the peripheral.
+ * @param[in] p_config Pointer to the peripheral configuration structure.
+ */
+NRFY_STATIC_INLINE void nrfy_lpcomp_periph_configure(NRF_LPCOMP_Type *            p_reg,
+                                                     nrfy_lpcomp_config_t const * p_config)
+{
+    nrf_lpcomp_configure(p_reg, &p_config->config);
+    nrf_lpcomp_input_select(p_reg, p_config->input);
+    nrf_barrier_w();
+}
+
+/**
+ * @brief Function for initializing the specified LPCOMP interrupts.
+ *
+ * @param[in] p_reg        Pointer to the structure of registers of the peripheral.
+ * @param[in] mask         Mask of interrupts to be initialized.
+ * @param[in] irq_priority Interrupt priority.
+ * @param[in] enable       True if the interrupts are to be enabled, false otherwise.
+ */
+NRFY_STATIC_INLINE void nrfy_lpcomp_int_init(NRF_LPCOMP_Type * p_reg,
+                                             uint32_t          mask,
+                                             uint8_t           irq_priority,
+                                             bool              enable)
+{
+
+    __nrfy_internal_lpcomp_event_enabled_clear(p_reg, mask, NRF_LPCOMP_EVENT_READY);
+    __nrfy_internal_lpcomp_event_enabled_clear(p_reg, mask, NRF_LPCOMP_EVENT_DOWN);
+    __nrfy_internal_lpcomp_event_enabled_clear(p_reg, mask, NRF_LPCOMP_EVENT_UP);
+    __nrfy_internal_lpcomp_event_enabled_clear(p_reg, mask, NRF_LPCOMP_EVENT_CROSS);
+    nrf_barrier_w();
+
+    NRFX_IRQ_PRIORITY_SET(nrfx_get_irq_number(p_reg), irq_priority);
+    NRFX_IRQ_ENABLE(nrfx_get_irq_number(p_reg));
+    if (enable)
+    {
+        nrf_lpcomp_int_enable(p_reg, mask);
+    }
+    nrf_barrier_w();
+}
+
+/**
+ * @brief Function for uninitializing the LPCOMP interrupts.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ */
+ NRFY_STATIC_INLINE void nrfy_lpcomp_int_uninit(NRF_LPCOMP_Type * p_reg)
+ {
+    NRFX_IRQ_DISABLE(nrfx_get_irq_number(p_reg));
+    nrf_barrier_w();
+ }
+
+/**
+ * @brief Function for processing the specified LPCOMP events.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ * @param[in] mask  Mask of events to be processed, created by @ref NRFY_EVENT_TO_INT_BITMASK().
+ *
+ * @return Mask of events that were generated and processed.
+ *         To be checked against the result of @ref NRFY_EVENT_TO_INT_BITMASK().
+ */
+NRFY_STATIC_INLINE uint32_t nrfy_lpcomp_events_process(NRF_LPCOMP_Type * p_reg,
+                                                       uint32_t          mask)
+{
+    uint32_t evt_mask = __nrfy_internal_lpcomp_events_process(p_reg, mask);
+    nrf_barrier_w();
+    return evt_mask;
+}
+
+/**
+ * @brief Function for reading the current state of the LPCOMP input.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ *
+ * @retval false The input voltage is below the threshold.
+ * @retval true  The input voltage is above the threshold.
+ */
+NRFY_STATIC_INLINE bool nrfy_lpcomp_sample_check(NRF_LPCOMP_Type * p_reg)
+{
+    nrf_lpcomp_task_trigger(p_reg, NRF_LPCOMP_TASK_SAMPLE);
+    nrf_barrier_rw();
+    bool sample = nrf_lpcomp_result_get(p_reg);
+    nrf_barrier_r();
+    return sample;
+}
+
+/** @refhal{nrf_lpcomp_configure} */
+NRFY_STATIC_INLINE void nrfy_lpcomp_configure(NRF_LPCOMP_Type *           p_reg,
+                                              nrf_lpcomp_config_t const * p_config)
+{
+    nrf_lpcomp_configure(p_reg, p_config);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_lpcomp_input_select} */
+NRFY_STATIC_INLINE void nrfy_lpcomp_input_select(NRF_LPCOMP_Type * p_reg, nrf_lpcomp_input_t input)
+{
+    nrf_lpcomp_input_select(p_reg, input);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_lpcomp_enable} */
+NRFY_STATIC_INLINE void nrfy_lpcomp_enable(NRF_LPCOMP_Type * p_reg)
+{
+    nrf_lpcomp_enable(p_reg);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_lpcomp_disable} */
+NRFY_STATIC_INLINE void nrfy_lpcomp_disable(NRF_LPCOMP_Type * p_reg)
+{
+    nrf_lpcomp_disable(p_reg);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_lpcomp_result_get} */
+NRFY_STATIC_INLINE uint32_t nrfy_lpcomp_result_get(NRF_LPCOMP_Type const * p_reg)
+{
+    nrf_barrier_rw();
+    uint32_t result = nrf_lpcomp_result_get(p_reg);
+    nrf_barrier_r();
+    return result;
+}
+
+/** @refhal{nrf_lpcomp_int_enable} */
+NRFY_STATIC_INLINE void nrfy_lpcomp_int_enable(NRF_LPCOMP_Type * p_reg, uint32_t mask)
+{
+    nrf_lpcomp_int_enable(p_reg, mask);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_lpcomp_int_disable} */
+NRFY_STATIC_INLINE void nrfy_lpcomp_int_disable(NRF_LPCOMP_Type * p_reg, uint32_t mask)
+{
+    nrf_lpcomp_int_disable(p_reg, mask);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_lpcomp_int_enable_check} */
+NRFY_STATIC_INLINE uint32_t nrfy_lpcomp_int_enable_check(NRF_LPCOMP_Type const * p_reg,
+                                                         uint32_t                mask)
+{
+    nrf_barrier_rw();
+    uint32_t check = nrf_lpcomp_int_enable_check(p_reg, mask);
+    nrf_barrier_r();
+    return check;
+}
+
+/** @refhal{nrf_lpcomp_task_address_get} */
+NRFY_STATIC_INLINE uint32_t nrfy_lpcomp_task_address_get(NRF_LPCOMP_Type const * p_reg,
+                                                         nrf_lpcomp_task_t       task)
+{
+    return nrf_lpcomp_task_address_get(p_reg, task);
+}
+
+/** @refhal{nrf_lpcomp_event_address_get} */
+NRFY_STATIC_INLINE uint32_t nrfy_lpcomp_event_address_get(NRF_LPCOMP_Type const * p_reg,
+                                                          nrf_lpcomp_event_t      event)
+{
+    return nrf_lpcomp_event_address_get(p_reg, event);
+}
+
+/** @refhal{nrf_lpcomp_shorts_enable} */
+NRFY_STATIC_INLINE void nrfy_lpcomp_shorts_enable(NRF_LPCOMP_Type * p_reg, uint32_t mask)
+{
+    nrf_lpcomp_shorts_enable(p_reg, mask);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_lpcomp_shorts_disable} */
+NRFY_STATIC_INLINE void nrfy_lpcomp_shorts_disable(NRF_LPCOMP_Type * p_reg, uint32_t mask)
+{
+    nrf_lpcomp_shorts_disable(p_reg, mask);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_lpcomp_task_trigger} */
+NRFY_STATIC_INLINE void nrfy_lpcomp_task_trigger(NRF_LPCOMP_Type * p_reg, nrf_lpcomp_task_t task)
+{
+    nrf_lpcomp_task_trigger(p_reg, task);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_lpcomp_event_clear} */
+NRFY_STATIC_INLINE void nrfy_lpcomp_event_clear(NRF_LPCOMP_Type * p_reg, nrf_lpcomp_event_t event)
+{
+    nrf_lpcomp_event_clear(p_reg, event);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_lpcomp_event_check} */
+NRFY_STATIC_INLINE bool nrfy_lpcomp_event_check(NRF_LPCOMP_Type const * p_reg,
+                                                nrf_lpcomp_event_t      event)
+{
+    nrf_barrier_rw();
+    bool check = nrf_lpcomp_event_check(p_reg, event);
+    nrf_barrier_r();
+    return check;
+}
+
+/** @} */
+
+NRFY_STATIC_INLINE void __nrfy_internal_lpcomp_event_enabled_clear(NRF_LPCOMP_Type *  p_reg,
+                                                                   uint32_t           mask,
+                                                                   nrf_lpcomp_event_t event)
+{
+    if (mask & NRFY_EVENT_TO_INT_BITMASK(event))
+    {
+        nrf_lpcomp_event_clear(p_reg, event);
+    }
+}
+
+NRFY_STATIC_INLINE bool __nrfy_internal_lpcomp_event_handle(NRF_LPCOMP_Type *  p_reg,
+                                                            uint32_t           mask,
+                                                            nrf_lpcomp_event_t event,
+                                                            uint32_t *         p_evt_mask)
+{
+    if ((mask & NRFY_EVENT_TO_INT_BITMASK(event)) && nrf_lpcomp_event_check(p_reg, event))
+    {
+        nrf_lpcomp_event_clear(p_reg, event);
+        if (p_evt_mask)
+        {
+            *p_evt_mask |= NRFY_EVENT_TO_INT_BITMASK(event);
+        }
+        return true;
+    }
+    return false;
+}
+
+NRFY_STATIC_INLINE uint32_t __nrfy_internal_lpcomp_events_process(NRF_LPCOMP_Type * p_reg,
+                                                                  uint32_t          mask)
+{
+    uint32_t event_mask = 0;
+
+    (void)__nrfy_internal_lpcomp_event_handle(p_reg,
+                                              mask,
+                                              NRF_LPCOMP_EVENT_READY,
+                                              &event_mask);
+    (void)__nrfy_internal_lpcomp_event_handle(p_reg,
+                                              mask,
+                                              NRF_LPCOMP_EVENT_DOWN,
+                                              &event_mask);
+    (void)__nrfy_internal_lpcomp_event_handle(p_reg,
+                                              mask,
+                                              NRF_LPCOMP_EVENT_UP,
+                                              &event_mask);
+    (void)__nrfy_internal_lpcomp_event_handle(p_reg,
+                                              mask,
+                                              NRF_LPCOMP_EVENT_CROSS,
+                                              &event_mask);
+    return event_mask;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // NRFY_LPCOMP_H__

--- a/nrfx/haly/nrfy_pdm.h
+++ b/nrfx/haly/nrfy_pdm.h
@@ -1,0 +1,540 @@
+/*
+ * Copyright (c) 2021 - 2023, Nordic Semiconductor ASA
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef NRFY_PDM_H__
+#define NRFY_PDM_H__
+
+#include <nrfx.h>
+#include <hal/nrf_pdm.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct nrfy_pdm_buffer_t nrfy_pdm_buffer_t;
+
+NRFY_STATIC_INLINE bool __nrfy_internal_pdm_event_handle(NRF_PDM_Type *  p_reg,
+                                                         uint32_t        mask,
+                                                         nrf_pdm_event_t event,
+                                                         uint32_t *      p_event_mask);
+
+NRFY_STATIC_INLINE uint32_t __nrfy_internal_pdm_events_process(NRF_PDM_Type *            p_reg,
+                                                               uint32_t                  mask,
+                                                               nrfy_pdm_buffer_t const * p_buffer);
+
+NRFY_STATIC_INLINE void __nrfy_internal_pdm_event_enabled_clear(NRF_PDM_Type *  p_reg,
+                                                                uint32_t        mask,
+                                                                nrf_pdm_event_t event);
+
+/**
+ * @defgroup nrfy_pdm PDM HALY
+ * @{
+ * @ingroup nrf_pdm
+ * @brief   Hardware access layer with cache and barrier support for managing the PDM peripheral.
+ */
+
+/** @brief Structure describing reception buffer.*/
+struct nrfy_pdm_buffer_t
+{
+    int16_t *  p_buff; ///< Pointer to the data buffer.
+    uint16_t   length; ///< Data buffer lenght.
+};
+
+/** @brief PDM pins configuration structure. */
+typedef struct
+{
+    uint32_t clk_pin; ///< CLK pin number.
+    uint32_t din_pin; ///< DIN pin number.
+} nrfy_pdm_pins_t;
+
+/** @brief PDM configuration structure. */
+typedef struct
+{
+    nrf_pdm_mode_t    mode;          ///< Interface operation mode.
+    nrf_pdm_edge_t    edge;          ///< Sampling mode.
+    nrfy_pdm_pins_t   pins;          ///< Pin configuration structure.
+    nrf_pdm_freq_t    clock_freq;    ///< Clock frequency.
+    nrf_pdm_gain_t    gain_l;        ///< Left channel gain.
+    nrf_pdm_gain_t    gain_r;        ///< Right channel gain.
+#if NRF_PDM_HAS_RATIO_CONFIG
+    nrf_pdm_ratio_t   ratio;         ///< Ratio between PDM_CLK and output sample rate.
+#endif
+#if NRF_PDM_HAS_MCLKCONFIG
+    nrf_pdm_mclksrc_t mclksrc;       ///< Master clock source selection.
+#endif
+    bool              skip_psel_cfg; ///< Skip pin selection configuration.
+                                     /**< When set to true, the driver does not modify
+                                      *   pin select registers in the peripheral.
+                                      *   Those registers are supposed to be set up
+                                      *   externally before the driver is initialized.
+                                      *   @note When both GPIO configuration and pin
+                                      *   selection are to be skipped, the structure
+                                      *   fields that specify pins can be omitted,
+                                      *   as they are ignored anyway. */
+} nrfy_pdm_config_t;
+
+/**
+ * @brief Function for configuring the PDM.
+ *
+ * @param[in] p_reg    Pointer to the structure of registers of the peripheral.
+ * @param[in] p_config Pointer to the peripheral configuration structure.
+ */
+NRFY_STATIC_INLINE void nrfy_pdm_periph_configure(NRF_PDM_Type *            p_reg,
+                                                  nrfy_pdm_config_t const * p_config)
+{
+#if NRF_PDM_HAS_RATIO_CONFIG
+    nrf_pdm_ratio_set(p_reg, p_config->ratio);
+#endif
+
+#if NRF_PDM_HAS_MCLKCONFIG
+    nrf_pdm_mclksrc_configure(p_reg, p_config->mclksrc);
+#endif
+    nrf_pdm_clock_set(p_reg, p_config->clock_freq);
+    nrf_pdm_mode_set(p_reg, p_config->mode, p_config->edge);
+    nrf_pdm_gain_set(p_reg, p_config->gain_l, p_config->gain_r);
+    if (!p_config->skip_psel_cfg)
+    {
+        nrf_pdm_psel_connect(p_reg, p_config->pins.clk_pin, p_config->pins.din_pin);
+    }
+    nrf_barrier_w();
+}
+
+/**
+ * @brief Function for initializing the specified PDM interrupts.
+ *
+ * @param[in] p_reg        Pointer to the structure of registers of the peripheral.
+ * @param[in] mask         Mask of interrupts to be initialized.
+ * @param[in] irq_priority Interrupt priority.
+ * @param[in] enable       True if the interrupts are to be enabled, false otherwise.
+ */
+NRFY_STATIC_INLINE void nrfy_pdm_int_init(NRF_PDM_Type * p_reg,
+                                          uint32_t       mask,
+                                          uint8_t        irq_priority,
+                                          bool           enable)
+{
+    __nrfy_internal_pdm_event_enabled_clear(p_reg, mask, NRF_PDM_EVENT_STARTED);
+    __nrfy_internal_pdm_event_enabled_clear(p_reg, mask, NRF_PDM_EVENT_END);
+    __nrfy_internal_pdm_event_enabled_clear(p_reg, mask, NRF_PDM_EVENT_STOPPED);
+    nrf_barrier_w();
+
+    NRFX_IRQ_PRIORITY_SET(nrfx_get_irq_number(p_reg), irq_priority);
+    NRFX_IRQ_ENABLE(nrfx_get_irq_number(p_reg));
+    if (enable)
+    {
+        nrf_pdm_int_enable(p_reg, mask);
+    }
+
+    nrf_barrier_w();
+}
+
+/**
+ * @brief Function for uninitializing the PDM interrupts.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ */
+NRFY_STATIC_INLINE void nrfy_pdm_int_uninit(NRF_PDM_Type * p_reg)
+{
+    NRFX_IRQ_DISABLE(nrfx_get_irq_number(p_reg));
+    nrf_barrier_w();
+}
+
+/**
+ * @brief Function for processing the specified PDM events.
+ *
+ * @param[in] p_reg    Pointer to the structure of registers of the peripheral.
+ * @param[in] mask     Mask of events to be processed, created by @ref NRFY_EVENT_TO_INT_BITMASK().
+ * @param[in] p_buffer Pointer to the structure containing buffer associated with the last reception. Can be NULL.
+ *
+ * @return Mask of events that were generated and processed.
+ *         To be checked against the result of @ref NRFY_EVENT_TO_INT_BITMASK().
+ */
+NRFY_STATIC_INLINE uint32_t nrfy_pdm_events_process(NRF_PDM_Type *      p_reg,
+                                                    uint32_t            mask,
+                                                    nrfy_pdm_buffer_t * p_buffer)
+{
+    uint32_t evt_mask = __nrfy_internal_pdm_events_process(p_reg, mask, p_buffer);
+    nrf_barrier_w();
+    return evt_mask;
+}
+
+/**
+ * @brief Function for setting the PDM sampling buffer.
+ *
+ * @param[in] p_reg    Pointer to the structure of registers of the peripheral.
+ * @param[in] p_buffer Pointer to the structure containing reception buffer.
+ */
+NRFY_STATIC_INLINE void nrfy_pdm_buffer_set(NRF_PDM_Type *            p_reg,
+                                            nrfy_pdm_buffer_t const * p_buffer)
+{
+    nrf_pdm_buffer_set(p_reg, (uint32_t *)(p_buffer->p_buff), p_buffer->length);
+    nrf_barrier_w();
+}
+
+/**
+ * @brief Function for starting the PDM sampling.
+ *
+ * @param[in] p_reg    Pointer to the structure of registers of the peripheral.
+ * @param[in] p_buffer Pointer to the structure containing reception buffer if the reception
+ *                     is to be blocking. NULL for non-blocking receptions.
+ */
+NRFY_STATIC_INLINE void nrfy_pdm_start(NRF_PDM_Type *            p_reg,
+                                       nrfy_pdm_buffer_t const * p_buffer)
+{
+    nrf_pdm_task_trigger(p_reg, NRF_PDM_TASK_START);
+    if (p_buffer)
+    {
+        nrf_barrier_w();
+        uint32_t evt_mask = NRFY_EVENT_TO_INT_BITMASK(NRF_PDM_EVENT_END);
+        while (!__nrfy_internal_pdm_events_process(p_reg, evt_mask, p_buffer))
+        {}
+    }
+    nrf_barrier_w();
+}
+
+/**
+ * @brief Function for aborting PDM transaction.
+ *
+ * @param[in] p_reg    Pointer to thr structure of registers of the peripheral.
+ * @param[in] p_buffer Pointer to the structure containing reception buffer if the reception
+ *                     is to be blocking. NULL for non-blocking receptions.
+ */
+NRFY_STATIC_INLINE void nrfy_pdm_abort(NRF_PDM_Type *            p_reg,
+                                       nrfy_pdm_buffer_t const * p_buffer)
+{
+    nrf_pdm_task_trigger(p_reg, NRF_PDM_TASK_STOP);
+    if (p_buffer)
+    {
+        nrf_barrier_w();
+        uint32_t evt_mask = NRFY_EVENT_TO_INT_BITMASK(NRF_PDM_EVENT_STOPPED) |
+                            NRFY_EVENT_TO_INT_BITMASK(NRF_PDM_EVENT_END);
+        while (!__nrfy_internal_pdm_events_process(p_reg, evt_mask, p_buffer))
+        {}
+    }
+    nrf_barrier_w();
+}
+
+/**
+ * @brief Function for setting the PDM pins configuration.
+ *
+ * @param[in]  p_reg  Pointer to the structure of registers of the peripheral.
+ * @param[out] p_pins Pointer to the PDM pin configurartion structure.
+ */
+NRFY_STATIC_INLINE void nrfy_pdm_pins_set(NRF_PDM_Type * p_reg, nrfy_pdm_pins_t * p_pins)
+{
+    nrf_pdm_psel_connect(p_reg, p_pins->clk_pin, p_pins->din_pin);
+    nrf_barrier_w();
+}
+
+/**
+ * @brief Function for getting the PDM pins configuration.
+ *
+ * @param[in]  p_reg  Pointer to the structure of registers of the peripheral.
+ * @param[out] p_pins Pointer to the structure to be filled with PDM pins configuration.
+ */
+NRFY_STATIC_INLINE void nrfy_pdm_pins_get(NRF_PDM_Type const * p_reg, nrfy_pdm_pins_t * p_pins)
+{
+    nrf_barrier_rw();
+    p_pins->clk_pin = nrf_pdm_clk_pin_get(p_reg);
+    p_pins->din_pin = nrf_pdm_din_pin_get(p_reg);
+    nrf_barrier_r();
+}
+
+/** @refhal{nrf_pdm_task_trigger} */
+NRFY_STATIC_INLINE void nrfy_pdm_task_trigger(NRF_PDM_Type * p_reg,
+                                              nrf_pdm_task_t task)
+{
+    nrf_pdm_task_trigger(p_reg, task);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_pdm_task_address_get} */
+NRFY_STATIC_INLINE uint32_t nrfy_pdm_task_address_get(NRF_PDM_Type const * p_reg,
+                                                      nrf_pdm_task_t       task)
+{
+    return nrf_pdm_task_address_get(p_reg, task);
+}
+
+/** @refhal{nrf_pdm_event_check} */
+NRFY_STATIC_INLINE bool nrfy_pdm_event_check(NRF_PDM_Type const * p_reg,
+                                             nrf_pdm_event_t      event)
+{
+    nrf_barrier_r();
+    bool check = nrf_pdm_event_check(p_reg, event);
+    nrf_barrier_r();
+    return check;
+}
+
+/** @refhal{nrf_pdm_event_clear} */
+NRFY_STATIC_INLINE void nrfy_pdm_event_clear(NRF_PDM_Type *  p_reg,
+                                             nrf_pdm_event_t event)
+{
+    nrf_pdm_event_clear(p_reg, event);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_pdm_event_address_get} */
+NRFY_STATIC_INLINE uint32_t nrfy_pdm_event_address_get(NRF_PDM_Type const * p_reg,
+                                                       nrf_pdm_event_t      event)
+{
+    return nrf_pdm_event_address_get(p_reg, event);
+}
+
+/** @refhal{nrf_pdm_int_enable} */
+NRFY_STATIC_INLINE void nrfy_pdm_int_enable(NRF_PDM_Type * p_reg,
+                                            uint32_t       mask)
+{
+    nrf_pdm_int_enable(p_reg, mask);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_pdm_int_enable_check} */
+NRFY_STATIC_INLINE uint32_t nrfy_pdm_int_enable_check(NRF_PDM_Type const * p_reg,
+                                                      uint32_t             mask)
+{
+    nrf_barrier_rw();
+    uint32_t check = nrf_pdm_int_enable_check(p_reg, mask);
+    nrf_barrier_r();
+    return check;
+}
+
+/** @refhal{nrf_pdm_int_disable} */
+NRFY_STATIC_INLINE void nrfy_pdm_int_disable(NRF_PDM_Type * p_reg,
+                                             uint32_t       mask)
+{
+    nrf_pdm_int_disable(p_reg, mask);
+    nrf_barrier_w();
+}
+
+#if defined(DPPI_PRESENT) || defined(__NRFX_DOXYGEN__)
+/** @refhal{nrf_pdm_subscribe_set} */
+NRFY_STATIC_INLINE void nrfy_pdm_subscribe_set(NRF_PDM_Type * p_reg,
+                                               nrf_pdm_task_t task,
+                                               uint8_t        channel)
+{
+    nrf_pdm_subscribe_set(p_reg, task, channel);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_pdm_subscribe_clear} */
+NRFY_STATIC_INLINE void nrfy_pdm_subscribe_clear(NRF_PDM_Type * p_reg,
+                                                 nrf_pdm_task_t task)
+{
+    nrf_pdm_subscribe_clear(p_reg, task);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_pdm_publish_set} */
+NRFY_STATIC_INLINE void nrfy_pdm_publish_set(NRF_PDM_Type *  p_reg,
+                                             nrf_pdm_event_t event,
+                                             uint8_t         channel)
+{
+    nrf_pdm_publish_set(p_reg, event, channel);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_pdm_publish_clear} */
+NRFY_STATIC_INLINE void nrfy_pdm_publish_clear(NRF_PDM_Type *  p_reg,
+                                               nrf_pdm_event_t event)
+{
+    nrf_pdm_publish_clear(p_reg, event);
+    nrf_barrier_w();
+}
+#endif
+
+/** @refhal{nrf_pdm_enable} */
+NRFY_STATIC_INLINE void nrfy_pdm_enable(NRF_PDM_Type * p_reg)
+{
+    nrf_pdm_enable(p_reg);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_pdm_disable} */
+NRFY_STATIC_INLINE void nrfy_pdm_disable(NRF_PDM_Type * p_reg)
+{
+    nrf_pdm_disable(p_reg);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_pdm_enable_check} */
+NRFY_STATIC_INLINE bool nrfy_pdm_enable_check(NRF_PDM_Type const * p_reg)
+{
+    nrf_barrier_rw();
+    bool check = nrf_pdm_enable_check(p_reg);
+    nrf_barrier_r();
+    return check;
+}
+
+/** @refhal{nrf_pdm_mode_set} */
+NRFY_STATIC_INLINE void nrfy_pdm_mode_set(NRF_PDM_Type * p_reg,
+                                          nrf_pdm_mode_t pdm_mode,
+                                          nrf_pdm_edge_t pdm_edge)
+{
+    nrf_pdm_mode_set(p_reg, pdm_mode, pdm_edge);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_pdm_mode_get} */
+NRFY_STATIC_INLINE void nrfy_pdm_mode_get(NRF_PDM_Type const * p_reg,
+                                          nrf_pdm_mode_t *     p_pdm_mode,
+                                          nrf_pdm_edge_t *     p_pdm_edge)
+{
+    nrf_barrier_rw();
+    nrf_pdm_mode_get(p_reg, p_pdm_mode, p_pdm_edge);
+    nrf_barrier_r();
+}
+
+/** @refhal{nrf_pdm_clock_set} */
+NRFY_STATIC_INLINE void nrfy_pdm_clock_set(NRF_PDM_Type * p_reg,
+                                           nrf_pdm_freq_t pdm_freq)
+{
+    nrf_pdm_clock_set(p_reg, pdm_freq);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_pdm_clock_get} */
+NRFY_STATIC_INLINE nrf_pdm_freq_t nrfy_pdm_clock_get(NRF_PDM_Type const * p_reg)
+{
+    nrf_barrier_rw();
+    nrf_pdm_freq_t clock = nrf_pdm_clock_get(p_reg);
+    nrf_barrier_r();
+    return clock;
+}
+
+/** @refhal{nrf_pdm_psel_disconnect} */
+NRFY_STATIC_INLINE void nrfy_pdm_pin_disconnect(NRF_PDM_Type * p_reg)
+{
+    nrf_pdm_psel_disconnect(p_reg);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_pdm_gain_set} */
+NRFY_STATIC_INLINE void nrfy_pdm_gain_set(NRF_PDM_Type * p_reg,
+                                          nrf_pdm_gain_t gain_l,
+                                          nrf_pdm_gain_t gain_r)
+{
+    nrf_pdm_gain_set(p_reg, gain_l, gain_r);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_pdm_gain_get} */
+NRFY_STATIC_INLINE void nrfy_pdm_gain_get(NRF_PDM_Type const * p_reg,
+                                          nrf_pdm_gain_t *     p_gain_l,
+                                          nrf_pdm_gain_t *     p_gain_r)
+{
+    nrf_barrier_rw();
+    nrf_pdm_gain_get(p_reg, p_gain_l, p_gain_r);
+    nrf_barrier_r();
+}
+
+/** @refhal{nrf_pdm_buffer_get} */
+NRFY_STATIC_INLINE uint32_t * nrfy_pdm_buffer_get(NRF_PDM_Type const * p_reg)
+{
+    nrf_barrier_rw();
+    uint32_t * p_buffer = nrf_pdm_buffer_get(p_reg);
+    nrf_barrier_r();
+    return p_buffer;
+}
+
+#if NRF_PDM_HAS_RATIO_CONFIG
+/** @refhal{nrf_pdm_ratio_set} */
+NRFY_STATIC_INLINE void nrfy_pdm_ratio_set(NRF_PDM_Type *  p_reg,
+                                           nrf_pdm_ratio_t ratio)
+{
+    nrf_pdm_ratio_set(p_reg, ratio);
+    nrf_barrier_w();
+}
+#endif
+
+#if NRF_PDM_HAS_MCLKCONFIG
+/** @refhal{nrf_pdm_mclksrc_configure} */
+NRFY_STATIC_INLINE void nrfy_pdm_mclksrc_configure(NRF_PDM_Type *    p_reg,
+                                                   nrf_pdm_mclksrc_t mclksrc)
+{
+    nrf_pdm_mclksrc_configure(p_reg, mclksrc);
+    nrf_barrier_w();
+}
+#endif
+
+/** @} */
+
+NRFY_STATIC_INLINE bool __nrfy_internal_pdm_event_handle(NRF_PDM_Type *  p_reg,
+                                                         uint32_t        mask,
+                                                         nrf_pdm_event_t event,
+                                                         uint32_t *      p_event_mask)
+{
+    if ((mask & NRFY_EVENT_TO_INT_BITMASK(event)) && nrf_pdm_event_check(p_reg, event))
+    {
+        nrf_pdm_event_clear(p_reg, event);
+        if (p_event_mask)
+        {
+            *p_event_mask |= NRFY_EVENT_TO_INT_BITMASK(event);
+        }
+        return true;
+    }
+    return false;
+}
+
+NRFY_STATIC_INLINE uint32_t __nrfy_internal_pdm_events_process(NRF_PDM_Type *            p_reg,
+                                                               uint32_t                  mask,
+                                                               nrfy_pdm_buffer_t const * p_buffer)
+{
+    uint32_t evt_mask = 0;
+
+    nrf_barrier_r();
+    (void)__nrfy_internal_pdm_event_handle(p_reg, mask, NRF_PDM_EVENT_STARTED, &evt_mask);
+
+    if (__nrfy_internal_pdm_event_handle(p_reg, mask, NRF_PDM_EVENT_STOPPED, &evt_mask) &&
+        p_buffer->p_buff)
+    {
+        NRFY_CACHE_INV(p_buffer->p_buff, p_buffer->length);
+    }
+
+    (void)__nrfy_internal_pdm_event_handle(p_reg, mask, NRF_PDM_EVENT_END, &evt_mask);
+    return evt_mask;
+}
+
+NRFY_STATIC_INLINE void __nrfy_internal_pdm_event_enabled_clear(NRF_PDM_Type *  p_reg,
+                                                                uint32_t        mask,
+                                                                nrf_pdm_event_t event)
+{
+    if (mask & NRFY_EVENT_TO_INT_BITMASK(event))
+    {
+        nrf_pdm_event_clear(p_reg, event);
+    }
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // NRFY_PDM_H__

--- a/nrfx/haly/nrfy_pwm.h
+++ b/nrfx/haly/nrfy_pwm.h
@@ -1,0 +1,469 @@
+/*
+ * Copyright (c) 2021 - 2023, Nordic Semiconductor ASA
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef NRFY_PWM_H__
+#define NRFY_PWM_H__
+
+#include <nrfx.h>
+#include <hal/nrf_pwm.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+NRFY_STATIC_INLINE bool __nrfy_internal_pwm_event_handle(NRF_PWM_Type *  p_reg,
+                                                         uint32_t        mask,
+                                                         nrf_pwm_event_t event,
+                                                         uint32_t *      p_evt_mask);
+
+NRFY_STATIC_INLINE uint32_t __nrfy_internal_pwm_events_process(NRF_PWM_Type * p_reg, uint32_t mask);
+
+NRFY_STATIC_INLINE void __nrfy_internal_pwm_event_enabled_clear(NRF_PWM_Type *  p_reg,
+                                                                uint32_t        mask,
+                                                                nrf_pwm_event_t event);
+
+/**
+ * @defgroup nrfy_pwm PWM HALY
+ * @{
+ * @ingroup nrf_pwm
+ * @brief   Hardware access layer with cache and barrier support for managing the PWM peripheral.
+ */
+
+/** @brief PWM configuration structure. */
+typedef struct
+{
+    uint32_t           output_pins[NRF_PWM_CHANNEL_COUNT]; ///< Pin numbers for individual output channels (optional).
+                                                           /**< Use @ref NRF_PWM_PIN_NOT_CONNECTED
+                                                            *   if a given output channel is not needed. */
+    uint16_t           top_value;                          ///< Value up to which the pulse generator counter counts.
+    nrf_pwm_clk_t      base_clock;                         ///< Base clock frequency.
+    nrf_pwm_mode_t     count_mode;                         ///< Operating mode of the pulse generator counter.
+    nrf_pwm_dec_load_t load_mode;                          ///< Mode of loading sequence data from RAM.
+    nrf_pwm_dec_step_t step_mode;                          ///< Mode of advancing the active sequence.
+    bool               skip_psel_cfg;                      ///< Skip pin selection configuration.
+                                                           /**< When set to true, the driver does not modify
+                                                            *   pin select registers in the peripheral.
+                                                            *   Those registers are supposed to be set up
+                                                            *   externally before the driver is initialized.
+                                                            *   @note When both GPIO configuration and pin
+                                                            *   selection are to be skipped, the structure
+                                                            *   fields that specify pins can be omitted,
+                                                            *   as they are ignored anyway. */
+} nrfy_pwm_config_t;
+
+/**
+ * @brief Function for configuring the PWM.
+ *
+ * @param[in] p_reg    Pointer to the structure of registers of the peripheral.
+ * @param[in] p_config Pointer to the peripheral configuration structure.
+ */
+NRFY_STATIC_INLINE void nrfy_pwm_periph_configure(NRF_PWM_Type *            p_reg,
+                                                  nrfy_pwm_config_t const * p_config)
+{
+    if (!p_config->skip_psel_cfg)
+    {
+        nrf_pwm_pins_set(p_reg, p_config->output_pins);
+    }
+    nrf_pwm_configure(p_reg, p_config->base_clock, p_config->count_mode, p_config->top_value);
+    nrf_pwm_decoder_set(p_reg, p_config->load_mode, p_config->step_mode);
+    nrf_barrier_w();
+}
+
+/**
+ * @brief Function for initializing the specified PWM interrupts.
+ *
+ * @param[in] p_reg        Pointer to the structure of registers of the peripheral.
+ * @param[in] mask         Mask of interrupts to be initialized.
+ * @param[in] irq_priority Interrupt priority.
+ * @param[in] enable       True if interrupts are to be enabled, false otherwise.
+ */
+NRFY_STATIC_INLINE void nrfy_pwm_int_init(NRF_PWM_Type * p_reg,
+                                          uint32_t       mask,
+                                          uint8_t        irq_priority,
+                                          bool           enable)
+{
+    __nrfy_internal_pwm_event_enabled_clear(p_reg, mask, NRF_PWM_EVENT_LOOPSDONE);
+    __nrfy_internal_pwm_event_enabled_clear(p_reg, mask, NRF_PWM_EVENT_SEQEND0);
+    __nrfy_internal_pwm_event_enabled_clear(p_reg, mask, NRF_PWM_EVENT_SEQEND1);
+    __nrfy_internal_pwm_event_enabled_clear(p_reg, mask, NRF_PWM_EVENT_STOPPED);
+    __nrfy_internal_pwm_event_enabled_clear(p_reg, mask, NRF_PWM_EVENT_SEQSTARTED0);
+    __nrfy_internal_pwm_event_enabled_clear(p_reg, mask, NRF_PWM_EVENT_SEQSTARTED1);
+    __nrfy_internal_pwm_event_enabled_clear(p_reg, mask, NRF_PWM_EVENT_PWMPERIODEND);
+    nrf_barrier_w();
+
+    NRFX_IRQ_PRIORITY_SET(nrfx_get_irq_number(p_reg), irq_priority);
+    NRFX_IRQ_ENABLE(nrfx_get_irq_number(p_reg));
+
+    if (enable)
+    {
+        nrf_pwm_int_enable(p_reg, mask);
+    }
+    nrf_barrier_w();
+}
+
+/**
+ * @brief Function for uninitializing the PWM interrupts.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ */
+NRFY_STATIC_INLINE void nrfy_pwm_int_uninit(NRF_PWM_Type * p_reg)
+{
+    NRFX_IRQ_DISABLE(nrfx_get_irq_number(p_reg));
+    nrf_barrier_w();
+}
+
+/**
+ * @brief Function for processing the specified PWM events.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ * @param[in] mask  Mask of events to be processed, created by @ref NRFY_EVENT_TO_INT_BITMASK.
+ *
+ * @return Mask of events that were generated and processed.
+ *         To be checked against the result of @ref NRFY_EVENT_TO_INT_BITMASK().
+ */
+NRFY_STATIC_INLINE uint32_t nrfy_pwm_events_process(NRF_PWM_Type * p_reg, uint32_t mask)
+{
+    nrf_barrier_r();
+    uint32_t evt_mask = __nrfy_internal_pwm_events_process(p_reg, mask);
+    nrf_barrier_w();
+    return evt_mask;
+}
+
+/**
+ * @brief Function for starting the PWM sequence.
+ *
+ * @param[in] p_reg  Pointer to the structure of registers of the peripheral.
+ * @param[in] seq_id Sequence index.
+ * @param[in] wait   True if the sequence is to be blocking, false otherwise.
+ */
+NRFY_STATIC_INLINE void nrfy_pwm_start(NRF_PWM_Type * p_reg,
+                                       uint8_t        seq_id,
+                                       bool           wait)
+{
+    nrf_pwm_task_trigger(p_reg, nrf_pwm_seqstart_task_get(seq_id));
+
+    if (wait)
+    {
+        nrf_barrier_w();
+        uint32_t evt_mask = NRFY_EVENT_TO_INT_BITMASK(nrf_pwm_seqend_event_get(seq_id));
+        while (!__nrfy_internal_pwm_events_process(p_reg, evt_mask))
+        {}
+    }
+    nrf_barrier_w();
+}
+
+/**
+ * @brief Function for aborting the ongoing PWM sequence.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ * @param[in] wait  True if the abort is to be blocking, false otherwise.
+ */
+NRFY_STATIC_INLINE void nrfy_pwm_abort(NRF_PWM_Type * p_reg, bool wait)
+{
+    nrf_pwm_task_trigger(p_reg, NRF_PWM_TASK_STOP);
+
+    if (wait)
+    {
+        nrf_barrier_w();
+        uint32_t evt_mask = NRFY_EVENT_TO_INT_BITMASK(NRF_PWM_EVENT_STOPPED);
+        while (!__nrfy_internal_pwm_events_process(p_reg, evt_mask))
+        {}
+        (void)__nrfy_internal_pwm_events_process(p_reg,
+            NRFY_EVENT_TO_INT_BITMASK(NRF_PWM_EVENT_SEQEND0) |
+            NRFY_EVENT_TO_INT_BITMASK(NRF_PWM_EVENT_SEQEND1));
+    }
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_pwm_task_trigger} */
+NRFY_STATIC_INLINE void nrfy_pwm_task_trigger(NRF_PWM_Type * p_reg,
+                                              nrf_pwm_task_t task)
+{
+    nrf_pwm_task_trigger(p_reg, task);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_pwm_task_address_get} */
+NRFY_STATIC_INLINE uint32_t nrfy_pwm_task_address_get(NRF_PWM_Type const * p_reg,
+                                                      nrf_pwm_task_t       task)
+{
+    return nrf_pwm_task_address_get(p_reg, task);
+}
+
+/** @refhal{nrf_pwm_event_clear} */
+NRFY_STATIC_INLINE void nrfy_pwm_event_clear(NRF_PWM_Type *  p_reg,
+                                             nrf_pwm_event_t event)
+{
+    nrf_pwm_event_clear(p_reg, event);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_pwm_event_check} */
+NRFY_STATIC_INLINE bool nrfy_pwm_event_check(NRF_PWM_Type const * p_reg,
+                                             nrf_pwm_event_t      event)
+{
+    nrf_barrier_r();
+    bool ret = nrf_pwm_event_check(p_reg, event);
+    nrf_barrier_r();
+    return ret;
+}
+
+/** @refhal{nrf_pwm_event_address_get} */
+NRFY_STATIC_INLINE uint32_t nrfy_pwm_event_address_get(NRF_PWM_Type const * p_reg,
+                                                       nrf_pwm_event_t      event)
+{
+    return nrf_pwm_event_address_get(p_reg, event);
+}
+
+/** @refhal{nrf_pwm_shorts_enable} */
+NRFY_STATIC_INLINE void nrfy_pwm_shorts_enable(NRF_PWM_Type * p_reg,
+                                               uint32_t       mask)
+{
+    nrf_pwm_shorts_enable(p_reg, mask);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_pwm_shorts_disable} */
+NRFY_STATIC_INLINE void nrfy_pwm_shorts_disable(NRF_PWM_Type * p_reg,
+                                                uint32_t       mask)
+{
+    nrf_pwm_shorts_disable(p_reg, mask);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_pwm_shorts_set} */
+NRFY_STATIC_INLINE void nrfy_pwm_shorts_set(NRF_PWM_Type * p_reg,
+                                            uint32_t       mask)
+{
+    nrf_pwm_shorts_set(p_reg, mask);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_pwm_int_enable} */
+NRFY_STATIC_INLINE void nrfy_pwm_int_enable(NRF_PWM_Type * p_reg,
+                                            uint32_t       mask)
+{
+    nrf_pwm_int_enable(p_reg, mask);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_pwm_int_disable} */
+NRFY_STATIC_INLINE void nrfy_pwm_int_disable(NRF_PWM_Type * p_reg,
+                                             uint32_t       mask)
+{
+    nrf_pwm_int_disable(p_reg, mask);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_pwm_int_set} */
+NRFY_STATIC_INLINE void nrfy_pwm_int_set(NRF_PWM_Type * p_reg,
+                                         uint32_t       mask)
+{
+    nrf_pwm_int_set(p_reg, mask);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_pwm_int_enable_check} */
+NRFY_STATIC_INLINE uint32_t nrfy_pwm_int_enable_check(NRF_PWM_Type const * p_reg, uint32_t mask)
+{
+    nrf_barrier_rw();
+    uint32_t ret = nrf_pwm_int_enable_check(p_reg, mask);
+    nrf_barrier_r();
+    return ret;
+}
+
+#if defined(DPPI_PRESENT) || defined(__NRFX_DOXYGEN__)
+/** @refhal{nrf_pwm_subscribe_set} */
+NRFY_STATIC_INLINE void nrfy_pwm_subscribe_set(NRF_PWM_Type * p_reg,
+                                               nrf_pwm_task_t task,
+                                               uint8_t        channel)
+{
+    nrf_pwm_subscribe_set(p_reg, task, channel);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_pwm_subscribe_clear} */
+NRFY_STATIC_INLINE void nrfy_pwm_subscribe_clear(NRF_PWM_Type * p_reg,
+                                                 nrf_pwm_task_t task)
+{
+    nrf_pwm_subscribe_clear(p_reg, task);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_pwm_publish_set} */
+NRFY_STATIC_INLINE void nrfy_pwm_publish_set(NRF_PWM_Type *  p_reg,
+                                             nrf_pwm_event_t event,
+                                             uint8_t         channel)
+{
+    nrf_pwm_publish_set(p_reg, event, channel);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_pwm_publish_clear} */
+NRFY_STATIC_INLINE void nrfy_pwm_publish_clear(NRF_PWM_Type *  p_reg,
+                                               nrf_pwm_event_t event)
+{
+    nrf_pwm_publish_clear(p_reg, event);
+    nrf_barrier_w();
+}
+#endif
+
+/** @refhal{nrf_pwm_enable} */
+NRFY_STATIC_INLINE void nrfy_pwm_enable(NRF_PWM_Type * p_reg)
+{
+    nrf_pwm_enable(p_reg);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_pwm_disable} */
+NRFY_STATIC_INLINE void nrfy_pwm_disable(NRF_PWM_Type * p_reg)
+{
+    nrf_pwm_disable(p_reg);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_pwm_pins_set} */
+NRFY_STATIC_INLINE void nrfy_pwm_pins_set(NRF_PWM_Type * p_reg,
+                                          uint32_t       out_pins[NRF_PWM_CHANNEL_COUNT])
+{
+    nrf_pwm_pins_set(p_reg, out_pins);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_pwm_pin_get} */
+NRFY_STATIC_INLINE uint32_t nrfy_pwm_pin_get(NRF_PWM_Type const * p_reg, uint8_t channel)
+{
+    nrf_barrier_rw();
+    uint32_t ret = nrf_pwm_pin_get(p_reg, channel);
+    nrf_barrier_r();
+    return ret;
+}
+
+/** @refhal{nrf_pwm_configure} */
+NRFY_STATIC_INLINE void nrfy_pwm_configure(NRF_PWM_Type * p_reg,
+                                           nrf_pwm_clk_t  base_clock,
+                                           nrf_pwm_mode_t mode,
+                                           uint16_t       top_value)
+{
+    nrf_pwm_configure(p_reg, base_clock, mode, top_value);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_pwm_sequence_set} */
+NRFY_STATIC_INLINE void nrfy_pwm_sequence_set(NRF_PWM_Type *             p_reg,
+                                              uint8_t                    seq_id,
+                                              nrf_pwm_sequence_t const * p_seq)
+{
+    NRFY_CACHE_WB(p_seq->values.p_raw, p_seq->length);
+    nrf_pwm_sequence_set(p_reg, seq_id, p_seq);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_pwm_decoder_set} */
+NRFY_STATIC_INLINE void nrfy_pwm_decoder_set(NRF_PWM_Type *     p_reg,
+                                             nrf_pwm_dec_load_t dec_load,
+                                             nrf_pwm_dec_step_t dec_step)
+{
+    nrf_pwm_decoder_set(p_reg, dec_load, dec_step);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_pwm_loop_set} */
+NRFY_STATIC_INLINE void nrfy_pwm_loop_set(NRF_PWM_Type * p_reg, uint16_t loop_count)
+{
+    nrf_pwm_loop_set(p_reg, loop_count);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_pwm_seqstart_task_get} */
+NRFY_STATIC_INLINE nrf_pwm_task_t nrfy_pwm_seqstart_task_get(uint8_t seq_id)
+{
+    return nrf_pwm_seqstart_task_get(seq_id);
+}
+
+/** @refhal{nrf_pwm_seqend_event_get} */
+NRFY_STATIC_INLINE nrf_pwm_event_t nrfy_pwm_seqend_event_get(uint8_t seq_id)
+{
+    return nrf_pwm_seqend_event_get(seq_id);
+}
+
+/** @} */
+
+NRFY_STATIC_INLINE bool __nrfy_internal_pwm_event_handle(NRF_PWM_Type *  p_reg,
+                                                         uint32_t        mask,
+                                                         nrf_pwm_event_t event,
+                                                         uint32_t *      p_evt_mask)
+{
+    if ((mask & NRFY_EVENT_TO_INT_BITMASK(event)) && nrf_pwm_event_check(p_reg, event))
+    {
+        nrf_barrier_r();
+        nrf_pwm_event_clear(p_reg, event);
+        if (p_evt_mask)
+        {
+            *p_evt_mask |= NRFY_EVENT_TO_INT_BITMASK(event);
+        }
+        return true;
+    }
+    return false;
+}
+
+NRFY_STATIC_INLINE uint32_t __nrfy_internal_pwm_events_process(NRF_PWM_Type * p_reg, uint32_t mask)
+{
+    uint32_t evt_mask = 0;
+
+    (void)__nrfy_internal_pwm_event_handle(p_reg, mask, NRF_PWM_EVENT_SEQEND0, &evt_mask);
+    (void)__nrfy_internal_pwm_event_handle(p_reg, mask, NRF_PWM_EVENT_SEQEND1, &evt_mask);
+    (void)__nrfy_internal_pwm_event_handle(p_reg, mask, NRF_PWM_EVENT_LOOPSDONE, &evt_mask);
+    (void)__nrfy_internal_pwm_event_handle(p_reg, mask, NRF_PWM_EVENT_STOPPED, &evt_mask);
+    (void)__nrfy_internal_pwm_event_handle(p_reg, mask, NRF_PWM_EVENT_SEQSTARTED0, &evt_mask);
+    (void)__nrfy_internal_pwm_event_handle(p_reg, mask, NRF_PWM_EVENT_SEQSTARTED1, &evt_mask);
+    (void)__nrfy_internal_pwm_event_handle(p_reg, mask, NRF_PWM_EVENT_PWMPERIODEND, &evt_mask);
+
+    return evt_mask;
+}
+
+NRFY_STATIC_INLINE void __nrfy_internal_pwm_event_enabled_clear(NRF_PWM_Type *  p_reg,
+                                                                uint32_t        mask,
+                                                                nrf_pwm_event_t event)
+{
+    if (mask & NRFY_EVENT_TO_INT_BITMASK(event))
+    {
+        nrf_pwm_event_clear(p_reg, event);
+    }
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // NRFY_PWM_H__

--- a/nrfx/haly/nrfy_qdec.h
+++ b/nrfx/haly/nrfy_qdec.h
@@ -1,0 +1,576 @@
+/*
+ * Copyright (c) 2021 - 2023, Nordic Semiconductor ASA
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef NRFY_QDEC_H__
+#define NRFY_QDEC_H__
+
+#include <nrfx.h>
+#include <hal/nrf_qdec.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+NRFY_STATIC_INLINE void __nrfy_internal_qdec_event_enabled_clear(NRF_QDEC_Type *  p_reg,
+                                                                 uint32_t         mask,
+                                                                 nrf_qdec_event_t event);
+
+NRFY_STATIC_INLINE bool __nrfy_internal_qdec_event_handle(NRF_QDEC_Type *  p_reg,
+                                                          uint32_t         mask,
+                                                          nrf_qdec_event_t event,
+                                                          uint32_t *       p_evt_mask);
+
+NRFY_STATIC_INLINE uint32_t __nrfy_internal_qdec_events_process(NRF_QDEC_Type * p_reg,
+                                                                uint32_t        mask);
+
+/**
+ * @defgroup nrfy_qdec QDEC HALY
+ * @{
+ * @ingroup nrf_qdec
+ * @brief   Hardware access layer with cache and barrier support for managing the QDEC peripheral.
+ */
+
+/** @brief Configuration structure for QDEC pins. */
+typedef struct
+{
+    uint32_t a_pin;   /**< Pin number for A input. */
+    uint32_t b_pin;   /**< Pin number for B input. */
+    uint32_t led_pin; /**< Pin number for LED output. */
+} nrfy_qdec_pins_t;
+
+/** @brief QDEC configuration structure. */
+typedef struct
+{
+    nrf_qdec_reportper_t reportper;     /**< Report period in samples. */
+    nrf_qdec_sampleper_t sampleper;     /**< Sampling period in microseconds. */
+    nrfy_qdec_pins_t     pins;          /**< Pin configuration structure. */
+    uint32_t             ledpre;        /**< Time (in microseconds) how long LED is switched on before sampling. */
+    nrf_qdec_ledpol_t    ledpol;        /**< Active LED polarity. */
+    bool                 dbfen;         /**< State of debouncing filter. */
+    bool                 skip_psel_cfg; /**< Skip pin selection configuration.
+                                             When set to true, the driver does not modify
+                                             pin select registers in the peripheral.
+                                             Those registers are supposed to be set up
+                                             externally before the driver is initialized.
+                                             @note When both GPIO configuration and pin
+                                             selection are to be skipped, the structure
+                                             fields that specify pins can be omitted,
+                                             as they are ignored anyway. */
+} nrfy_qdec_config_t;
+
+/**
+ * @brief Function for configuring the QDEC.
+ *
+ * @param[in] p_reg    Pointer to the structure of registers of the peripheral.
+ * @param[in] p_config Pointer to the peripheral configuration structure.
+ */
+NRFY_STATIC_INLINE void nrfy_qdec_periph_configure(NRF_QDEC_Type *            p_reg,
+                                                   nrfy_qdec_config_t const * p_config)
+{
+    nrf_qdec_sampleper_set(p_reg, p_config->sampleper);
+    nrf_qdec_reportper_set(p_reg, p_config->reportper);
+
+    if (p_config->pins.led_pin != NRF_QDEC_PIN_NOT_CONNECTED)
+    {
+        nrf_qdec_ledpre_set(p_reg, p_config->ledpre);
+        nrf_qdec_ledpol_set(p_reg, p_config->ledpol);
+    }
+
+    if (!p_config->skip_psel_cfg)
+    {
+        nrf_qdec_pins_set(p_reg,
+                          p_config->pins.a_pin,
+                          p_config->pins.b_pin,
+                          p_config->pins.led_pin);
+    }
+
+    if (p_config->dbfen)
+    {
+        nrf_qdec_dbfen_enable(p_reg);
+    }
+    else
+    {
+        nrf_qdec_dbfen_disable(p_reg);
+    }
+
+    nrf_barrier_w();
+}
+
+/**
+ * @brief Function for initializing the specified QDEC interrupts.
+ *
+ * @param[in] p_reg        Pointer to the structure of registers of the peripheral.
+ * @param[in] mask         Mask of interrupts to be initialized.
+ * @param[in] irq_priority Interrupt priority.
+ * @param[in] enable       True if the interrupts are to be enabled, false otherwise.
+ */
+NRFY_STATIC_INLINE void nrfy_qdec_int_init(NRF_QDEC_Type * p_reg,
+                                           uint32_t        mask,
+                                           uint8_t         irq_priority,
+                                           bool            enable)
+{
+    __nrfy_internal_qdec_event_enabled_clear(p_reg, mask, NRF_QDEC_EVENT_SAMPLERDY);
+    __nrfy_internal_qdec_event_enabled_clear(p_reg, mask, NRF_QDEC_EVENT_REPORTRDY);
+    __nrfy_internal_qdec_event_enabled_clear(p_reg, mask, NRF_QDEC_EVENT_ACCOF);
+#if NRF_QDEC_HAS_EVENT_DBLRDY
+    __nrfy_internal_qdec_event_enabled_clear(p_reg, mask, NRF_QDEC_EVENT_DBLRDY);
+#endif
+#if NRF_QDEC_HAS_EVENT_STOPPED
+    __nrfy_internal_qdec_event_enabled_clear(p_reg, mask, NRF_QDEC_EVENT_STOPPED);
+#endif
+
+    nrf_barrier_w();
+
+    NRFX_IRQ_PRIORITY_SET(nrfx_get_irq_number(p_reg), irq_priority);
+    NRFX_IRQ_ENABLE(nrfx_get_irq_number(p_reg));
+
+    if (enable)
+    {
+        nrf_qdec_int_enable(p_reg, mask);
+    }
+
+    nrf_barrier_w();
+}
+
+/**
+ * @brief Function for uninitializing the QDEC interrupts.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ */
+NRFY_STATIC_INLINE void nrfy_qdec_int_uninit(NRF_QDEC_Type * p_reg)
+{
+    NRFX_IRQ_DISABLE(nrfx_get_irq_number(p_reg));
+    nrf_barrier_w();
+}
+
+/**
+ * @brief Function for processing the specified QDEC events.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ * @param[in] mask  Mask of events to be processed, created by @ref NRFY_EVENT_TO_INT_BITMASK().
+ *
+ * @return Mask of events that were generated and processed.
+ *         To be checked against the result of @ref NRFY_EVENT_TO_INT_BITMASK().
+ */
+NRFY_STATIC_INLINE uint32_t nrfy_qdec_events_process(NRF_QDEC_Type * p_reg,
+                                                     uint32_t        mask)
+{
+    uint32_t evt_mask = __nrfy_internal_qdec_events_process(p_reg, mask);
+    nrf_barrier_w();
+    return evt_mask;
+}
+
+/**
+ * @brief Function for reading QDEC accumulators.
+ *
+ * @param[in] p_reg    Pointer to the structure of registers of the peripheral.
+ * @param[in] p_acc    Pointer to store the accumulated transitions
+ * @param[in] p_accdbl Pointer to store the accumulated double transitions.
+ */
+NRFY_STATIC_INLINE void nrfy_qdec_accumulators_read(NRF_QDEC_Type const * p_reg,
+                                                    int32_t *             p_acc,
+                                                    uint32_t *            p_accdbl)
+{
+    nrf_barrier_r();
+    *p_acc    = nrf_qdec_accread_get(p_reg);
+    *p_accdbl = nrf_qdec_accdblread_get(p_reg);
+    nrf_barrier_r();
+}
+
+/**
+ * @brief Function for reading QDEC pins.
+ *
+ * @param[in] p_reg  Pointer to the structure of registers of the peripheral.
+ * @param[in] p_pins Pointer to the QDEC pin configurartion structure.
+ */
+NRFY_STATIC_INLINE void nrfy_qdec_pins_get(NRF_QDEC_Type const * p_reg,
+                                           nrfy_qdec_pins_t *    p_pins)
+{
+    nrf_barrier_rw();
+    p_pins->a_pin   = nrf_qdec_phase_a_pin_get(p_reg);
+    p_pins->b_pin   = nrf_qdec_phase_b_pin_get(p_reg);
+    p_pins->led_pin = nrf_qdec_led_pin_get(p_reg);
+    nrf_barrier_r();
+}
+
+/**
+ * @brief Function for setting QDEC pins.
+ *
+ * @param[in] p_reg  Pointer to the structure of registers of the peripheral.
+ * @param[in] p_pins Pointer to the QDEC pin configurartion structure.
+ */
+NRFY_STATIC_INLINE void nrfy_qdec_pins_set(NRF_QDEC_Type *          p_reg,
+                                           nrfy_qdec_pins_t const * p_pins)
+{
+    nrf_qdec_pins_set(p_reg, p_pins->a_pin, p_pins->b_pin, p_pins->led_pin);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_qdec_enable} */
+NRFY_STATIC_INLINE void nrfy_qdec_enable(NRF_QDEC_Type * p_reg)
+{
+    nrf_qdec_enable(p_reg);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_qdec_disable} */
+NRFY_STATIC_INLINE void nrfy_qdec_disable(NRF_QDEC_Type * p_reg)
+{
+    nrf_qdec_disable(p_reg);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_qdec_enable_get} */
+NRFY_STATIC_INLINE uint32_t nrfy_qdec_enable_get(NRF_QDEC_Type const * p_reg)
+{
+    nrf_barrier_rw();
+    uint32_t ret = nrf_qdec_enable_get(p_reg);
+    nrf_barrier_r();
+    return ret;
+}
+
+/** @refhal{nrf_qdec_int_enable} */
+NRFY_STATIC_INLINE void nrfy_qdec_int_enable(NRF_QDEC_Type * p_reg, uint32_t mask)
+{
+    nrf_qdec_int_enable(p_reg, mask);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_qdec_int_disable} */
+NRFY_STATIC_INLINE void nrfy_qdec_int_disable(NRF_QDEC_Type * p_reg, uint32_t mask)
+{
+    nrf_qdec_int_disable(p_reg, mask);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_qdec_int_enable_check} */
+NRFY_STATIC_INLINE uint32_t nrfy_qdec_int_enable_check(NRF_QDEC_Type const * p_reg, uint32_t mask)
+{
+    nrf_barrier_rw();
+    uint32_t ret = nrf_qdec_int_enable_check(p_reg, mask);
+    nrf_barrier_r();
+    return ret;
+}
+
+/** @refhal{nrf_qdec_dbfen_enable} */
+NRFY_STATIC_INLINE void nrfy_qdec_dbfen_enable(NRF_QDEC_Type * p_reg)
+{
+    nrf_qdec_dbfen_enable(p_reg);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_qdec_dbfen_disable} */
+NRFY_STATIC_INLINE void nrfy_qdec_dbfen_disable(NRF_QDEC_Type * p_reg)
+{
+    nrf_qdec_dbfen_disable(p_reg);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_qdec_dbfen_get} */
+NRFY_STATIC_INLINE uint32_t nrfy_qdec_dbfen_get(NRF_QDEC_Type const * p_reg)
+{
+    nrf_barrier_rw();
+    uint32_t ret = nrf_qdec_dbfen_get(p_reg);
+    nrf_barrier_r();
+    return ret;
+}
+
+/** @refhal{nrf_qdec_phase_a_pin_get} */
+NRFY_STATIC_INLINE uint32_t nrfy_qdec_a_pin_get(NRF_QDEC_Type const * p_reg)
+{
+    nrf_barrier_rw();
+    uint32_t ret = nrf_qdec_phase_a_pin_get(p_reg);
+    nrf_barrier_r();
+    return ret;
+}
+
+/** @refhal{nrf_qdec_phase_b_pin_get} */
+NRFY_STATIC_INLINE uint32_t nrfy_qdec_b_pin_get(NRF_QDEC_Type const * p_reg)
+{
+    nrf_barrier_rw();
+    uint32_t ret = nrf_qdec_phase_b_pin_get(p_reg);
+    nrf_barrier_r();
+    return ret;
+}
+
+/** @refhal{nrf_qdec_led_pin_get} */
+NRFY_STATIC_INLINE uint32_t nrfy_qdec_led_pin_get(NRF_QDEC_Type const * p_reg)
+{
+    nrf_barrier_rw();
+    uint32_t ret = nrf_qdec_led_pin_get(p_reg);
+    nrf_barrier_r();
+    return ret;
+}
+
+/** @refhal{nrf_qdec_task_trigger} */
+NRFY_STATIC_INLINE void nrfy_qdec_task_trigger(NRF_QDEC_Type * p_reg, nrf_qdec_task_t task)
+{
+    nrf_qdec_task_trigger(p_reg, task);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_qdec_task_address_get} */
+NRFY_STATIC_INLINE uint32_t nrfy_qdec_task_address_get(NRF_QDEC_Type const * p_reg,
+                                                       nrf_qdec_task_t       task)
+{
+    return nrf_qdec_task_address_get(p_reg, task);
+}
+
+/** @refhal{nrf_qdec_event_clear} */
+NRFY_STATIC_INLINE void nrfy_qdec_event_clear(NRF_QDEC_Type * p_reg, nrf_qdec_event_t event)
+{
+    nrf_qdec_event_clear(p_reg, event);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_qdec_event_check} */
+NRFY_STATIC_INLINE bool nrfy_qdec_event_check(NRF_QDEC_Type const * p_reg, nrf_qdec_event_t event)
+{
+    nrf_barrier_rw();
+    bool ret = nrf_qdec_event_check(p_reg, event);
+    nrf_barrier_r();
+    return ret;
+}
+
+/** @refhal{nrf_qdec_event_address_get} */
+NRFY_STATIC_INLINE uint32_t nrfy_qdec_event_address_get(NRF_QDEC_Type const * p_reg,
+                                                        nrf_qdec_event_t      event)
+{
+    return nrf_qdec_event_address_get(p_reg, event);
+}
+
+/** @refhal{nrf_qdec_shorts_enable} */
+NRFY_STATIC_INLINE void nrfy_qdec_shorts_enable(NRF_QDEC_Type * p_reg, uint32_t mask)
+{
+    nrf_qdec_shorts_enable(p_reg, mask);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_qdec_shorts_disable} */
+NRFY_STATIC_INLINE void nrfy_qdec_shorts_disable(NRF_QDEC_Type * p_reg, uint32_t mask)
+{
+    nrf_qdec_shorts_disable(p_reg, mask);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_qdec_sampleper_to_value} */
+NRFY_STATIC_INLINE uint32_t nrfy_qdec_sampleper_to_value(nrf_qdec_sampleper_t sampleper)
+{
+    return nrf_qdec_sampleper_to_value(sampleper);
+}
+
+/** @refhal{nrf_qdec_sampleper_set} */
+NRFY_STATIC_INLINE void nrfy_qdec_sampleper_set(NRF_QDEC_Type *      p_reg,
+                                                nrf_qdec_sampleper_t sampleper)
+{
+    nrf_qdec_sampleper_set(p_reg, sampleper);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_qdec_sampleper_get} */
+NRFY_STATIC_INLINE nrf_qdec_sampleper_t nrfy_qdec_sampleper_get(NRF_QDEC_Type const * p_reg)
+{
+    nrf_barrier_rw();
+    nrf_qdec_sampleper_t ret = nrf_qdec_sampleper_get(p_reg);
+    nrf_barrier_r();
+    return ret;
+}
+
+/** @refhal{nrf_qdec_sample_get} */
+NRFY_STATIC_INLINE int32_t nrfy_qdec_sample_get(NRF_QDEC_Type const * p_reg)
+{
+    nrf_barrier_rw();
+    int32_t ret = nrf_qdec_sample_get(p_reg);
+    nrf_barrier_r();
+    return ret;
+}
+
+/** @refhal{nrf_qdec_acc_get} */
+NRFY_STATIC_INLINE int32_t nrfy_qdec_acc_get(NRF_QDEC_Type const * p_reg)
+{
+    nrf_barrier_r();
+    int32_t ret = nrf_qdec_acc_get(p_reg);
+    nrf_barrier_r();
+    return ret;
+}
+
+/** @refhal{nrf_qdec_accread_get} */
+NRFY_STATIC_INLINE int32_t nrfy_qdec_accread_get(NRF_QDEC_Type const * p_reg)
+{
+    nrf_barrier_r();
+    int32_t ret = nrf_qdec_accread_get(p_reg);
+    nrf_barrier_r();
+    return ret;
+}
+
+/** @refhal{nrf_qdec_accdbl_get} */
+NRFY_STATIC_INLINE uint32_t nrfy_qdec_accdbl_get(NRF_QDEC_Type const * p_reg)
+{
+    nrf_barrier_r();
+    uint32_t ret = nrf_qdec_accdbl_get(p_reg);
+    nrf_barrier_r();
+    return ret;
+}
+
+/** @refhal{nrf_qdec_accdblread_get} */
+NRFY_STATIC_INLINE uint32_t nrfy_qdec_accdblread_get(NRF_QDEC_Type const * p_reg)
+{
+    nrf_barrier_r();
+    uint32_t ret = nrf_qdec_accdblread_get(p_reg);
+    nrf_barrier_r();
+    return ret;
+}
+
+/** @refhal{nrf_qdec_ledpre_set} */
+NRFY_STATIC_INLINE void nrfy_qdec_ledpre_set(NRF_QDEC_Type * p_reg, uint32_t time_us)
+{
+    nrf_qdec_ledpre_set(p_reg, time_us);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_qdec_ledpre_get} */
+NRFY_STATIC_INLINE uint32_t nrfy_qdec_ledpre_get(NRF_QDEC_Type const * p_reg)
+{
+    nrf_barrier_rw();
+    uint32_t ret = nrf_qdec_ledpre_get(p_reg);
+    nrf_barrier_r();
+    return ret;
+}
+
+/** @refhal{nrf_qdec_ledpol_set} */
+NRFY_STATIC_INLINE void nrfy_qdec_ledpol_set(NRF_QDEC_Type * p_reg, nrf_qdec_ledpol_t pol)
+{
+    nrf_qdec_ledpol_set(p_reg, pol);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_qdec_ledpol_get} */
+NRFY_STATIC_INLINE uint32_t nrfy_qdec_ledpol_get(NRF_QDEC_Type const * p_reg)
+{
+    nrf_barrier_rw();
+    uint32_t ret = nrf_qdec_ledpol_get(p_reg);
+    nrf_barrier_r();
+
+    return ret;
+}
+
+/** @refhal{nrf_qdec_reportper_set} */
+NRFY_STATIC_INLINE void nrfy_qdec_reportper_set(NRF_QDEC_Type *      p_reg,
+                                                nrf_qdec_reportper_t reportper)
+{
+    nrf_qdec_reportper_set(p_reg, reportper);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_qdec_reportper_get} */
+NRFY_STATIC_INLINE nrf_qdec_reportper_t nrfy_qdec_reportper_get(NRF_QDEC_Type const * p_reg)
+{
+    nrf_barrier_rw();
+    nrf_qdec_reportper_t ret = nrf_qdec_reportper_get(p_reg);
+    nrf_barrier_r();
+    return ret;
+}
+
+/** @refhal{nrf_qdec_reportper_to_value} */
+NRFY_STATIC_INLINE uint32_t nrfy_qdec_reportper_to_value(nrf_qdec_reportper_t reportper)
+{
+    return nrf_qdec_reportper_to_value(reportper);
+}
+
+/** @} */
+
+NRFY_STATIC_INLINE void __nrfy_internal_qdec_event_enabled_clear(NRF_QDEC_Type *  p_reg,
+                                                                 uint32_t         mask,
+                                                                 nrf_qdec_event_t event)
+{
+    if (mask & NRFY_EVENT_TO_INT_BITMASK(event))
+    {
+        nrf_qdec_event_clear(p_reg, event);
+    }
+}
+
+NRFY_STATIC_INLINE bool __nrfy_internal_qdec_event_handle(NRF_QDEC_Type *  p_reg,
+                                                          uint32_t         mask,
+                                                          nrf_qdec_event_t event,
+                                                          uint32_t *       p_evt_mask)
+{
+    if ((mask & NRFY_EVENT_TO_INT_BITMASK(event)) && nrf_qdec_event_check(p_reg, event))
+    {
+        nrf_qdec_event_clear(p_reg, event);
+        if (p_evt_mask)
+        {
+            *p_evt_mask |= NRFY_EVENT_TO_INT_BITMASK(event);
+        }
+        return true;
+    }
+    return false;
+}
+
+NRFY_STATIC_INLINE uint32_t __nrfy_internal_qdec_events_process(NRF_QDEC_Type * p_reg,
+                                                                uint32_t        mask)
+{
+    uint32_t event_mask = 0;
+
+    nrf_barrier_r();
+    (void)__nrfy_internal_qdec_event_handle(p_reg,
+                                            mask,
+                                            NRF_QDEC_EVENT_SAMPLERDY,
+                                            &event_mask);
+    (void)__nrfy_internal_qdec_event_handle(p_reg,
+                                            mask,
+                                            NRF_QDEC_EVENT_REPORTRDY,
+                                            &event_mask);
+    (void)__nrfy_internal_qdec_event_handle(p_reg,
+                                            mask,
+                                            NRF_QDEC_EVENT_ACCOF,
+                                            &event_mask);
+#if NRF_QDEC_HAS_EVENT_DBLRDY
+    (void)__nrfy_internal_qdec_event_handle(p_reg,
+                                            mask,
+                                            NRF_QDEC_EVENT_DBLRDY,
+                                            &event_mask);
+#endif
+#if NRF_QDEC_HAS_EVENT_STOPPED
+    (void)__nrfy_internal_qdec_event_handle(p_reg,
+                                            mask,
+                                            NRF_QDEC_EVENT_STOPPED,
+                                            &event_mask);
+#endif
+    return event_mask;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // NRFY_QDEC_H__

--- a/nrfx/haly/nrfy_rtc.h
+++ b/nrfx/haly/nrfy_rtc.h
@@ -1,0 +1,426 @@
+/*
+ * Copyright (c) 2021 - 2023, Nordic Semiconductor ASA
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef NRFY_RTC_H__
+#define NRFY_RTC_H__
+
+#include <nrfx.h>
+#include <hal/nrf_rtc.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+NRFY_STATIC_INLINE bool __nrfy_internal_rtc_event_handle(NRF_RTC_Type *  p_reg,
+                                                         uint32_t        mask,
+                                                         nrf_rtc_event_t event,
+                                                         uint32_t *      p_event_mask);
+
+NRFY_STATIC_INLINE uint32_t __nrfy_internal_rtc_events_process(NRF_RTC_Type * p_reg,
+                                                               uint32_t       mask);
+
+NRFY_STATIC_INLINE void __nrfy_internal_rtc_event_enabled_clear(NRF_RTC_Type *  p_reg,
+                                                                uint32_t        mask,
+                                                                nrf_rtc_event_t event);
+
+/**
+ * @defgroup nrfy_rtc RTC HALY
+ * @{
+ * @ingroup nrf_rtc
+ * @brief   Hardware access layer with cache and barrier support for managing the RTC peripheral.
+ */
+
+/** @brief Structure for RTC configuration. */
+typedef struct
+{
+    uint32_t prescaler; ///< Prescaler.
+} nrfy_rtc_config_t;
+
+/**
+ * @brief Function for configuring the RTC.
+ *
+ * @param[in] p_reg    Pointer to the structure of registers of the peripheral.
+ * @param[in] p_config Pointer to the peripheral configuration structure.
+ */
+NRFY_STATIC_INLINE void nrfy_rtc_periph_configure(NRF_RTC_Type *            p_reg,
+                                                  nrfy_rtc_config_t const * p_config)
+{
+    nrf_rtc_prescaler_set(p_reg, p_config->prescaler);
+    nrf_barrier_w();
+}
+
+/**
+ * @brief Function for initializing the specified RTC interrupts.
+ *
+ * @param[in] p_reg        Pointer to the structure of registers of the peripheral.
+ * @param[in] mask         Mask of interrupts to be initialized.
+ * @param[in] irq_priority Interrupt priority.
+ * @param[in] enable       True if interrupts are to be enabled, false otherwise.
+ */
+NRFY_STATIC_INLINE void nrfy_rtc_int_init(NRF_RTC_Type * p_reg,
+                                          uint32_t       mask,
+                                          uint8_t        irq_priority,
+                                          bool           enable)
+{
+    __nrfy_internal_rtc_event_enabled_clear(p_reg, mask, NRF_RTC_EVENT_TICK);
+    __nrfy_internal_rtc_event_enabled_clear(p_reg, mask, NRF_RTC_EVENT_OVERFLOW);
+
+    for (size_t i = 0; i < NRF_RTC_CC_COUNT_MAX; i++)
+    {
+        __nrfy_internal_rtc_event_enabled_clear(p_reg, mask, nrf_rtc_compare_event_get(i));
+    }
+
+    nrf_barrier_w();
+
+    NRFX_IRQ_PRIORITY_SET(nrfx_get_irq_number(p_reg), irq_priority);
+    NRFX_IRQ_ENABLE(nrfx_get_irq_number(p_reg));
+    if (enable)
+    {
+        nrf_rtc_int_enable(p_reg, mask);
+    }
+    nrf_barrier_w();
+}
+
+/**
+ * @brief Function for uninitializing the RTC interrupts.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ */
+NRFY_STATIC_INLINE void nrfy_rtc_int_uninit(NRF_RTC_Type * p_reg)
+{
+    NRFX_IRQ_DISABLE(nrfx_get_irq_number(p_reg));
+    nrf_barrier_w();
+}
+
+/**
+ * @brief Function for processing the specified RTC events.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ * @param[in] mask  Mask of events to be processed, created by @ref NRFY_EVENT_TO_INT_BITMASK().
+ *
+ * @return Mask of events that were generated and processed.
+ *         To be checked against the result of @ref NRFY_EVENT_TO_INT_BITMASK().
+ */
+NRFY_STATIC_INLINE uint32_t nrfy_rtc_events_process(NRF_RTC_Type * p_reg,
+                                                    uint32_t       mask)
+{
+    uint32_t evt_mask = __nrfy_internal_rtc_events_process(p_reg, mask);
+    nrf_barrier_w();
+    return evt_mask;
+}
+
+/**
+ * @brief Function for stopping the RTC.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ * @param[in] mask  Mask of events to be disabled.
+ */
+NRFY_STATIC_INLINE void nrfy_rtc_stop(NRF_RTC_Type * p_reg,
+                                      uint32_t       mask)
+{
+    nrf_rtc_task_trigger(p_reg, NRF_RTC_TASK_STOP);
+    nrf_barrier_w();
+    nrf_rtc_event_disable(p_reg, mask);
+    nrf_rtc_int_disable(p_reg, mask);
+    nrf_barrier_w();
+}
+
+/**
+ * @brief Function for enabling the RTC event and optionally associated interrupt.
+ *
+ * @note Event is implicitly cleared before enabling the associated interrupt.
+ *
+ * @param[in] p_reg  Pointer to the structure of registers of the peripheral.
+ * @param[in] event  Event to be enabled.
+ * @param[in] enable True if associated interrupt is to be enabled, false otherwise.
+ */
+NRFY_STATIC_INLINE void nrfy_rtc_event_int_clear_enable(NRF_RTC_Type *  p_reg,
+                                                        nrf_rtc_event_t event,
+                                                        bool            enable)
+{
+    if (enable)
+    {
+        nrf_rtc_event_clear(p_reg, event);
+        nrf_barrier_w();
+        nrf_rtc_int_enable(p_reg, NRFY_EVENT_TO_INT_BITMASK(event));
+    }
+    nrf_rtc_event_enable(p_reg,  NRFY_EVENT_TO_INT_BITMASK(event));
+    nrf_barrier_w();
+}
+
+/**
+ * @brief Function for disabling the RTC events and corresponding interrupts.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ * @param[in] mask  Mask of events to be disabled.
+ */
+NRFY_STATIC_INLINE void nrfy_rtc_event_int_disable(NRF_RTC_Type * p_reg,
+                                                   uint32_t       mask)
+{
+    nrf_rtc_event_disable(p_reg, mask);
+    nrf_rtc_int_disable(p_reg, mask);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_rtc_cc_set} */
+NRFY_STATIC_INLINE void nrfy_rtc_cc_set(NRF_RTC_Type * p_reg,
+                                        uint32_t       ch,
+                                        uint32_t       cc_val)
+{
+    nrf_rtc_cc_set(p_reg, ch, cc_val);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_rtc_cc_get} */
+NRFY_STATIC_INLINE uint32_t nrfy_rtc_cc_get(NRF_RTC_Type const * p_reg,
+                                            uint32_t             ch)
+{
+    nrf_barrier_rw();
+    uint32_t cc = nrf_rtc_cc_get(p_reg, ch);
+    nrf_barrier_r();
+    return cc;
+}
+
+/** @refhal{nrf_rtc_int_enable} */
+NRFY_STATIC_INLINE void nrfy_rtc_int_enable(NRF_RTC_Type * p_reg,
+                                            uint32_t       mask)
+{
+    nrf_rtc_int_enable(p_reg, mask);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_rtc_int_disable} */
+NRFY_STATIC_INLINE void nrfy_rtc_int_disable(NRF_RTC_Type * p_reg,
+                                             uint32_t       mask)
+{
+    nrf_rtc_int_disable(p_reg, mask);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_rtc_int_enable_check} */
+NRFY_STATIC_INLINE uint32_t nrfy_rtc_int_enable_check(NRF_RTC_Type * p_reg,
+                                                      uint32_t       mask)
+{
+    nrf_barrier_rw();
+    uint32_t check = nrf_rtc_int_enable_check(p_reg, mask);
+    nrf_barrier_r();
+    return check;
+}
+
+#if defined(DPPI_PRESENT) || defined(__NRFX_DOXYGEN__)
+/** @refhal{nrf_rtc_subscribe_set} */
+NRFY_STATIC_INLINE void nrfy_rtc_subscribe_set(NRF_RTC_Type * p_reg,
+                                               nrf_rtc_task_t task,
+                                               uint8_t        channel)
+{
+    nrf_rtc_subscribe_set(p_reg, task, channel);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_rtc_subscribe_clear} */
+NRFY_STATIC_INLINE void nrfy_rtc_subscribe_clear(NRF_RTC_Type * p_reg,
+                                                 nrf_rtc_task_t task)
+{
+    nrf_rtc_subscribe_clear(p_reg, task);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_rtc_publish_set} */
+NRFY_STATIC_INLINE void nrfy_rtc_publish_set(NRF_RTC_Type *  p_reg,
+                                             nrf_rtc_event_t event,
+                                             uint8_t         channel)
+{
+    nrf_rtc_publish_set(p_reg, event, channel);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_rtc_publish_clear} */
+NRFY_STATIC_INLINE void nrfy_rtc_publish_clear(NRF_RTC_Type *  p_reg,
+                                               nrf_rtc_event_t event)
+{
+    nrf_rtc_publish_clear(p_reg, event);
+    nrf_barrier_w();
+}
+#endif
+
+/** @refhal{nrf_rtc_event_check} */
+NRFY_STATIC_INLINE bool nrfy_rtc_event_check(NRF_RTC_Type *  p_reg,
+                                             nrf_rtc_event_t event)
+{
+    nrf_barrier_r();
+    bool check = nrf_rtc_event_check(p_reg, event);
+    nrf_barrier_r();
+    return check;
+}
+
+/** @refhal{nrf_rtc_event_clear} */
+NRFY_STATIC_INLINE void nrfy_rtc_event_clear(NRF_RTC_Type *  p_reg,
+                                             nrf_rtc_event_t event)
+{
+    nrf_rtc_event_clear(p_reg, event);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_rtc_counter_get} */
+NRFY_STATIC_INLINE uint32_t nrfy_rtc_counter_get(NRF_RTC_Type const * p_reg)
+{
+    nrf_barrier_r();
+    uint32_t counter = nrf_rtc_counter_get(p_reg);
+    nrf_barrier_r();
+    return counter;
+}
+
+/** @refhal{nrf_rtc_prescaler_set} */
+NRFY_STATIC_INLINE void nrfy_rtc_prescaler_set(NRF_RTC_Type * p_reg,
+                                               uint32_t       val)
+{
+    nrf_rtc_prescaler_set(p_reg, val);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_rtc_prescaler_get} */
+NRFY_STATIC_INLINE uint32_t nrfy_rtc_prescaler_get(NRF_RTC_Type const * p_reg)
+{
+    nrf_barrier_rw();
+    uint32_t prescaler = nrf_rtc_prescaler_get(p_reg);
+    nrf_barrier_r();
+    return prescaler;
+}
+
+/** @refhal{nrf_rtc_event_address_get} */
+NRFY_STATIC_INLINE uint32_t nrfy_rtc_event_address_get(NRF_RTC_Type const * p_reg,
+                                                       nrf_rtc_event_t      event)
+{
+    return nrf_rtc_event_address_get(p_reg, event);
+}
+
+/** @refhal{nrf_rtc_task_address_get} */
+NRFY_STATIC_INLINE uint32_t nrfy_rtc_task_address_get(NRF_RTC_Type const * p_reg,
+                                                      nrf_rtc_task_t       task)
+{
+    return nrf_rtc_task_address_get(p_reg, task);
+}
+
+/** @refhal{nrf_rtc_task_trigger} */
+NRFY_STATIC_INLINE void nrfy_rtc_task_trigger(NRF_RTC_Type * p_reg,
+                                              nrf_rtc_task_t task)
+{
+    nrf_rtc_task_trigger(p_reg, task);
+    nrf_barrier_w();
+}
+
+#if defined(RTC_TASKS_CAPTURE_TASKS_CAPTURE_Msk) || defined(__NRFX_DOXYGEN__)
+/** @refhal{nrf_rtc_capture_task_get} */
+NRFY_STATIC_INLINE nrf_rtc_task_t nrfy_rtc_capture_task_get(uint8_t index)
+{
+    return nrf_rtc_capture_task_get(index);
+}
+#endif
+
+/** @refhal{nrf_rtc_event_enable} */
+NRFY_STATIC_INLINE void nrfy_rtc_event_enable(NRF_RTC_Type * p_reg,
+                                              uint32_t       mask)
+{
+    nrf_rtc_event_enable(p_reg, mask);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_rtc_event_disable} */
+NRFY_STATIC_INLINE void nrfy_rtc_event_disable(NRF_RTC_Type * p_reg,
+                                               uint32_t       mask)
+{
+    nrf_rtc_event_disable(p_reg, mask);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_rtc_compare_event_get} */
+NRFY_STATIC_INLINE nrf_rtc_event_t nrfy_rtc_compare_event_get(uint8_t index)
+{
+    return nrf_rtc_compare_event_get(index);
+}
+
+/** @} */
+
+NRFY_STATIC_INLINE bool __nrfy_internal_rtc_event_handle(NRF_RTC_Type *  p_reg,
+                                                         uint32_t        mask,
+                                                         nrf_rtc_event_t event,
+                                                         uint32_t *      p_event_mask)
+{
+    if ((mask & NRFY_EVENT_TO_INT_BITMASK(event)) && nrf_rtc_event_check(p_reg, event))
+    {
+        nrf_rtc_event_clear(p_reg, event);
+        if (p_event_mask)
+        {
+            *p_event_mask |= NRFY_EVENT_TO_INT_BITMASK(event);
+        }
+        return true;
+    }
+    return false;
+}
+
+NRFY_STATIC_INLINE uint32_t __nrfy_internal_rtc_events_process(NRF_RTC_Type * p_reg,
+                                                               uint32_t       mask)
+{
+    uint32_t event_mask = 0;
+
+    nrf_barrier_r();
+    for (uint32_t i = 0; i < NRF_RTC_CC_COUNT_MAX; i++)
+    {
+        (void)__nrfy_internal_rtc_event_handle(p_reg,
+                                               mask,
+                                               nrf_rtc_compare_event_get(i),
+                                               &event_mask);
+    }
+
+    (void)__nrfy_internal_rtc_event_handle(p_reg, mask, NRF_RTC_EVENT_TICK, &event_mask);
+
+    (void)__nrfy_internal_rtc_event_handle(p_reg, mask, NRF_RTC_EVENT_OVERFLOW, &event_mask);
+
+    return event_mask;
+}
+
+NRFY_STATIC_INLINE void __nrfy_internal_rtc_event_enabled_clear(NRF_RTC_Type *  p_reg,
+                                                                uint32_t        mask,
+                                                                nrf_rtc_event_t event)
+{
+    if (mask & NRFY_EVENT_TO_INT_BITMASK(event))
+    {
+        nrf_rtc_event_clear(p_reg, event);
+    }
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // NRFY_RTC_H__

--- a/nrfx/haly/nrfy_saadc.h
+++ b/nrfx/haly/nrfy_saadc.h
@@ -1,0 +1,712 @@
+/*
+ * Copyright (c) 2021 - 2023, Nordic Semiconductor ASA
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef NRFY_SAADC_H__
+#define NRFY_SAADC_H__
+
+#include <nrfx.h>
+#include <hal/nrf_saadc.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct nrfy_saadc_buffer_t nrfy_saadc_buffer_t;
+
+NRFY_STATIC_INLINE bool __nrfy_internal_saadc_event_handle(NRF_SAADC_Type *  p_reg,
+                                                           uint32_t          mask,
+                                                           nrf_saadc_event_t event,
+                                                           uint32_t *        p_event_mask);
+
+NRFY_STATIC_INLINE
+uint32_t __nrfy_internal_saadc_events_process(NRF_SAADC_Type *            p_reg,
+                                              uint32_t                    mask,
+                                              nrfy_saadc_buffer_t const * p_desc);
+
+NRFY_STATIC_INLINE void __nrfy_internal_saadc_event_enabled_clear(NRF_SAADC_Type *  p_reg,
+                                                                  uint32_t          mask,
+                                                                  nrf_saadc_event_t event);
+
+NRFY_STATIC_INLINE void __nrfy_internal_saadc_buffer_latch(NRF_SAADC_Type * p_reg, bool wait);
+
+NRFY_STATIC_INLINE void __nrfy_internal_saadc_stop(NRF_SAADC_Type * p_reg, bool wait);
+
+/**
+ * @defgroup nrfy_saadc SAADC HALY
+ * @{
+ * @ingroup nrf_saadc
+ * @brief   Hardware access layer with cache and barrier support for managing the SAADC peripheral.
+ */
+
+/** @brief Structure describing SAADC sampling buffer. */
+struct nrfy_saadc_buffer_t
+{
+    nrf_saadc_value_t * p_buffer; ///< Pointer to the sampling buffer.
+    size_t              length;   ///< Sampling buffer length.
+};
+
+/** @brief SAADC configuration structure. */
+typedef struct
+{
+    nrf_saadc_resolution_t resolution;   ///< Sampling resolution.
+    nrf_saadc_oversample_t oversampling; ///< Oversampling setting.
+} nrfy_saadc_config_t;
+
+/** @brief SAADC channel input configuration structure. */
+typedef struct
+{
+    nrf_saadc_input_t input_p; ///< Positive input.
+    nrf_saadc_input_t input_n; ///< Negative input.
+} nrfy_saadc_channel_input_t;
+
+/**
+ * @brief Function for configuring the SAADC.
+ *
+ * @param[in] p_reg    Pointer to the structure of registers of the peripheral.
+ * @param[in] p_config Pointer to the peripheral configuration structure.
+ */
+NRFY_STATIC_INLINE void nrfy_saadc_periph_configure(NRF_SAADC_Type *            p_reg,
+                                                    nrfy_saadc_config_t const * p_config)
+{
+    nrf_saadc_resolution_set(p_reg, p_config->resolution);
+    nrf_saadc_oversample_set(p_reg, p_config->oversampling);
+    nrf_barrier_w();
+}
+
+/**
+ * @brief Function for initializing the specified SAADC interrupts.
+ *
+ * @param[in] p_reg        Pointer to the structure of registers of the peripheral.
+ * @param[in] mask         Mask of interrupts to be initialized.
+ * @param[in] irq_priority Interrupt priority.
+ * @param[in] enable       True if the interrupts are to be enabled, false otherwise.
+ */
+NRFY_STATIC_INLINE void nrfy_saadc_int_init(NRF_SAADC_Type * p_reg,
+                                            uint32_t         mask,
+                                            uint8_t          irq_priority,
+                                            bool             enable)
+{
+    __nrfy_internal_saadc_event_enabled_clear(p_reg, mask, NRF_SAADC_EVENT_STARTED);
+    __nrfy_internal_saadc_event_enabled_clear(p_reg, mask, NRF_SAADC_EVENT_END);
+    __nrfy_internal_saadc_event_enabled_clear(p_reg, mask, NRF_SAADC_EVENT_DONE);
+    __nrfy_internal_saadc_event_enabled_clear(p_reg, mask, NRF_SAADC_EVENT_RESULTDONE);
+    __nrfy_internal_saadc_event_enabled_clear(p_reg, mask, NRF_SAADC_EVENT_CALIBRATEDONE);
+    __nrfy_internal_saadc_event_enabled_clear(p_reg, mask, NRF_SAADC_EVENT_STOPPED);
+
+    for (uint32_t i = 0; i < SAADC_CH_NUM; i++)
+    {
+         nrf_saadc_event_t event = nrf_saadc_limit_event_get(i, NRF_SAADC_LIMIT_LOW);
+         __nrfy_internal_saadc_event_enabled_clear(p_reg, mask, event);
+
+         event = nrf_saadc_limit_event_get(i, NRF_SAADC_LIMIT_HIGH);
+         __nrfy_internal_saadc_event_enabled_clear(p_reg, mask, event);
+    }
+
+    nrf_barrier_w();
+
+    NRFX_IRQ_PRIORITY_SET(nrfx_get_irq_number(p_reg), irq_priority);
+    NRFX_IRQ_ENABLE(nrfx_get_irq_number(p_reg));
+    if (enable)
+    {
+        nrf_saadc_int_enable(p_reg, mask);
+    }
+
+    nrf_barrier_w();
+}
+
+/**
+ * @brief Function for uninitializing the SAADC interrupts.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ */
+NRFY_STATIC_INLINE void nrfy_saadc_int_uninit(NRF_SAADC_Type * p_reg)
+{
+    NRFX_IRQ_DISABLE(nrfx_get_irq_number(p_reg));
+    nrf_barrier_w();
+}
+
+/**
+ * @brief Function for processing the specified SAADC events.
+ *
+ * @param[in] p_reg  Pointer to the structure of registers of the peripheral.
+ * @param[in] mask   Mask of events to be processed, created by @ref NRFY_EVENT_TO_INT_BITMASK().
+ * @param[in] p_desc Pointer to the structure containing buffer associated with the last sampling.
+ *                   Can be NULL.
+ *
+ * @return Mask of events that were generated and processed.
+ *         To be checked against the result of @ref NRFY_EVENT_TO_INT_BITMASK().
+ */
+NRFY_STATIC_INLINE uint32_t nrfy_saadc_events_process(NRF_SAADC_Type *            p_reg,
+                                                      uint32_t                    mask,
+                                                      nrfy_saadc_buffer_t const * p_desc)
+{
+    uint32_t evt_mask = __nrfy_internal_saadc_events_process(p_reg, mask, p_desc);
+    nrf_barrier_w();
+    return evt_mask;
+}
+
+/**
+ * @brief Function for configuring the specified SAADC channel.
+ *
+ * @param[in] p_reg    Pointer to the structure of registers of the peripheral.
+ * @param[in] channel  Channel number.
+ * @param[in] p_config Pointer to the channel configuration structure.
+ *                     NULL if configuration is to be omitted.
+ * @param[in] p_input  Pointer to the channel input configuration structure.
+ *                     NULL if configuration is to be omitted.
+ */
+NRFY_STATIC_INLINE void nrfy_saadc_channel_configure(NRF_SAADC_Type *                   p_reg,
+                                                     uint8_t                            channel,
+                                                     nrf_saadc_channel_config_t const * p_config,
+                                                     nrfy_saadc_channel_input_t const * p_input)
+{
+    if (p_config)
+    {
+        nrf_saadc_channel_init(p_reg, channel, p_config);
+    }
+    if (p_input)
+    {
+        nrf_saadc_channel_input_set(p_reg, channel, p_input->input_p, p_input->input_n);
+    }
+    nrf_barrier_w();
+}
+
+/**
+ * @brief Function for setting the SAADC sampling buffer.
+ *
+ * @param[in] p_reg  Pointer to the structure of registers of the peripheral.
+ * @param[in] p_desc Pointer to the structure containing sampling buffer description.
+ * @param[in] latch  True if buffer is to be latched, false otherwise.
+ * @param[in] wait   True if latching is to be blocking, false otherwise.
+ */
+NRFY_STATIC_INLINE void nrfy_saadc_buffer_set(NRF_SAADC_Type *            p_reg,
+                                              nrfy_saadc_buffer_t const * p_desc,
+                                              bool                        latch,
+                                              bool                        wait)
+{
+    nrf_saadc_buffer_init(p_reg, p_desc->p_buffer, p_desc->length);
+    nrf_barrier_w();
+    if (latch)
+    {
+        __nrfy_internal_saadc_buffer_latch(p_reg, wait);
+    }
+}
+
+/**
+ * @brief Function for latching the SAADC sampling buffer.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ * @param[in] wait  True if latching is to be blocking, false otherwise.
+ */
+NRFY_STATIC_INLINE void nrfy_saadc_buffer_latch(NRF_SAADC_Type * p_reg, bool wait)
+{
+    __nrfy_internal_saadc_buffer_latch(p_reg, wait);
+}
+
+/**
+ * @brief Function for starting the SAADC sampling.
+ *
+ * @param[in] p_reg  Pointer to the structure of registers of the peripheral.
+ * @param[in] p_desc Pointer to the structure containing sampling buffer
+ *                   if the sampling is to be blocking. NULL for non-blocking operation.
+ */
+NRFY_STATIC_INLINE void nrfy_saadc_sample_start(NRF_SAADC_Type *            p_reg,
+                                                nrfy_saadc_buffer_t const * p_desc)
+{
+    nrf_saadc_task_trigger(p_reg, NRF_SAADC_TASK_SAMPLE);
+    if (p_desc)
+    {
+        nrf_barrier_w();
+        uint32_t evt_mask = NRFY_EVENT_TO_INT_BITMASK(NRF_SAADC_EVENT_END);
+        while (!__nrfy_internal_saadc_events_process(p_reg, evt_mask, p_desc))
+        {}
+        nrf_saadc_event_clear(p_reg, NRF_SAADC_EVENT_DONE);
+        nrf_saadc_event_clear(p_reg, NRF_SAADC_EVENT_RESULTDONE);
+    }
+    nrf_barrier_w();
+}
+
+/**
+ * @brief Function for aborting the ongoing SAADC sampling.
+ *
+ * @param[in] p_reg  Pointer to the structure of registers of the peripheral.
+ * @param[in] p_desc Pointer to the structure containing sampling buffer
+ *                   if the abort is to be blocking. NULL for non-blocking operation.
+ */
+NRFY_STATIC_INLINE void nrfy_saadc_abort(NRF_SAADC_Type *            p_reg,
+                                         nrfy_saadc_buffer_t const * p_desc)
+{
+    __nrfy_internal_saadc_stop(p_reg, p_desc ? true : false);
+    if (p_desc)
+    {
+        (void)__nrfy_internal_saadc_events_process(p_reg,
+                                                   NRFY_EVENT_TO_INT_BITMASK(NRF_SAADC_EVENT_END),
+                                                   p_desc);
+    }
+    nrf_barrier_w();
+}
+
+/**
+ * @brief Function for stopping the SAADC.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ * @param[in] wait  True if stopping is to be blocking, false otherwise.
+ */
+NRFY_STATIC_INLINE void nrfy_saadc_stop(NRF_SAADC_Type * p_reg, bool wait)
+{
+    __nrfy_internal_saadc_stop(p_reg, wait);
+    nrf_barrier_w();
+}
+
+/**
+ * @brief Function for calibrating the SAADC.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ * @param[in] wait  True if calibration is to be blocking, false otherwise.
+ */
+NRFY_STATIC_INLINE void nrfy_saadc_calibrate(NRF_SAADC_Type * p_reg, bool wait)
+{
+    nrf_saadc_task_trigger(p_reg, NRF_SAADC_TASK_CALIBRATEOFFSET);
+    if (wait)
+    {
+        nrf_barrier_w();
+        uint32_t evt_mask = NRFY_EVENT_TO_INT_BITMASK(NRF_SAADC_EVENT_CALIBRATEDONE);
+        while (!__nrfy_internal_saadc_events_process(p_reg, evt_mask, NULL))
+        {}
+        nrf_saadc_event_clear(p_reg, NRF_SAADC_EVENT_END);
+    }
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_saadc_task_trigger} */
+NRFY_STATIC_INLINE void nrfy_saadc_task_trigger(NRF_SAADC_Type * p_reg, nrf_saadc_task_t task)
+{
+    nrf_saadc_task_trigger(p_reg, task);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_saadc_task_address_get} */
+NRFY_STATIC_INLINE uint32_t nrfy_saadc_task_address_get(NRF_SAADC_Type const * p_reg,
+                                                        nrf_saadc_task_t       task)
+{
+    return nrf_saadc_task_address_get(p_reg, task);
+}
+
+/** @refhal{nrf_saadc_event_check} */
+NRFY_STATIC_INLINE bool nrfy_saadc_event_check(NRF_SAADC_Type const * p_reg,
+                                               nrf_saadc_event_t      event)
+{
+    nrf_barrier_r();
+    bool check = nrf_saadc_event_check(p_reg, event);
+    nrf_barrier_r();
+    return check;
+}
+
+/** @refhal{nrf_saadc_event_clear} */
+NRFY_STATIC_INLINE void nrfy_saadc_event_clear(NRF_SAADC_Type * p_reg, nrf_saadc_event_t event)
+{
+    nrf_saadc_event_clear(p_reg, event);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_saadc_event_address_get} */
+NRFY_STATIC_INLINE uint32_t nrfy_saadc_event_address_get(NRF_SAADC_Type const * p_reg,
+                                                         nrf_saadc_event_t      event)
+{
+    return nrf_saadc_event_address_get(p_reg, event);
+}
+
+#if defined(DPPI_PRESENT) || defined(__NRFX_DOXYGEN__)
+/** @refhal{nrf_saadc_subscribe_set} */
+NRFY_STATIC_INLINE void nrfy_saadc_subscribe_set(NRF_SAADC_Type * p_reg,
+                                                 nrf_saadc_task_t task,
+                                                 uint8_t          channel)
+{
+    nrf_saadc_subscribe_set(p_reg, task, channel);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_saadc_subscribe_clear} */
+NRFY_STATIC_INLINE void nrfy_saadc_subscribe_clear(NRF_SAADC_Type * p_reg, nrf_saadc_task_t task)
+{
+    nrf_saadc_subscribe_clear(p_reg, task);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_saadc_publish_set} */
+NRFY_STATIC_INLINE void nrfy_saadc_publish_set(NRF_SAADC_Type *  p_reg,
+                                               nrf_saadc_event_t event,
+                                               uint8_t           channel)
+{
+    nrf_saadc_publish_set(p_reg, event, channel);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_saadc_publish_clear} */
+NRFY_STATIC_INLINE void nrfy_saadc_publish_clear(NRF_SAADC_Type * p_reg, nrf_saadc_event_t event)
+{
+    nrf_saadc_publish_clear(p_reg, event);
+    nrf_barrier_w();
+}
+#endif // defined(DPPI_PRESENT) || defined(__NRFX_DOXYGEN__)
+
+/** @refhal{nrf_saadc_limit_event_get} */
+NRFY_STATIC_INLINE nrf_saadc_event_t nrfy_saadc_limit_event_get(uint8_t           channel,
+                                                                nrf_saadc_limit_t limit_type)
+{
+    return nrf_saadc_limit_event_get(channel, limit_type);
+}
+
+/** @refhal{nrf_saadc_channel_input_set} */
+NRFY_STATIC_INLINE void nrfy_saadc_channel_input_set(NRF_SAADC_Type *  p_reg,
+                                                     uint8_t           channel,
+                                                     nrf_saadc_input_t pselp,
+                                                     nrf_saadc_input_t pseln)
+{
+    nrf_saadc_channel_input_set(p_reg, channel, pselp, pseln);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_saadc_channel_pos_input_set} */
+NRFY_STATIC_INLINE void nrfy_saadc_channel_pos_input_set(NRF_SAADC_Type *  p_reg,
+                                                         uint8_t           channel,
+                                                         nrf_saadc_input_t pselp)
+{
+    nrf_saadc_channel_pos_input_set(p_reg, channel, pselp);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_saadc_channel_limits_set} */
+NRFY_STATIC_INLINE void nrfy_saadc_channel_limits_set(NRF_SAADC_Type * p_reg,
+                                                      uint8_t          channel,
+                                                      int16_t          low,
+                                                      int16_t          high)
+{
+    nrf_saadc_channel_limits_set(p_reg, channel, low, high);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_saadc_int_set} */
+NRFY_STATIC_INLINE void nrfy_saadc_int_set(NRF_SAADC_Type * p_reg, uint32_t mask)
+{
+    nrf_saadc_int_set(p_reg, mask);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_saadc_int_enable} */
+NRFY_STATIC_INLINE void nrfy_saadc_int_enable(NRF_SAADC_Type * p_reg, uint32_t mask)
+{
+    nrf_saadc_int_enable(p_reg, mask);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_saadc_int_enable_check} */
+NRFY_STATIC_INLINE uint32_t nrfy_saadc_int_enable_check(NRF_SAADC_Type const * p_reg, uint32_t mask)
+{
+    nrf_barrier_rw();
+    uint32_t check = nrf_saadc_int_enable_check(p_reg, mask);
+    nrf_barrier_r();
+    return check;
+}
+
+/** @refhal{nrf_saadc_int_disable} */
+NRFY_STATIC_INLINE void nrfy_saadc_int_disable(NRF_SAADC_Type * p_reg, uint32_t mask)
+{
+    nrf_saadc_int_disable(p_reg, mask);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_saadc_limit_int_get} */
+NRFY_STATIC_INLINE uint32_t nrfy_saadc_limit_int_get(uint8_t           channel,
+                                                     nrf_saadc_limit_t limit_type)
+{
+    return nrf_saadc_limit_int_get(channel, limit_type);
+}
+
+/** @refhal{nrf_saadc_busy_check} */
+NRFY_STATIC_INLINE bool nrfy_saadc_busy_check(NRF_SAADC_Type const * p_reg)
+{
+    nrf_barrier_r();
+    bool check = nrf_saadc_busy_check(p_reg);
+    nrf_barrier_r();
+    return check;
+}
+
+/** @refhal{nrf_saadc_enable} */
+NRFY_STATIC_INLINE void nrfy_saadc_enable(NRF_SAADC_Type * p_reg)
+{
+    nrf_saadc_enable(p_reg);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_saadc_disable} */
+NRFY_STATIC_INLINE void nrfy_saadc_disable(NRF_SAADC_Type * p_reg)
+{
+    nrf_saadc_disable(p_reg);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_saadc_enable_check} */
+NRFY_STATIC_INLINE bool nrfy_saadc_enable_check(NRF_SAADC_Type const * p_reg)
+{
+    nrf_barrier_rw();
+    bool check = nrf_saadc_enable_check(p_reg);
+    nrf_barrier_r();
+    return check;
+}
+
+/** @refhal{nrf_saadc_buffer_init} */
+NRFY_STATIC_INLINE void nrfy_saadc_buffer_init(NRF_SAADC_Type *    p_reg,
+                                               nrf_saadc_value_t * p_buffer,
+                                               uint32_t            size)
+{
+    nrf_saadc_buffer_init(p_reg, p_buffer, size);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_saadc_buffer_pointer_set} */
+NRFY_STATIC_INLINE void nrfy_saadc_buffer_pointer_set(NRF_SAADC_Type *    p_reg,
+                                                      nrf_saadc_value_t * p_buffer)
+{
+    nrf_saadc_buffer_pointer_set(p_reg, p_buffer);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_saadc_buffer_pointer_get} */
+NRFY_STATIC_INLINE nrf_saadc_value_t * nrfy_saadc_buffer_pointer_get(NRF_SAADC_Type const * p_reg)
+{
+    nrf_barrier_rw();
+    nrf_saadc_value_t * p_buffer = nrf_saadc_buffer_pointer_get(p_reg);
+    nrf_barrier_r();
+    return p_buffer;
+}
+
+/** @refhal{nrf_saadc_amount_get} */
+NRFY_STATIC_INLINE uint16_t nrfy_saadc_amount_get(NRF_SAADC_Type const * p_reg)
+{
+    nrf_barrier_r();
+    uint16_t amount = nrf_saadc_amount_get(p_reg);
+    nrf_barrier_r();
+    return amount;
+}
+
+/** @refhal{nrf_saadc_resolution_set} */
+NRFY_STATIC_INLINE void nrfy_saadc_resolution_set(NRF_SAADC_Type *       p_reg,
+                                                  nrf_saadc_resolution_t resolution)
+{
+    nrf_saadc_resolution_set(p_reg, resolution);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_saadc_resolution_get} */
+NRFY_STATIC_INLINE nrf_saadc_resolution_t nrfy_saadc_resolution_get(NRF_SAADC_Type const * p_reg)
+{
+    nrf_barrier_rw();
+    nrf_saadc_resolution_t resolution = nrf_saadc_resolution_get(p_reg);
+    nrf_barrier_r();
+    return resolution;
+}
+
+/** @refhal{nrf_saadc_oversample_set} */
+NRFY_STATIC_INLINE void nrfy_saadc_oversample_set(NRF_SAADC_Type *       p_reg,
+                                                  nrf_saadc_oversample_t oversample)
+{
+    nrf_saadc_oversample_set(p_reg, oversample);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_saadc_oversample_get} */
+NRFY_STATIC_INLINE nrf_saadc_oversample_t nrfy_saadc_oversample_get(NRF_SAADC_Type const * p_reg)
+{
+    nrf_barrier_rw();
+    nrf_saadc_oversample_t oversample = nrf_saadc_oversample_get(p_reg);
+    nrf_barrier_r();
+    return oversample;
+}
+
+/** @refhal{nrf_saadc_oversample_sample_count_get} */
+NRFY_STATIC_INLINE
+uint32_t nrfy_saadc_oversample_sample_count_get(nrf_saadc_oversample_t oversample)
+{
+    return nrf_saadc_oversample_sample_count_get(oversample);
+}
+
+/** @refhal{nrf_saadc_continuous_mode_enable} */
+NRFY_STATIC_INLINE void nrfy_saadc_continuous_mode_enable(NRF_SAADC_Type * p_reg, uint16_t cc)
+{
+    nrf_saadc_continuous_mode_enable(p_reg, cc);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_saadc_continuous_mode_enable_check} */
+NRFY_STATIC_INLINE bool nrfy_saadc_continuous_mode_enable_check(NRF_SAADC_Type const * p_reg)
+{
+    nrf_barrier_rw();
+    bool check = nrf_saadc_continuous_mode_enable_check(p_reg);
+    nrf_barrier_r();
+    return check;
+}
+
+/** @refhal{nrf_saadc_continuous_mode_disable} */
+NRFY_STATIC_INLINE void nrfy_saadc_continuous_mode_disable(NRF_SAADC_Type * p_reg)
+{
+    nrf_saadc_continuous_mode_disable(p_reg);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_saadc_channel_init} */
+NRFY_STATIC_INLINE void nrfy_saadc_channel_init(NRF_SAADC_Type *                   p_reg,
+                                                uint8_t                            channel,
+                                                nrf_saadc_channel_config_t const * config)
+{
+    nrf_saadc_channel_init(p_reg, channel, config);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_saadc_burst_set} */
+NRFY_STATIC_INLINE void nrfy_saadc_burst_set(NRF_SAADC_Type *  p_reg,
+                                             uint8_t           channel,
+                                             nrf_saadc_burst_t burst)
+{
+    nrf_saadc_burst_set(p_reg, channel, burst);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_saadc_value_min_get} */
+NRFY_STATIC_INLINE nrf_saadc_value_t nrfy_saadc_value_min_get(nrf_saadc_resolution_t resolution)
+{
+    return nrf_saadc_value_min_get(resolution);
+}
+
+/** @refhal{nrf_saadc_value_max_get} */
+NRFY_STATIC_INLINE nrf_saadc_value_t nrfy_saadc_value_max_get(nrf_saadc_resolution_t resolution)
+{
+    return nrf_saadc_value_max_get(resolution);
+}
+
+/** @} */
+
+NRFY_STATIC_INLINE bool __nrfy_internal_saadc_event_handle(NRF_SAADC_Type *  p_reg,
+                                                           uint32_t          mask,
+                                                           nrf_saadc_event_t event,
+                                                           uint32_t *        p_event_mask)
+{
+    if ((mask & NRFY_EVENT_TO_INT_BITMASK(event)) && nrf_saadc_event_check(p_reg, event))
+    {
+        nrf_saadc_event_clear(p_reg, event);
+        if (p_event_mask)
+        {
+            *p_event_mask |= NRFY_EVENT_TO_INT_BITMASK(event);
+        }
+        return true;
+    }
+    return false;
+}
+
+NRFY_STATIC_INLINE
+uint32_t __nrfy_internal_saadc_events_process(NRF_SAADC_Type *            p_reg,
+                                              uint32_t                    mask,
+                                              nrfy_saadc_buffer_t const * p_desc)
+{
+    uint32_t evt_mask = 0;
+
+    nrf_barrier_r();
+
+    (void)__nrfy_internal_saadc_event_handle(p_reg, mask, NRF_SAADC_EVENT_STARTED, &evt_mask);
+    bool stop = __nrfy_internal_saadc_event_handle(p_reg, mask, NRF_SAADC_EVENT_STOPPED, &evt_mask);
+
+    if (__nrfy_internal_saadc_event_handle(p_reg, mask, NRF_SAADC_EVENT_END, &evt_mask) && p_desc)
+    {
+        size_t size = stop ? nrf_saadc_amount_get(p_reg) : p_desc->length;
+        NRFY_CACHE_INV(p_desc->p_buffer, size);
+    }
+
+    (void)__nrfy_internal_saadc_event_handle(p_reg, mask, NRF_SAADC_EVENT_DONE, &evt_mask);
+    (void)__nrfy_internal_saadc_event_handle(p_reg, mask, NRF_SAADC_EVENT_RESULTDONE, &evt_mask);
+    (void)__nrfy_internal_saadc_event_handle(p_reg, mask, NRF_SAADC_EVENT_CALIBRATEDONE, &evt_mask);
+
+    if (mask & NRF_SAADC_ALL_CHANNELS_LIMITS_INT_MASK)
+    {
+        for (uint32_t i = 0; i < SAADC_CH_NUM; i++)
+        {
+             nrf_saadc_event_t event = nrf_saadc_limit_event_get(i, NRF_SAADC_LIMIT_LOW);
+             __nrfy_internal_saadc_event_handle(p_reg, mask, event, &evt_mask);
+
+             event = nrf_saadc_limit_event_get(i, NRF_SAADC_LIMIT_HIGH);
+             __nrfy_internal_saadc_event_handle(p_reg, mask, event, &evt_mask);
+        }
+    }
+
+    return evt_mask;
+}
+
+NRFY_STATIC_INLINE void __nrfy_internal_saadc_event_enabled_clear(NRF_SAADC_Type *  p_reg,
+                                                                  uint32_t          mask,
+                                                                  nrf_saadc_event_t event)
+{
+    if (mask & NRFY_EVENT_TO_INT_BITMASK(event))
+    {
+        nrf_saadc_event_clear(p_reg, event);
+    }
+}
+
+NRFY_STATIC_INLINE void __nrfy_internal_saadc_buffer_latch(NRF_SAADC_Type * p_reg, bool wait)
+{
+    nrf_saadc_task_trigger(p_reg, NRF_SAADC_TASK_START);
+    if (wait)
+    {
+        nrf_barrier_w();
+        uint32_t evt_mask = NRFY_EVENT_TO_INT_BITMASK(NRF_SAADC_EVENT_STARTED);
+        while (!__nrfy_internal_saadc_events_process(p_reg, evt_mask, NULL))
+        {}
+    }
+    nrf_barrier_w();
+}
+
+NRFY_STATIC_INLINE void __nrfy_internal_saadc_stop(NRF_SAADC_Type * p_reg, bool wait)
+{
+    nrf_saadc_task_trigger(p_reg, NRF_SAADC_TASK_STOP);
+    if (wait)
+    {
+        nrf_barrier_w();
+        uint32_t evt_mask = NRFY_EVENT_TO_INT_BITMASK(NRF_SAADC_EVENT_STOPPED);
+        while (!__nrfy_internal_saadc_events_process(p_reg, evt_mask, NULL))
+        {}
+    }
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // NRFY_SAADC_H__

--- a/nrfx/haly/nrfy_spim.h
+++ b/nrfx/haly/nrfy_spim.h
@@ -1,0 +1,874 @@
+/*
+ * Copyright (c) 2021 - 2023, Nordic Semiconductor ASA
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef NRFY_SPIM_H__
+#define NRFY_SPIM_H__
+
+#include <nrfx.h>
+#include <hal/nrf_spim.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct nrfy_spim_xfer_desc_t nrfy_spim_xfer_desc_t;
+
+NRFY_STATIC_INLINE bool __nrfy_internal_spim_event_handle(NRF_SPIM_Type *  p_reg,
+                                                          uint32_t         mask,
+                                                          nrf_spim_event_t event,
+                                                          uint32_t *       p_evt_mask);
+
+NRFY_STATIC_INLINE
+uint32_t __nrfy_internal_spim_events_process(NRF_SPIM_Type *               p_reg,
+                                             uint32_t                      mask,
+                                             nrfy_spim_xfer_desc_t const * p_xfer);
+
+NRFY_STATIC_INLINE void __nrfy_internal_spim_event_enabled_clear(NRF_SPIM_Type *  p_reg,
+                                                                 uint32_t         mask,
+                                                                 nrf_spim_event_t event);
+
+/**
+ * @defgroup nrfy_spim SPIM HALY
+ * @{
+ * @ingroup nrf_spim
+ * @brief   Hardware access layer with cache and barrier support for managing the SPIM peripheral.
+ */
+
+#if NRF_SPIM_HAS_HW_CSN || defined(__NRFX_DOXYGEN__)
+/** @refhal{NRF_SPIM_HAS_HW_CSN} */
+#define NRFY_SPIM_HAS_HW_CSN 1
+#else
+#define NRFY_SPIM_HAS_HW_CSN 0
+#endif
+
+#if NRF_SPIM_HAS_DCX || defined(__NRFX_DOXYGEN__)
+/** @refhal{NRF_SPIM_HAS_DCX} */
+#define NRFY_SPIM_HAS_DCX 1
+#else
+#define NRFY_SPIM_HAS_DCX 0
+#endif
+
+#if NRF_SPIM_HAS_RXDELAY || defined(__NRFX_DOXYGEN__)
+/** @refhal{NRF_SPIM_HAS_RXDELAY} */
+#define NRFY_SPIM_HAS_RXDELAY 1
+#else
+#define NRFY_SPIM_HAS_RXDELAY 0
+#endif
+
+#if NRF_SPIM_HAS_STALLSTAT || defined(__NRFX_DOXYGEN__)
+/** @refhal{NRF_SPIM_HAS_STALLSTAT} */
+#define NRFY_SPIM_HAS_STALLSTAT 1
+#else
+#define NRFY_SPIM_HAS_STALLSTAT 0
+#endif
+
+#if NRF_SPIM_HAS_EXTENDED || defined(__NRFX_DOXYGEN__)
+/** @refhal{NRF_SPIM_HAS_EXTENDED} */
+#define NRFY_SPIM_HAS_EXTENDED 1
+#else
+#define NRFY_SPIM_HAS_EXTENDED 0
+#endif
+
+#if NRF_SPIM_HAS_ARRAY_LIST || defined(__NRFX_DOXYGEN__)
+/** @refhal{NRF_SPIM_HAS_ARRAY_LIST} */
+#define NRFY_SPIM_HAS_ARRAY_LIST 1
+#else
+#define NRFY_SPIM_HAS_ARRAY_LIST 0
+#endif
+
+#if NRF_SPIM_HAS_FREQUENCY || defined(__NRFX_DOXYGEN__)
+/** @refhal{NRF_SPIM_HAS_FREQUENCY} */
+#define NRFY_SPIM_HAS_FREQUENCY 1
+#else
+#define NRFY_SPIM_HAS_FREQUENCY 0
+#endif
+
+#if NRF_SPIM_HAS_PRESCALER || defined(__NRFX_DOXYGEN__)
+/** @refhal{NRF_SPIM_HAS_PRESCALER} */
+#define NRFY_SPIM_HAS_PRESCALER 1
+#else
+#define NRFY_SPIM_HAS_PRESCALER 0
+#endif
+
+/** @brief Structure describing single SPIM transfer. */
+struct nrfy_spim_xfer_desc_t
+{
+    uint8_t const * p_tx_buffer; ///< Pointer to the TX data buffer.
+    size_t          tx_length;   ///< TX data buffer length.
+    uint8_t *       p_rx_buffer; ///< Pointer to the RX data buffer.
+    size_t          rx_length;   ///< RX data buffer length.
+};
+
+#if NRFY_SPIM_HAS_EXTENDED
+/** @brief Configuration structure for SPIM pins used for extended features. */
+typedef struct
+{
+#if NRFY_SPIM_HAS_DCX
+    uint32_t dcx_pin; ///< D/CX pin number.
+                      /**< Set to @ref NRF_SPIM_PIN_NOT_CONNECTED if this signal is not needed. */
+#endif
+#if NRFY_SPIM_HAS_HW_CSN
+    uint32_t csn_pin; ///< CSN pin number.
+                      /**< Set to @ref NRF_SPIM_PIN_NOT_CONNECTED if this signal is not needed. */
+#endif
+} nrfy_spim_ext_pins_t;
+
+/** @brief Configuration structure for SPIM extended features. */
+typedef struct
+{
+    nrfy_spim_ext_pins_t pins;         ///< Pin configuration structure.
+#if NRFY_SPIM_HAS_HW_CSN
+    nrf_spim_csn_pol_t   csn_pol;      ///< Polarity of the CSN pin.
+    uint8_t              csn_duration; ///< Minimum duration between the edge of CSN and the edge of SCK.
+                                       /**< Also, minimum duration of CSN inactivity between transactions.
+                                        *   The value is specified in number of 64 MHz clock cycles (15.625 ns). */
+#endif
+#if NRFY_SPIM_HAS_RXDELAY
+    uint8_t              rx_delay;     ///< Sample delay for input serial data on MISO.
+                                       /**< This value specifies the delay between the occurrence
+                                        *   of the SCK sampling edge and actual sampling operation,
+                                        *   expressed in number of 64 MHz clock cycles (15.625 ns). */
+#endif
+} nrfy_spim_ext_config_t;
+#endif // NRFY_SPIM_HAS_EXTENDED
+
+/** @brief SPIM pins configuration structure. */
+typedef struct
+{
+    uint32_t sck_pin;  ///< SCK pin number.
+    uint32_t mosi_pin; ///< MOSI pin number.
+                       /**< Set to @ref NRF_SPIM_PIN_NOT_CONNECTED if this signal is not needed. */
+    uint32_t miso_pin; ///< MISO pin number.
+                       /**< Set to @ref NRF_SPIM_PIN_NOT_CONNECTED if this signal is not needed. */
+} nrfy_spim_pins_t;
+
+/** @brief SPIM configuration structure. */
+typedef struct
+{
+    nrfy_spim_pins_t       pins;          ///< Pin configuration structure.
+    uint8_t                orc;           ///< Overrun character.
+                                          /**< This character is transmitted when the TX buffer gets exhausted,
+                                               but the transaction continues due to RX. */
+#if NRFY_SPIM_HAS_FREQUENCY
+    nrf_spim_frequency_t   frequency;     ///< SPIM frequency.
+#elif NRFY_SPIM_HAS_PRESCALER
+    uint32_t               prescaler;     ///< SPIM prescaler value.
+#endif
+    nrf_spim_mode_t        mode;          ///< SPIM mode.
+    nrf_spim_bit_order_t   bit_order;     ///< SPIM bit order.
+#if NRFY_SPIM_HAS_EXTENDED
+    nrfy_spim_ext_config_t ext_config;    ///< Extended features configuration structure.
+                                          /**< Used only if @p ext_enable is true. */
+    bool                   ext_enable;    ///< True if extended features are to be configured, false otherwise.
+#endif
+    bool                   skip_psel_cfg; ///< Skip pin selection configuration.
+                                          /**< When set to true, the driver does not modify
+                                           *   pin select registers in the peripheral.
+                                           *   Those registers are supposed to be set up
+                                           *   externally before the driver is initialized.
+                                           *   @note When both GPIO configuration and pin
+                                           *   selection are to be skipped, the structure
+                                           *   fields that specify pins can be omitted,
+                                           *   as they are ignored anyway. */
+} nrfy_spim_config_t;
+
+/**
+ * @brief Function for configuring the SPIM.
+ *
+ * @param[in] p_reg    Pointer to the structure of registers of the peripheral.
+ * @param[in] p_config Pointer to the peripheral configuration structure.
+ */
+NRFY_STATIC_INLINE void nrfy_spim_periph_configure(NRF_SPIM_Type *            p_reg,
+                                                   nrfy_spim_config_t const * p_config)
+{
+    if (!p_config->skip_psel_cfg)
+    {
+        nrf_spim_pins_set(p_reg,
+            p_config->pins.sck_pin, p_config->pins.mosi_pin, p_config->pins.miso_pin);
+    }
+    nrf_spim_orc_set(p_reg, p_config->orc);
+#if NRFY_SPIM_HAS_FREQUENCY
+    nrf_spim_frequency_set(p_reg, p_config->frequency);
+#elif NRFY_SPIM_HAS_PRESCALER
+    nrf_spim_prescaler_set(p_reg, p_config->prescaler);
+#endif
+    nrf_spim_configure(p_reg, p_config->mode, p_config->bit_order);
+#if NRFY_SPIM_HAS_EXTENDED
+    if (p_config->ext_enable)
+    {
+        if (!p_config->skip_psel_cfg)
+        {
+#if NRFY_SPIM_HAS_DCX
+            if (p_config->ext_config.pins.dcx_pin != NRF_SPIM_PIN_NOT_CONNECTED)
+            {
+                nrf_spim_dcx_pin_set(p_reg, p_config->ext_config.pins.dcx_pin);
+            }
+#endif
+#if NRFY_SPIM_HAS_HW_CSN
+            if (p_config->ext_config.pins.csn_pin != NRF_SPIM_PIN_NOT_CONNECTED)
+            {
+                nrf_spim_csn_configure(p_reg,
+                                       p_config->ext_config.pins.csn_pin,
+                                       p_config->ext_config.csn_pol,
+                                       p_config->ext_config.csn_duration);
+            }
+#endif
+        }
+#if NRFY_SPIM_HAS_RXDELAY
+        nrf_spim_iftiming_set(p_reg, p_config->ext_config.rx_delay);
+#endif
+    }
+#endif // NRFY_SPIM_HAS_EXTENDED
+    nrf_barrier_w();
+}
+
+/**
+ * @brief Function for initializing the specified SPIM interrupts.
+ *
+ * @param[in] p_reg        Pointer to the structure of registers of the peripheral.
+ * @param[in] mask         Mask of interrupts to be initialized.
+ * @param[in] irq_priority Interrupt priority.
+ * @param[in] enable       True if interrupts associated with the event mask are to be enabled, false otherwise.
+ */
+NRFY_STATIC_INLINE void nrfy_spim_int_init(NRF_SPIM_Type * p_reg,
+                                           uint32_t        mask,
+                                           uint8_t         irq_priority,
+                                           bool            enable)
+{
+    __nrfy_internal_spim_event_enabled_clear(p_reg, mask, NRF_SPIM_EVENT_STOPPED);
+    __nrfy_internal_spim_event_enabled_clear(p_reg, mask, NRF_SPIM_EVENT_ENDRX);
+    __nrfy_internal_spim_event_enabled_clear(p_reg, mask, NRF_SPIM_EVENT_END);
+    __nrfy_internal_spim_event_enabled_clear(p_reg, mask, NRF_SPIM_EVENT_ENDTX);
+    __nrfy_internal_spim_event_enabled_clear(p_reg, mask, NRF_SPIM_EVENT_STARTED);
+
+    nrf_barrier_w();
+    NRFX_IRQ_PRIORITY_SET(nrfx_get_irq_number(p_reg), irq_priority);
+    NRFX_IRQ_ENABLE(nrfx_get_irq_number(p_reg));
+    if (enable)
+    {
+        nrf_spim_int_enable(p_reg, mask);
+    }
+    nrf_barrier_w();
+}
+
+/**
+ * @brief Function for uninitializing the SPIM interrupts.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ */
+NRFY_STATIC_INLINE void nrfy_spim_int_uninit(NRF_SPIM_Type * p_reg)
+{
+    NRFX_IRQ_DISABLE(nrfx_get_irq_number(p_reg));
+    nrf_barrier_w();
+}
+
+/**
+ * @brief Function for processing the specified SPIM events.
+ *
+ * @param[in] p_reg  Pointer to the structure of registers of the peripheral.
+ * @param[in] mask   Mask of events to be processed, created by @ref NRFY_EVENT_TO_INT_BITMASK();
+ * @param[in] p_xfer Pointer to the structure containing buffers associated with the last transaction.
+ *                   Can be NULL.
+ *
+ * @return Mask of events that were generated and processed.
+ *         To be checked against the result of @ref NRFY_EVENT_TO_INT_BITMASK().
+ */
+NRFY_STATIC_INLINE uint32_t nrfy_spim_events_process(NRF_SPIM_Type *               p_reg,
+                                                     uint32_t                      mask,
+                                                     nrfy_spim_xfer_desc_t const * p_xfer)
+{
+    uint32_t evt_mask = __nrfy_internal_spim_events_process(p_reg, mask, p_xfer);
+    nrf_barrier_w();
+    return evt_mask;
+}
+
+/**
+ * @brief Function for setting the SPIM transaction buffers.
+ *
+ * @param[in] p_reg  Pointer to the structure of registers of the peripheral.
+ * @param[in] p_xfer Pointer to the structure containing transaction buffers.
+ */
+NRFY_STATIC_INLINE void nrfy_spim_buffers_set(NRF_SPIM_Type *               p_reg,
+                                              nrfy_spim_xfer_desc_t const * p_xfer)
+{
+    if (p_xfer->p_tx_buffer)
+    {
+        NRFY_CACHE_WB(p_xfer->p_tx_buffer, p_xfer->tx_length);
+    }
+    nrf_spim_tx_buffer_set(p_reg, p_xfer->p_tx_buffer, p_xfer->tx_length);
+    nrf_spim_rx_buffer_set(p_reg, p_xfer->p_rx_buffer, p_xfer->rx_length);
+    nrf_barrier_w();
+}
+
+/**
+ * @brief Function for starting the SPIM transaction.
+ *
+ * @param[in] p_reg  Pointer to the structure of registers of the peripheral.
+ * @param[in] p_xfer Pointer to the structure containing transaction buffers
+ *                   if the transaction is to be blocking. NULL for non-blocking transactions.
+ */
+NRFY_STATIC_INLINE void nrfy_spim_xfer_start(NRF_SPIM_Type *               p_reg,
+                                             nrfy_spim_xfer_desc_t const * p_xfer)
+{
+    nrf_spim_task_trigger(p_reg, NRF_SPIM_TASK_START);
+    if (p_xfer)
+    {
+        nrf_barrier_w();
+        while (!nrf_spim_event_check(p_reg, NRF_SPIM_EVENT_END))
+        {}
+        (void)__nrfy_internal_spim_events_process(p_reg,
+                                                  NRFY_EVENT_TO_INT_BITMASK(NRF_SPIM_EVENT_END),
+                                                  p_xfer);
+    }
+    nrf_barrier_w();
+}
+
+/**
+ * @brief Function for aborting the ongoing SPIM transaction.
+ *
+ * @param[in] p_reg  Pointer to the structure of registers of the peripheral.
+ * @param[in] p_xfer Pointer to the structure containing transaction buffers
+ *                   if the abort is to be blocking. NULL for non-blocking operation.
+ */
+NRFY_STATIC_INLINE void nrfy_spim_abort(NRF_SPIM_Type * p_reg, nrfy_spim_xfer_desc_t const * p_xfer)
+{
+    nrf_spim_task_trigger(p_reg, NRF_SPIM_TASK_STOP);
+    if (p_xfer)
+    {
+        nrf_barrier_w();
+        uint32_t evt_mask = NRFY_EVENT_TO_INT_BITMASK(NRF_SPIM_EVENT_STOPPED);
+        while (!__nrfy_internal_spim_events_process(p_reg, evt_mask, p_xfer))
+        {}
+        (void)__nrfy_internal_spim_events_process(p_reg,
+                                                  NRFY_EVENT_TO_INT_BITMASK(NRF_SPIM_EVENT_END),
+                                                  NULL);
+    }
+    nrf_barrier_w();
+}
+
+/**
+ * @brief Function for getting the SPIM pins configuration.
+ *
+ * @param[in]  p_reg  Pointer to the structure of registers of the peripheral.
+ * @param[out] p_pins Pointer to the structure to be filled with SPIM pins configuration.
+ */
+NRFY_STATIC_INLINE void nrfy_spim_pins_get(NRF_SPIM_Type const * p_reg, nrfy_spim_pins_t * p_pins)
+{
+    p_pins->sck_pin  = nrf_spim_sck_pin_get(p_reg);
+    p_pins->mosi_pin = nrf_spim_mosi_pin_get(p_reg);
+    p_pins->miso_pin = nrf_spim_miso_pin_get(p_reg);
+}
+
+#if NRFY_SPIM_HAS_EXTENDED
+/**
+ * @brief Function for getting the configuration of the SPIM pins used for extended features.
+ *
+ * @param[in]  p_reg  Pointer to the structure of registers of the peripheral.
+ * @param[out] p_pins Pointer to the structure to be filled with SPIM pins configuration.
+ */
+NRFY_STATIC_INLINE void nrfy_spim_ext_pins_get(NRF_SPIM_Type const *  p_reg,
+                                               nrfy_spim_ext_pins_t * p_pins)
+{
+    p_pins->dcx_pin = nrf_spim_dcx_pin_get(p_reg);
+    p_pins->csn_pin = nrf_spim_csn_pin_get(p_reg);
+}
+#endif
+
+#if NRFY_SPIM_HAS_ARRAY_LIST
+/**
+ * @brief Function for enabling or disabling the TX list feature.
+ *
+ * @param[in] p_reg  Pointer to the structure of registers of the peripheral.
+ * @param[in] enable True if TX list feature is to be enabled, false otherwise.
+ */
+NRFY_STATIC_INLINE void nrfy_spim_tx_list_set(NRF_SPIM_Type * p_reg, bool enable)
+{
+    if (enable)
+    {
+        nrf_spim_tx_list_enable(p_reg);
+    }
+    else
+    {
+        nrf_spim_tx_list_disable(p_reg);
+    }
+    nrf_barrier_w();
+}
+
+/**
+ * @brief Function for enabling or disabling the RX list feature.
+ *
+ * @param[in] p_reg  Pointer to the structure of registers of the peripheral.
+ * @param[in] enable True if RX list feature is to be enabled, false otherwise.
+ */
+NRFY_STATIC_INLINE void nrfy_spim_rx_list_set(NRF_SPIM_Type * p_reg, bool enable)
+{
+    if (enable)
+    {
+        nrf_spim_rx_list_enable(p_reg);
+    }
+    else
+    {
+        nrf_spim_rx_list_disable(p_reg);
+    }
+    nrf_barrier_w();
+}
+#endif
+
+/** @refhal{nrf_spim_task_trigger} */
+NRFY_STATIC_INLINE void nrfy_spim_task_trigger(NRF_SPIM_Type * p_reg,
+                                               nrf_spim_task_t task)
+{
+    nrf_spim_task_trigger(p_reg, task);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_spim_task_address_get} */
+NRFY_STATIC_INLINE uint32_t nrfy_spim_task_address_get(NRF_SPIM_Type const * p_reg,
+                                                       nrf_spim_task_t       task)
+{
+    return nrf_spim_task_address_get(p_reg, task);
+}
+
+/** @refhal{nrf_spim_event_clear} */
+NRFY_STATIC_INLINE void nrfy_spim_event_clear(NRF_SPIM_Type * p_reg, nrf_spim_event_t event)
+{
+    nrf_spim_event_clear(p_reg, event);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_spim_event_check} */
+NRFY_STATIC_INLINE bool nrfy_spim_event_check(NRF_SPIM_Type const * p_reg, nrf_spim_event_t event)
+{
+    nrf_barrier_r();
+    bool check = nrf_spim_event_check(p_reg, event);
+    nrf_barrier_r();
+    return check;
+}
+
+/** @refhal{nrf_spim_event_address_get} */
+NRFY_STATIC_INLINE uint32_t nrfy_spim_event_address_get(NRF_SPIM_Type const * p_reg,
+                                                        nrf_spim_event_t      event)
+{
+    return nrf_spim_event_address_get(p_reg, event);
+}
+
+/** @refhal{nrf_spim_shorts_enable} */
+NRFY_STATIC_INLINE void nrfy_spim_shorts_enable(NRF_SPIM_Type * p_reg, uint32_t mask)
+{
+    nrf_spim_shorts_enable(p_reg, mask);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_spim_shorts_disable} */
+NRFY_STATIC_INLINE void nrfy_spim_shorts_disable(NRF_SPIM_Type * p_reg, uint32_t mask)
+{
+    nrf_spim_shorts_disable(p_reg, mask);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_spim_shorts_get} */
+NRFY_STATIC_INLINE uint32_t nrfy_spim_shorts_get(NRF_SPIM_Type const * p_reg)
+{
+    nrf_barrier_rw();
+    uint32_t shorts = nrf_spim_shorts_get(p_reg);
+    nrf_barrier_r();
+    return shorts;
+}
+
+/** @refhal{nrf_spim_int_enable} */
+NRFY_STATIC_INLINE void nrfy_spim_int_enable(NRF_SPIM_Type * p_reg, uint32_t mask)
+{
+    nrf_spim_int_enable(p_reg, mask);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_spim_int_disable} */
+NRFY_STATIC_INLINE void nrfy_spim_int_disable(NRF_SPIM_Type * p_reg, uint32_t mask)
+{
+    nrf_spim_int_disable(p_reg, mask);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_spim_int_enable_check} */
+NRFY_STATIC_INLINE uint32_t nrfy_spim_int_enable_check(NRF_SPIM_Type const * p_reg, uint32_t mask)
+{
+    nrf_barrier_rw();
+    uint32_t check = nrf_spim_int_enable_check(p_reg, mask);
+    nrf_barrier_r();
+    return check;
+}
+
+#if defined(DPPI_PRESENT) || defined(__NRFX_DOXYGEN__)
+/** @refhal{nrf_spim_subscribe_set} */
+NRFY_STATIC_INLINE void nrfy_spim_subscribe_set(NRF_SPIM_Type * p_reg,
+                                                nrf_spim_task_t task,
+                                                uint8_t         channel)
+{
+    nrf_spim_subscribe_set(p_reg, task, channel);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_spim_subscribe_clear} */
+NRFY_STATIC_INLINE void nrfy_spim_subscribe_clear(NRF_SPIM_Type * p_reg,
+                                                  nrf_spim_task_t task)
+{
+    nrf_spim_subscribe_clear(p_reg, task);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_spim_publish_set} */
+NRFY_STATIC_INLINE void nrfy_spim_publish_set(NRF_SPIM_Type *  p_reg,
+                                              nrf_spim_event_t event,
+                                              uint8_t          channel)
+{
+    nrf_spim_publish_set(p_reg, event, channel);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_spim_publish_clear} */
+NRFY_STATIC_INLINE void nrfy_spim_publish_clear(NRF_SPIM_Type *  p_reg,
+                                                nrf_spim_event_t event)
+{
+    nrf_spim_publish_clear(p_reg, event);
+    nrf_barrier_w();
+}
+#endif // defined(DPPI_PRESENT) || defined(__NRFX_DOXYGEN__)
+
+/** @refhal{nrf_spim_enable} */
+NRFY_STATIC_INLINE void nrfy_spim_enable(NRF_SPIM_Type * p_reg)
+{
+    nrf_spim_enable(p_reg);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_spim_disable} */
+NRFY_STATIC_INLINE void nrfy_spim_disable(NRF_SPIM_Type * p_reg)
+{
+    nrf_spim_disable(p_reg);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_spim_pins_set} */
+NRFY_STATIC_INLINE void nrfy_spim_pins_set(NRF_SPIM_Type * p_reg,
+                                           uint32_t        sck_pin,
+                                           uint32_t        mosi_pin,
+                                           uint32_t        miso_pin)
+{
+    nrf_spim_pins_set(p_reg, sck_pin, mosi_pin, miso_pin);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_spim_sck_pin_get} */
+NRFY_STATIC_INLINE uint32_t nrfy_spim_sck_pin_get(NRF_SPIM_Type const * p_reg)
+{
+    nrf_barrier_rw();
+    uint32_t pin = nrf_spim_sck_pin_get(p_reg);
+    nrf_barrier_r();
+    return pin;
+}
+
+/** @refhal{nrf_spim_mosi_pin_get} */
+NRFY_STATIC_INLINE uint32_t nrfy_spim_mosi_pin_get(NRF_SPIM_Type const * p_reg)
+{
+    nrf_barrier_rw();
+    uint32_t pin = nrf_spim_mosi_pin_get(p_reg);
+    nrf_barrier_r();
+    return pin;
+}
+
+/** @refhal{nrf_spim_miso_pin_get} */
+NRFY_STATIC_INLINE uint32_t nrfy_spim_miso_pin_get(NRF_SPIM_Type const * p_reg)
+{
+    nrf_barrier_rw();
+    uint32_t pin = nrf_spim_miso_pin_get(p_reg);
+    nrf_barrier_r();
+    return pin;
+}
+
+
+#if NRFY_SPIM_HAS_HW_CSN
+/** @refhal{nrf_spim_csn_configure} */
+NRFY_STATIC_INLINE void nrfy_spim_csn_configure(NRF_SPIM_Type *    p_reg,
+                                                uint32_t           pin,
+                                                nrf_spim_csn_pol_t polarity,
+                                                uint32_t           duration)
+{
+    nrf_spim_csn_configure(p_reg, pin, polarity, duration);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_spim_csn_pin_get} */
+NRFY_STATIC_INLINE uint32_t nrfy_spim_csn_pin_get(NRF_SPIM_Type const * p_reg)
+{
+    nrf_barrier_rw();
+    uint32_t pin = nrf_spim_csn_pin_get(p_reg);
+    nrf_barrier_r();
+    return pin;
+}
+#endif
+
+#if NRFY_SPIM_HAS_DCX
+/** @refhal{nrf_spim_dcx_pin_set} */
+NRFY_STATIC_INLINE void nrfy_spim_dcx_pin_set(NRF_SPIM_Type * p_reg,
+                                              uint32_t        dcx_pin)
+{
+    nrf_spim_dcx_pin_set(p_reg, dcx_pin);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_spim_dcx_pin_get} */
+NRFY_STATIC_INLINE uint32_t nrfy_spim_dcx_pin_get(NRF_SPIM_Type const * p_reg)
+{
+    nrf_barrier_rw();
+    uint32_t pin = nrf_spim_dcx_pin_get(p_reg);
+    nrf_barrier_r();
+    return pin;
+}
+
+/** @refhal{nrf_spim_dcx_cnt_set} */
+NRFY_STATIC_INLINE void nrfy_spim_dcx_cnt_set(NRF_SPIM_Type * p_reg, uint32_t count)
+{
+    nrf_spim_dcx_cnt_set(p_reg, count);
+    nrf_barrier_w();
+}
+#endif
+
+#if NRFY_SPIM_HAS_RXDELAY
+/** @refhal{nrf_spim_iftiming_set} */
+NRFY_STATIC_INLINE void nrfy_spim_iftiming_set(NRF_SPIM_Type * p_reg,
+                                               uint32_t        rxdelay)
+{
+    nrf_spim_iftiming_set(p_reg, rxdelay);
+    nrf_barrier_w();
+}
+#endif
+
+#if NRFY_SPIM_HAS_STALLSTAT
+/** @refhal{nrf_spim_stallstat_rx_clear} */
+NRFY_STATIC_INLINE void nrfy_spim_stallstat_rx_clear(NRF_SPIM_Type * p_reg)
+{
+    nrf_spim_stallstat_rx_clear(p_reg);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_spim_stallstat_rx_get} */
+NRFY_STATIC_INLINE bool nrfy_spim_stallstat_rx_get(NRF_SPIM_Type const * p_reg)
+{
+    nrf_barrier_rw();
+    bool stallstat = nrf_spim_stallstat_rx_get(p_reg);
+    nrf_barrier_r();
+    return stallstat;
+}
+
+/** @refhal{nrf_spim_stallstat_tx_clear} */
+NRFY_STATIC_INLINE void nrfy_spim_stallstat_tx_clear(NRF_SPIM_Type * p_reg)
+{
+    nrf_spim_stallstat_tx_clear(p_reg);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_spim_stallstat_tx_get} */
+NRFY_STATIC_INLINE bool nrfy_spim_stallstat_tx_get(NRF_SPIM_Type const * p_reg)
+{
+    nrf_barrier_rw();
+    bool stallstat = nrf_spim_stallstat_tx_get(p_reg);
+    nrf_barrier_r();
+    return stallstat;
+}
+#endif // NRFY_SPIM_HAS_STALLSTAT
+
+#if NRFY_SPIM_HAS_FREQUENCY
+/** @refhal{nrf_spim_frequency_set} */
+NRFY_STATIC_INLINE void nrfy_spim_frequency_set(NRF_SPIM_Type *      p_reg,
+                                                nrf_spim_frequency_t frequency)
+{
+    nrf_spim_frequency_set(p_reg, frequency);
+    nrf_barrier_w();
+}
+#endif
+
+#if NRFY_SPIM_HAS_PRESCALER
+/** @refhal{nrf_spim_prescaler_set} */
+NRF_STATIC_INLINE void nrfy_spim_prescaler_set(NRF_SPIM_Type * p_reg, uint32_t prescaler)
+{
+    nrf_spim_prescaler_set(p_reg, prescaler);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_spim_prescaler_get} */
+NRF_STATIC_INLINE uint32_t nrfy_spim_prescaler_get(NRF_SPIM_Type const * p_reg)
+{
+    nrf_barrier_rw();
+    uint32_t prescaler = nrf_spim_prescaler_get(p_reg);
+    nrf_barrier_r();
+    return prescaler;
+}
+#endif
+
+/** @refhal{nrf_spim_tx_buffer_set} */
+NRFY_STATIC_INLINE void nrfy_spim_tx_buffer_set(NRF_SPIM_Type * p_reg,
+                                                uint8_t const * p_buffer,
+                                                size_t          length)
+{
+    nrf_spim_tx_buffer_set(p_reg, p_buffer, length);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_spim_tx_amount_get} */
+NRFY_STATIC_INLINE uint32_t nrfy_spim_tx_amount_get(NRF_SPIM_Type const * p_reg)
+{
+    nrf_barrier_r();
+    uint32_t amount = nrf_spim_tx_amount_get(p_reg);
+    nrf_barrier_r();
+    return amount;
+}
+
+/** @refhal{nrf_spim_tx_maxcnt_get} */
+NRFY_STATIC_INLINE uint32_t nrfy_spim_tx_maxcnt_get(NRF_SPIM_Type const * p_reg)
+{
+    nrf_barrier_rw();
+    uint32_t maxcnt = nrf_spim_tx_maxcnt_get(p_reg);
+    nrf_barrier_r();
+    return maxcnt;
+}
+
+/** @refhal{nrf_spim_rx_buffer_set} */
+NRFY_STATIC_INLINE void nrfy_spim_rx_buffer_set(NRF_SPIM_Type * p_reg,
+                                                uint8_t *       p_buffer,
+                                                size_t          length)
+{
+    nrf_spim_rx_buffer_set(p_reg, p_buffer, length);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_spim_tx_amount_get} */
+NRFY_STATIC_INLINE uint32_t nrfy_spim_rx_amount_get(NRF_SPIM_Type const * p_reg)
+{
+    nrf_barrier_r();
+    uint32_t amount = nrf_spim_rx_amount_get(p_reg);
+    nrf_barrier_r();
+    return amount;
+}
+
+/** @refhal{nrf_spim_rx_maxcnt_get} */
+NRFY_STATIC_INLINE uint32_t nrfy_spim_rx_maxcnt_get(NRF_SPIM_Type const * p_reg)
+{
+    nrf_barrier_rw();
+    uint32_t maxcnt = nrf_spim_rx_maxcnt_get(p_reg);
+    nrf_barrier_r();
+    return maxcnt;
+}
+
+/** @refhal{nrf_spim_configure} */
+NRFY_STATIC_INLINE void nrfy_spim_configure(NRF_SPIM_Type *      p_reg,
+                                            nrf_spim_mode_t      spi_mode,
+                                            nrf_spim_bit_order_t spi_bit_order)
+{
+    nrf_spim_configure(p_reg, spi_mode, spi_bit_order);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_spim_orc_set} */
+NRFY_STATIC_INLINE void nrfy_spim_orc_set(NRF_SPIM_Type * p_reg,
+                                          uint8_t         orc)
+{
+    nrf_spim_orc_set(p_reg, orc);
+    nrf_barrier_w();
+}
+
+/** @} */
+
+NRFY_STATIC_INLINE bool __nrfy_internal_spim_event_handle(NRF_SPIM_Type *  p_reg,
+                                                          uint32_t         mask,
+                                                          nrf_spim_event_t event,
+                                                          uint32_t *       p_evt_mask)
+{
+    if ((mask & NRFY_EVENT_TO_INT_BITMASK(event)) && nrf_spim_event_check(p_reg, event))
+    {
+        nrf_spim_event_clear(p_reg, event);
+        if (p_evt_mask)
+        {
+            *p_evt_mask |= NRFY_EVENT_TO_INT_BITMASK(event);
+        }
+        return true;
+    }
+    return false;
+}
+
+NRFY_STATIC_INLINE
+uint32_t __nrfy_internal_spim_events_process(NRF_SPIM_Type *               p_reg,
+                                             uint32_t                      mask,
+                                             nrfy_spim_xfer_desc_t const * p_xfer)
+{
+    uint32_t evt_mask = 0;
+
+    nrf_barrier_r();
+    (void)__nrfy_internal_spim_event_handle(p_reg, mask, NRF_SPIM_EVENT_STARTED, &evt_mask);
+
+    bool stop = __nrfy_internal_spim_event_handle(p_reg, mask, NRF_SPIM_EVENT_STOPPED, &evt_mask);
+
+    bool invalidated = false;
+    if (__nrfy_internal_spim_event_handle(p_reg, mask, NRF_SPIM_EVENT_END, &evt_mask) && p_xfer)
+    {
+        size_t size = stop ? nrf_spim_rx_amount_get(p_reg) : p_xfer->rx_length;
+        NRFY_CACHE_INV(p_xfer->p_rx_buffer, size);
+        invalidated = true;
+    }
+
+    if (__nrfy_internal_spim_event_handle(p_reg, mask, NRF_SPIM_EVENT_ENDRX, &evt_mask) &&
+        p_xfer && !invalidated)
+    {
+        size_t size = stop ? nrf_spim_rx_amount_get(p_reg) : p_xfer->rx_length;
+        NRFY_CACHE_INV(p_xfer->p_rx_buffer, size);
+    }
+
+    (void)__nrfy_internal_spim_event_handle(p_reg, mask, NRF_SPIM_EVENT_ENDTX, &evt_mask);
+
+    return evt_mask;
+}
+
+NRFY_STATIC_INLINE void __nrfy_internal_spim_event_enabled_clear(NRF_SPIM_Type *  p_reg,
+                                                                 uint32_t         mask,
+                                                                 nrf_spim_event_t event)
+{
+    if (mask & NRFY_EVENT_TO_INT_BITMASK(event))
+    {
+        nrf_spim_event_clear(p_reg, event);
+    }
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // NRFY_SPIM_H__

--- a/nrfx/haly/nrfy_temp.h
+++ b/nrfx/haly/nrfy_temp.h
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2012 - 2023, Nordic Semiconductor ASA
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef NRFY_TEMP_H__
+#define NRFY_TEMP_H__
+
+#include <nrfx.h>
+#include <hal/nrf_temp.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+* @defgroup nrfy_temp TEMP HALY
+* @{
+* @ingroup nrf_temp
+* @brief   Hardware access layer with cache and barrier support
+           for managing the Temperature sensor (TEMP).
+*/
+
+/**
+ * @brief Function for initializing the specified TEMP interrupts.
+ *
+ * @param[in] p_reg        Pointer to the structure of registers of the peripheral.
+ * @param[in] mask         Mask of interrupts to be initialized.
+ * @param[in] irq_priority Interrupt priority.
+ * @param[in] enable       True if the interrupts are to be enabled, false otherwise.
+ */
+NRFY_STATIC_INLINE void nrfy_temp_int_init(NRF_TEMP_Type * p_reg,
+                                           uint32_t        mask,
+                                           uint8_t         irq_priority,
+                                           bool            enable)
+{
+    (void)mask;
+    nrf_temp_event_clear(p_reg, NRF_TEMP_EVENT_DATARDY);
+    nrf_barrier_w();
+
+    NRFX_IRQ_PRIORITY_SET(nrfx_get_irq_number(p_reg), irq_priority);
+    NRFX_IRQ_ENABLE(nrfx_get_irq_number(p_reg));
+    if (enable)
+    {
+        nrf_temp_int_enable(p_reg, NRF_TEMP_INT_DATARDY_MASK);
+    }
+    nrf_barrier_w();
+}
+
+/**
+ * @brief Function for uninitializing the TEMP interrupts.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ */
+NRFY_STATIC_INLINE void nrfy_temp_int_uninit(NRF_TEMP_Type * p_reg)
+{
+    NRFX_IRQ_DISABLE(nrfx_get_irq_number(p_reg));
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_temp_int_enable} */
+NRF_STATIC_INLINE void nrfy_temp_int_enable(NRF_TEMP_Type * p_reg, uint32_t mask)
+{
+    nrf_temp_int_enable(p_reg, mask);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_temp_int_disable} */
+NRF_STATIC_INLINE void nrfy_temp_int_disable(NRF_TEMP_Type * p_reg, uint32_t mask)
+{
+    nrf_temp_int_disable(p_reg, mask);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_temp_int_enable_check} */
+NRF_STATIC_INLINE uint32_t nrfy_temp_int_enable_check(NRF_TEMP_Type const * p_reg, uint32_t mask)
+{
+    nrf_barrier_rw();
+    uint32_t check = nrf_temp_int_enable_check(p_reg, mask);
+    nrf_barrier_r();
+    return check;
+}
+
+/** @refhal{nrf_temp_task_address_get} */
+NRF_STATIC_INLINE uint32_t nrfy_temp_task_address_get(NRF_TEMP_Type const * p_reg,
+                                                      nrf_temp_task_t       task)
+{
+    return nrf_temp_task_address_get(p_reg, task);
+}
+
+/** @refhal{nrf_temp_task_trigger} */
+NRF_STATIC_INLINE void nrfy_temp_task_trigger(NRF_TEMP_Type * p_reg, nrf_temp_task_t task)
+{
+    nrf_temp_task_trigger(p_reg, task);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_temp_event_address_get} */
+NRF_STATIC_INLINE uint32_t nrfy_temp_event_address_get(NRF_TEMP_Type const * p_reg,
+                                                       nrf_temp_event_t      event)
+{
+    return nrf_temp_event_address_get(p_reg, event);
+}
+
+/** @refhal{nrf_temp_event_clear} */
+NRF_STATIC_INLINE void nrfy_temp_event_clear(NRF_TEMP_Type * p_reg, nrf_temp_event_t event)
+{
+    nrf_temp_event_clear(p_reg, event);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_temp_event_check} */
+NRF_STATIC_INLINE bool nrfy_temp_event_check(NRF_TEMP_Type const * p_reg, nrf_temp_event_t event)
+{
+    nrf_barrier_rw();
+    uint32_t check = nrf_temp_event_check(p_reg, event);
+    nrf_barrier_r();
+    return check;
+}
+
+/** @refhal{nrf_temp_result_get} */
+NRF_STATIC_INLINE int32_t nrfy_temp_result_get(NRF_TEMP_Type const * p_reg)
+{
+    nrf_barrier_r();
+    int32_t temperature = nrf_temp_result_get(p_reg);
+    nrf_barrier_r();
+    return temperature;
+}
+
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // NRFY_TEMP_H__

--- a/nrfx/haly/nrfy_timer.h
+++ b/nrfx/haly/nrfy_timer.h
@@ -1,0 +1,452 @@
+/*
+ * Copyright (c) 2021 - 2023, Nordic Semiconductor ASA
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef NRFY_TIMER_H__
+#define NRFY_TIMER_H__
+
+#include <nrfx.h>
+#include <hal/nrf_timer.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+NRFY_STATIC_INLINE void __nrfy_internal_timer_event_enabled_clear(NRF_TIMER_Type *  p_reg,
+                                                                  uint32_t          mask,
+                                                                  nrf_timer_event_t event);
+
+NRFY_STATIC_INLINE bool __nrfy_internal_timer_event_handle(NRF_TIMER_Type *  p_reg,
+                                                           uint32_t          mask,
+                                                           nrf_timer_event_t event,
+                                                           uint32_t *        p_evt_mask);
+
+NRFY_STATIC_INLINE uint32_t __nrfy_internal_timer_events_process(NRF_TIMER_Type * p_reg,
+                                                                 uint32_t         mask);
+
+/**
+ * @defgroup nrfy_timer TIMER HALY
+ * @{
+ * @ingroup nrf_timer
+ * @brief   Hardware access layer with cache and barrier support for managing the TIMER peripheral.
+ */
+
+ #if NRF_TIMER_HAS_ONE_SHOT || defined(__NRFX_DOXYGEN__)
+ /** @refhal{NRF_TIMER_HAS_ONE_SHOT} */
+ #define NRFY_TIMER_HAS_ONE_SHOT 1
+ #else
+ #define NRFY_TIMER_HAS_ONE_SHOT 0
+ #endif
+
+/** @brief TIMER configuration structure. */
+typedef struct
+{
+    uint32_t              prescaler; ///< Prescaler value.
+    nrf_timer_mode_t      mode;      ///< Mode of operation.
+    nrf_timer_bit_width_t bit_width; ///< Bit width.
+} nrfy_timer_config_t;
+
+/**
+ * @brief Function for configuring the TIMER.
+ *
+ * @param[in] p_reg    Pointer to the structure of registers of the peripheral.
+ * @param[in] p_config Pointer to the peripheral configuration structure.
+ */
+NRFY_STATIC_INLINE void nrfy_timer_periph_configure(NRF_TIMER_Type *            p_reg,
+                                                    nrfy_timer_config_t const * p_config)
+{
+    nrf_timer_mode_set(p_reg, p_config->mode);
+    nrf_timer_bit_width_set(p_reg, p_config->bit_width);
+    nrf_timer_prescaler_set(p_reg, p_config->prescaler);
+    nrf_barrier_w();
+}
+
+/**
+ * @brief Function for initializing the specified TIMER interrupts.
+ *
+ * @param[in] p_reg        Pointer to the structure of registers of the peripheral.
+ * @param[in] mask         Mask of interrupts to be initialized.
+ * @param[in] irq_priority Interrupt priority.
+ * @param[in] enable       True if the interrupts are to be enabled, false otherwise.
+ */
+NRFY_STATIC_INLINE void nrfy_timer_int_init(NRF_TIMER_Type * p_reg,
+                                            uint32_t         mask,
+                                            uint8_t          irq_priority,
+                                            bool             enable)
+{
+    for (size_t i = 0; i < NRF_TIMER_CC_COUNT_MAX; i++)
+    {
+        __nrfy_internal_timer_event_enabled_clear(p_reg, mask, nrf_timer_compare_event_get(i));
+    }
+
+    nrf_barrier_w();
+
+    NRFX_IRQ_PRIORITY_SET(nrfx_get_irq_number(p_reg), irq_priority);
+    NRFX_IRQ_ENABLE(nrfx_get_irq_number(p_reg));
+    if (enable)
+    {
+        nrf_timer_int_enable(p_reg, mask);
+    }
+    nrf_barrier_w();
+}
+
+/**
+ * @brief Function for uninitializing the TIMER interrupts.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ */
+NRFY_STATIC_INLINE void nrfy_timer_int_uninit(NRF_TIMER_Type * p_reg)
+{
+    NRFX_IRQ_DISABLE(nrfx_get_irq_number(p_reg));
+    nrf_barrier_w();
+}
+
+/**
+ * @brief Function for processing the specified TIMER events.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ * @param[in] mask  Mask of events to be processed, created by @ref NRFY_EVENT_TO_INT_BITMASK().
+ *
+ * @return Mask of events that were generated and processed.
+ *         To be checked against the result of @ref NRFY_EVENT_TO_INT_BITMASK().
+ */
+NRFY_STATIC_INLINE uint32_t nrfy_timer_events_process(NRF_TIMER_Type * p_reg,
+                                                      uint32_t         mask)
+{
+    uint32_t evt_mask = __nrfy_internal_timer_events_process(p_reg, mask);
+    nrf_barrier_w();
+    return evt_mask;
+}
+
+/**
+ * @brief Function for capturing the TIMER value.
+ *
+ * @note This function triggers the capture task for given @p channel and returns
+ *       latched timer value.
+ *
+ * @param[in] p_reg   Pointer to the structure of registers of the peripheral.
+ * @param[in] channel Capture channel number.
+ *
+ * @return Captured value.
+ */
+NRFY_STATIC_INLINE uint32_t nrfy_timer_capture_get(NRF_TIMER_Type *       p_reg,
+                                                   nrf_timer_cc_channel_t channel)
+{
+    nrf_timer_task_trigger(p_reg, nrf_timer_capture_task_get(channel));
+    nrf_barrier_rw();
+    uint32_t cc = nrf_timer_cc_get(p_reg, channel);
+    nrf_barrier_r();
+    return cc;
+}
+
+/** @refhal{nrf_timer_task_trigger} */
+NRFY_STATIC_INLINE void nrfy_timer_task_trigger(NRF_TIMER_Type * p_reg,
+                                                nrf_timer_task_t task)
+{
+    nrf_timer_task_trigger(p_reg, task);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_timer_task_address_get} */
+NRFY_STATIC_INLINE uint32_t nrfy_timer_task_address_get(NRF_TIMER_Type const * p_reg,
+                                                        nrf_timer_task_t       task)
+{
+    return nrf_timer_task_address_get(p_reg, task);
+}
+
+/** @refhal{nrf_timer_event_clear} */
+NRFY_STATIC_INLINE void nrfy_timer_event_clear(NRF_TIMER_Type *  p_reg,
+                                               nrf_timer_event_t event)
+{
+    nrf_timer_event_clear(p_reg, event);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_timer_event_check} */
+NRFY_STATIC_INLINE bool nrfy_timer_event_check(NRF_TIMER_Type const * p_reg,
+                                               nrf_timer_event_t      event)
+{
+    nrf_barrier_r();
+    bool check = nrf_timer_event_check(p_reg, event);
+    nrf_barrier_r();
+    return check;
+}
+
+/** @refhal{nrf_timer_event_address_get} */
+NRFY_STATIC_INLINE uint32_t nrfy_timer_event_address_get(NRF_TIMER_Type const * p_reg,
+                                                         nrf_timer_event_t      event)
+{
+    return nrf_timer_event_address_get(p_reg, event);
+}
+
+/** @refhal{nrf_timer_shorts_enable} */
+NRFY_STATIC_INLINE void nrfy_timer_shorts_enable(NRF_TIMER_Type * p_reg,
+                                                 uint32_t         mask)
+{
+    nrf_timer_shorts_enable(p_reg, mask);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_timer_shorts_disable} */
+NRFY_STATIC_INLINE void nrfy_timer_shorts_disable(NRF_TIMER_Type * p_reg,
+                                                  uint32_t         mask)
+{
+    nrf_timer_shorts_disable(p_reg, mask);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_timer_shorts_set} */
+NRFY_STATIC_INLINE void nrfy_timer_shorts_set(NRF_TIMER_Type * p_reg,
+                                              uint32_t         mask)
+{
+    nrf_timer_shorts_set(p_reg, mask);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_timer_int_enable} */
+NRFY_STATIC_INLINE void nrfy_timer_int_enable(NRF_TIMER_Type * p_reg,
+                                              uint32_t         mask)
+{
+    nrf_timer_int_enable(p_reg, mask);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_timer_int_disable} */
+NRFY_STATIC_INLINE void nrfy_timer_int_disable(NRF_TIMER_Type * p_reg,
+                                               uint32_t         mask)
+{
+    nrf_timer_int_disable(p_reg, mask);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_timer_int_enable_check} */
+NRFY_STATIC_INLINE uint32_t nrfy_timer_int_enable_check(NRF_TIMER_Type const * p_reg,
+                                                        uint32_t               mask)
+{
+    nrf_barrier_rw();
+    uint32_t check = nrf_timer_int_enable_check(p_reg, mask);
+    nrf_barrier_r();
+    return check;
+}
+
+#if defined(DPPI_PRESENT) || defined(__NRFX_DOXYGEN__)
+/** @refhal{nrf_timer_subscribe_set} */
+NRFY_STATIC_INLINE void nrfy_timer_subscribe_set(NRF_TIMER_Type * p_reg,
+                                                 nrf_timer_task_t task,
+                                                 uint8_t          channel)
+{
+    nrf_timer_subscribe_set(p_reg, task, channel);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_timer_subscribe_clear} */
+NRFY_STATIC_INLINE void nrfy_timer_subscribe_clear(NRF_TIMER_Type * p_reg,
+                                                   nrf_timer_task_t task)
+{
+    nrf_timer_subscribe_clear(p_reg, task);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_timer_publish_set} */
+NRFY_STATIC_INLINE void nrfy_timer_publish_set(NRF_TIMER_Type *  p_reg,
+                                               nrf_timer_event_t event,
+                                               uint8_t           channel)
+{
+    nrf_timer_publish_set(p_reg, event, channel);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_timer_publish_clear} */
+NRFY_STATIC_INLINE void nrfy_timer_publish_clear(NRF_TIMER_Type *  p_reg,
+                                                 nrf_timer_event_t event)
+{
+    nrf_timer_publish_clear(p_reg, event);
+    nrf_barrier_w();
+}
+#endif // defined(DPPI_PRESENT) || defined(__NRFX_DOXYGEN__)
+
+/** @refhal{nrf_timer_mode_set} */
+NRFY_STATIC_INLINE void nrfy_timer_mode_set(NRF_TIMER_Type * p_reg,
+                                            nrf_timer_mode_t mode)
+{
+    nrf_timer_mode_set(p_reg, mode);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_timer_mode_get} */
+NRFY_STATIC_INLINE nrf_timer_mode_t nrfy_timer_mode_get(NRF_TIMER_Type const * p_reg)
+{
+    nrf_barrier_rw();
+    nrf_timer_mode_t mode = nrf_timer_mode_get(p_reg);
+    nrf_barrier_r();
+    return mode;
+}
+
+/** @refhal{nrf_timer_bit_width_set} */
+NRFY_STATIC_INLINE void nrfy_timer_bit_width_set(NRF_TIMER_Type *      p_reg,
+                                                 nrf_timer_bit_width_t bit_width)
+{
+    nrf_timer_bit_width_set(p_reg, bit_width);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_timer_bit_width_get} */
+NRFY_STATIC_INLINE nrf_timer_bit_width_t nrfy_timer_bit_width_get(NRF_TIMER_Type const * p_reg)
+{
+    nrf_barrier_rw();
+    nrf_timer_bit_width_t bit_width = nrf_timer_bit_width_get(p_reg);
+    nrf_barrier_r();
+    return bit_width;
+}
+
+/** @refhal{nrf_timer_prescaler_set} */
+NRF_STATIC_INLINE void nrfy_timer_prescaler_set(NRF_TIMER_Type * p_reg, uint32_t prescaler_factor)
+{
+    nrf_timer_prescaler_set(p_reg, prescaler_factor);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_timer_prescaler_get} */
+NRF_STATIC_INLINE uint32_t nrfy_timer_prescaler_get(NRF_TIMER_Type const * p_reg)
+{
+    nrf_barrier_rw();
+    uint32_t prescaler = nrf_timer_prescaler_get(p_reg);
+    nrf_barrier_r();
+    return prescaler;
+}
+
+/** @refhal{nrf_timer_cc_set} */
+NRFY_STATIC_INLINE void nrfy_timer_cc_set(NRF_TIMER_Type *       p_reg,
+                                          nrf_timer_cc_channel_t cc_channel,
+                                          uint32_t               cc_value)
+{
+    nrf_timer_cc_set(p_reg, cc_channel, cc_value);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_timer_cc_get} */
+NRFY_STATIC_INLINE uint32_t nrfy_timer_cc_get(NRF_TIMER_Type const * p_reg,
+                                              nrf_timer_cc_channel_t cc_channel)
+{
+    nrf_barrier_rw();
+    uint32_t cc = nrf_timer_cc_get(p_reg, cc_channel);
+    nrf_barrier_r();
+    return cc;
+}
+
+/** @refhal{nrf_timer_capture_task_get} */
+NRFY_STATIC_INLINE nrf_timer_task_t nrfy_timer_capture_task_get(uint8_t channel)
+{
+    return nrf_timer_capture_task_get(channel);
+}
+
+/** @refhal{nrf_timer_compare_event_get} */
+NRFY_STATIC_INLINE nrf_timer_event_t nrfy_timer_compare_event_get(uint8_t channel)
+{
+    return nrf_timer_compare_event_get(channel);
+}
+
+/** @refhal{nrf_timer_compare_int_get} */
+NRFY_STATIC_INLINE nrf_timer_int_mask_t nrfy_timer_compare_int_get(uint8_t channel)
+{
+    return nrf_timer_compare_int_get(channel);
+}
+
+#if NRFY_TIMER_HAS_ONE_SHOT
+/** @refhal{nrf_timer_one_shot_enable} */
+NRFY_STATIC_INLINE void nrfy_timer_one_shot_enable(NRF_TIMER_Type *       p_reg,
+                                                   nrf_timer_cc_channel_t cc_channel)
+{
+    nrf_timer_one_shot_enable(p_reg, cc_channel);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_timer_one_shot_disable} */
+NRFY_STATIC_INLINE void nrfy_timer_one_shot_disable(NRF_TIMER_Type *       p_reg,
+                                                    nrf_timer_cc_channel_t cc_channel)
+{
+    nrf_timer_one_shot_disable(p_reg, cc_channel);
+    nrf_barrier_w();
+}
+#endif // NRFY_TIMER_HAS_ONE_SHOT
+
+/** @} */
+
+NRFY_STATIC_INLINE void __nrfy_internal_timer_event_enabled_clear(NRF_TIMER_Type *  p_reg,
+                                                                  uint32_t          mask,
+                                                                  nrf_timer_event_t event)
+{
+    if (mask & NRFY_EVENT_TO_INT_BITMASK(event))
+    {
+        nrf_timer_event_clear(p_reg, event);
+    }
+}
+
+NRFY_STATIC_INLINE bool __nrfy_internal_timer_event_handle(NRF_TIMER_Type *  p_reg,
+                                                           uint32_t          mask,
+                                                           nrf_timer_event_t event,
+                                                           uint32_t *        p_evt_mask)
+{
+    if ((mask & NRFY_EVENT_TO_INT_BITMASK(event)) && nrf_timer_event_check(p_reg, event))
+    {
+        nrf_timer_event_clear(p_reg, event);
+        if (p_evt_mask)
+        {
+            *p_evt_mask |= NRFY_EVENT_TO_INT_BITMASK(event);
+        }
+        return true;
+    }
+    return false;
+}
+
+NRFY_STATIC_INLINE uint32_t __nrfy_internal_timer_events_process(NRF_TIMER_Type * p_reg,
+                                                                 uint32_t         mask)
+{
+    uint32_t event_mask = 0;
+
+    nrf_barrier_r();
+    for (uint32_t i = 0; i < NRF_TIMER_CC_COUNT_MAX; i++)
+    {
+        __nrfy_internal_timer_event_handle(p_reg,
+                                           mask,
+                                           nrf_timer_compare_event_get(i),
+                                           &event_mask);
+    }
+
+    return event_mask;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // NRFY_TIMER_H__

--- a/nrfx/haly/nrfy_twim.h
+++ b/nrfx/haly/nrfy_twim.h
@@ -1,0 +1,725 @@
+/*
+ * Copyright (c) 2021 - 2023, Nordic Semiconductor ASA
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef NRFY_TWIM_H__
+#define NRFY_TWIM_H__
+
+#include <nrfx.h>
+#include <hal/nrf_twim.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct nrfy_twim_xfer_desc_t nrfy_twim_xfer_desc_t;
+
+NRFY_STATIC_INLINE void __nrfy_internal_twim_event_enabled_clear(NRF_TWIM_Type *  p_reg,
+                                                                 uint32_t         mask,
+                                                                 nrf_twim_event_t event);
+
+NRFY_STATIC_INLINE bool __nrfy_internal_twim_event_handle(NRF_TWIM_Type *  p_reg,
+                                                          uint32_t         mask,
+                                                          nrf_twim_event_t event,
+                                                          uint32_t *       p_evt_mask);
+
+NRFY_STATIC_INLINE
+uint32_t __nrfy_internal_twim_events_process(NRF_TWIM_Type *               p_reg,
+                                             uint32_t                      mask,
+                                             nrfy_twim_xfer_desc_t const * p_xfer);
+
+/**
+ * @defgroup nrfy_twim TWIM HALY
+ * @{
+ * @ingroup nrf_twim
+ * @brief   Hardware access layer with cache and barrier support for managing the TWIM peripheral.
+ */
+
+#if NRF_TWIM_HAS_ARRAY_LIST || defined(__NRFX_DOXYGEN__)
+/** @refhal{NRF_TWIM_HAS_ARRAY_LIST} */
+#define NRFY_TWIM_HAS_ARRAY_LIST 1
+#else
+#define NRFY_TWIM_HAS_ARRAY_LIST 0
+#endif
+
+/** @brief TWIM pins configuration structure. */
+typedef struct
+{
+    uint32_t scl_pin; ///< SCL pin number.
+    uint32_t sda_pin; ///< SDA pin number.
+} nrfy_twim_pins_t;
+
+/** @brief TWIM configuration structure. */
+typedef struct
+{
+    nrfy_twim_pins_t     pins;          ///< TWIM pins configuation.
+    nrf_twim_frequency_t frequency;     ///< TWIM frequency.
+    bool                 skip_psel_cfg; ///< Skip pin selection configuration.
+                                        /**< When set to true, the driver does not modify
+                                         *   pin select registers in the peripheral.
+                                         *   Those registers are supposed to be set up
+                                         *   externally before the driver is initialized.
+                                         *   @note When both GPIO configuration and pin
+                                         *   selection are to be skipped, the structure
+                                         *   fields that specify pins can be omitted,
+                                         *   as they are ignored anyway. */
+} nrfy_twim_config_t;
+
+/** @brief Structure describing a TWIM transfer. */
+struct nrfy_twim_xfer_desc_t
+{
+    uint8_t * p_buffer; ///< Pointer to transferred data.
+    size_t    length;   ///< Number of bytes transferred.
+};
+
+/**
+ * @brief Function for configuring the TWIM.
+ *
+ * @param[in] p_reg    Pointer to the structure of registers of the peripheral.
+ * @param[in] p_config Pointer to the peripheral configuration structure.
+ */
+NRFY_STATIC_INLINE void nrfy_twim_periph_configure(NRF_TWIM_Type *            p_reg,
+                                                   nrfy_twim_config_t const * p_config)
+{
+    if (!p_config->skip_psel_cfg)
+    {
+        nrf_twim_pins_set(p_reg, p_config->pins.scl_pin, p_config->pins.sda_pin);
+    }
+    nrf_twim_frequency_set(p_reg, p_config->frequency);
+    nrf_barrier_w();
+}
+
+/**
+ * @brief Function for initializing the specified TWIM interrupts.
+ *
+ * @param[in] p_reg        Pointer to the structure of registers of the peripheral.
+ * @param[in] mask         Mask of interrupts to be initialized.
+ * @param[in] irq_priority Interrupt priority.
+ * @param[in] enable       True if interrupts associated with the event mask are to be enabled, false otherwise.
+ */
+NRFY_STATIC_INLINE void nrfy_twim_int_init(NRF_TWIM_Type * p_reg,
+                                           uint32_t        mask,
+                                           uint8_t         irq_priority,
+                                           bool            enable)
+{
+    __nrfy_internal_twim_event_enabled_clear(p_reg, mask, NRF_TWIM_EVENT_TXSTARTED);
+    __nrfy_internal_twim_event_enabled_clear(p_reg, mask, NRF_TWIM_EVENT_RXSTARTED);
+    __nrfy_internal_twim_event_enabled_clear(p_reg, mask, NRF_TWIM_EVENT_LASTTX);
+    __nrfy_internal_twim_event_enabled_clear(p_reg, mask, NRF_TWIM_EVENT_LASTRX);
+    __nrfy_internal_twim_event_enabled_clear(p_reg, mask, NRF_TWIM_EVENT_STOPPED);
+    __nrfy_internal_twim_event_enabled_clear(p_reg, mask, NRF_TWIM_EVENT_SUSPENDED);
+    __nrfy_internal_twim_event_enabled_clear(p_reg, mask, NRF_TWIM_EVENT_ERROR);
+    nrf_barrier_w();
+
+    NRFX_IRQ_PRIORITY_SET(nrfx_get_irq_number(p_reg), irq_priority);
+    NRFX_IRQ_ENABLE(nrfx_get_irq_number(p_reg));
+    if (enable)
+    {
+        nrf_twim_int_enable(p_reg, mask);
+    }
+    nrf_barrier_w();
+}
+
+/**
+ * @brief Function for uninitializing the TWIM interrupts.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ */
+NRFY_STATIC_INLINE void nrfy_twim_int_uninit(NRF_TWIM_Type * p_reg)
+{
+    NRFX_IRQ_DISABLE(nrfx_get_irq_number(p_reg));
+    nrf_barrier_w();
+}
+
+/**
+ * @brief Function for processing the specified TWIM events.
+ *
+ * @param[in] p_reg  Pointer to the structure of registers of the peripheral.
+ * @param[in] mask   Mask of events to be processed, created by @ref NRFY_EVENT_TO_INT_BITMASK();
+ * @param[in] p_xfer Pointer to the structure containing buffer associated with the last reception.
+ *                   Can be NULL.
+ *
+ * @return Mask of events that were generated and processed.
+ *         To be checked against the result of @ref NRFY_EVENT_TO_INT_BITMASK().
+ */
+NRFY_STATIC_INLINE uint32_t nrfy_twim_events_process(NRF_TWIM_Type *               p_reg,
+                                                     uint32_t                      mask,
+                                                     nrfy_twim_xfer_desc_t const * p_xfer)
+{
+    uint32_t evt_mask = __nrfy_internal_twim_events_process(p_reg, mask, p_xfer);
+    nrf_barrier_w();
+    return evt_mask;
+}
+
+/**
+ * @brief Function for setting the TWIM transaction buffer.
+ *
+ * @param[in] p_reg  Pointer to the structure of registers of the peripheral.
+ * @param[in] p_xfer Pointer to the structure containing transaction buffer.
+ */
+NRFY_STATIC_INLINE void nrfy_twim_tx_buffer_set(NRF_TWIM_Type *               p_reg,
+                                                nrfy_twim_xfer_desc_t const * p_xfer)
+{
+    if (p_xfer->p_buffer)
+    {
+        NRFY_CACHE_WB(p_xfer->p_buffer, p_xfer->length);
+    }
+    nrf_twim_tx_buffer_set(p_reg, p_xfer->p_buffer, p_xfer->length);
+    nrf_barrier_w();
+}
+
+/**
+ * @brief Function for setting the TWIM reception buffer.
+ *
+ * @param[in] p_reg  Pointer to the structure of registers of the peripheral.
+ * @param[in] p_xfer Pointer to the structure containing reception buffer.
+ */
+NRFY_STATIC_INLINE void nrfy_twim_rx_buffer_set(NRF_TWIM_Type *               p_reg,
+                                                nrfy_twim_xfer_desc_t const * p_xfer)
+{
+    nrf_twim_rx_buffer_set(p_reg, p_xfer->p_buffer, p_xfer->length);
+    nrf_barrier_w();
+}
+
+/**
+ * @brief Function for starting TWIM transaction.
+ *
+ * @param[in] p_reg  Pointer to the structure of registers of the peripheral.
+ * @param[in] p_xfer Pointer to the structure containing transaction buffer.
+ */
+NRFY_STATIC_INLINE void nrfy_twim_tx_start(NRF_TWIM_Type *               p_reg,
+                                           nrfy_twim_xfer_desc_t const * p_xfer)
+{
+    nrf_twim_task_trigger(p_reg, NRF_TWIM_TASK_STARTTX);
+    if (p_xfer)
+    {
+        if (p_xfer->length == 0)
+        {
+            nrf_twim_task_trigger(p_reg, NRF_TWIM_TASK_STOP);
+        }
+        nrf_barrier_w();
+        uint32_t mask = NRFY_EVENT_TO_INT_BITMASK(NRF_TWIM_EVENT_SUSPENDED) |
+                        NRFY_EVENT_TO_INT_BITMASK(NRF_TWIM_EVENT_STOPPED) |
+                        NRFY_EVENT_TO_INT_BITMASK(NRF_TWIM_EVENT_ERROR);
+        uint32_t evt_mask = 0;
+        while (!(evt_mask & (NRFY_EVENT_TO_INT_BITMASK(NRF_TWIM_EVENT_SUSPENDED) |
+                             NRFY_EVENT_TO_INT_BITMASK(NRF_TWIM_EVENT_STOPPED))))
+        {
+            evt_mask = __nrfy_internal_twim_events_process(p_reg, mask, p_xfer);
+            if (evt_mask & NRFY_EVENT_TO_INT_BITMASK(NRF_TWIM_EVENT_ERROR))
+            {
+                bool lasttx_triggered = __nrfy_internal_twim_events_process(p_reg,
+                                                NRFY_EVENT_TO_INT_BITMASK(NRF_TWIM_EVENT_LASTTX),
+                                                NULL);
+                nrf_barrier_rw();
+                uint32_t shorts_mask = nrf_twim_shorts_get(p_reg);
+                nrf_barrier_r();
+
+                if (!(lasttx_triggered && (shorts_mask & NRF_TWIM_SHORT_LASTTX_STOP_MASK)))
+                {
+                    // Unless LASTTX event arrived and LASTTX_STOP shortcut is active,
+                    // triggering of STOP task in case of error has to be done manually.
+                    nrf_twim_task_trigger(p_reg, NRF_TWIM_TASK_RESUME);
+                    nrf_twim_task_trigger(p_reg, NRF_TWIM_TASK_STOP);
+                    nrf_barrier_w();
+
+                    // Mark transmission as not finished yet,
+                    // as STOPPED event is expected to arrive.
+                    // If LASTTX_SUSPENDED shortcut is active,
+                    // NACK has been received on last byte sent
+                    // and SUSPENDED event happened to be checked before ERROR,
+                    // transmission will be marked as finished.
+                    // In such case this flag has to be overwritten.
+                    evt_mask = 0;
+                }
+
+                if (lasttx_triggered && (shorts_mask & NRF_TWIM_SHORT_LASTTX_SUSPEND_MASK))
+                {
+                    // When STOP task was triggered just before SUSPEND task has taken effect,
+                    // SUSPENDED event may not arrive.
+                    // However if SUSPENDED arrives it always arrives after ERROR.
+                    // Therefore SUSPENDED has to be cleared
+                    // so it does not cause premature termination of busy loop
+                    // waiting for STOPPED event to arrive.
+                    (void)__nrfy_internal_twim_events_process(p_reg,
+                                            NRFY_EVENT_TO_INT_BITMASK(NRF_TWIM_EVENT_SUSPENDED),
+                                            p_xfer);
+                    // Mark transmission as not finished yet,
+                    // for same reasons as above.
+                    evt_mask = 0;
+                }
+            }
+        }
+    }
+    nrf_barrier_w();
+}
+
+/**
+ * @brief Function for starting TWIM reception.
+ *
+ * @param[in] p_reg  Pointer to the structure of registers of the peripheral.
+ * @param[in] p_xfer Pointer to the structure containing reception buffer.
+ */
+NRFY_STATIC_INLINE void nrfy_twim_rx_start(NRF_TWIM_Type *               p_reg,
+                                           nrfy_twim_xfer_desc_t const * p_xfer)
+{
+    nrf_twim_task_trigger(p_reg, NRF_TWIM_TASK_STARTRX);
+    if (p_xfer)
+    {
+        if (p_xfer->length == 0)
+        {
+            nrf_twim_task_trigger(p_reg, NRF_TWIM_TASK_STOP);
+        }
+
+        nrf_barrier_w();
+        uint32_t mask = NRFY_EVENT_TO_INT_BITMASK(NRF_TWIM_EVENT_SUSPENDED) |
+                        NRFY_EVENT_TO_INT_BITMASK(NRF_TWIM_EVENT_STOPPED) |
+                        NRFY_EVENT_TO_INT_BITMASK(NRF_TWIM_EVENT_ERROR);
+        uint32_t evt_mask = 0;
+        while (!(evt_mask & (NRFY_EVENT_TO_INT_BITMASK(NRF_TWIM_EVENT_SUSPENDED) |
+                             NRFY_EVENT_TO_INT_BITMASK(NRF_TWIM_EVENT_STOPPED))))
+        {
+            evt_mask = __nrfy_internal_twim_events_process(p_reg, mask, p_xfer);
+            if (evt_mask & NRFY_EVENT_TO_INT_BITMASK(NRF_TWIM_EVENT_ERROR))
+            {
+                // triggering of STOP task in case of error has to be done manually.
+                nrf_twim_task_trigger(p_reg, NRF_TWIM_TASK_STOP);
+                nrf_barrier_w();
+            }
+        }
+    }
+    nrf_barrier_w();
+}
+
+/**
+ * @brief Function for aborting the ongoing TWIM transaction.
+ *
+ * @param[in] p_reg  Pointer to the structure of registers of the peripheral.
+ * @param[in] p_xfer Pointer to the structure containing reception buffer
+ *                   if the abort is to be blocking. NULL for non-blocking operation.
+ */
+NRFY_STATIC_INLINE void nrfy_twim_abort(NRF_TWIM_Type * p_reg, nrfy_twim_xfer_desc_t const * p_xfer)
+{
+    nrf_twim_task_trigger(p_reg, NRF_TWIM_TASK_STOP);
+    if (p_xfer)
+    {
+        nrf_barrier_w();
+        uint32_t evt_mask = NRFY_EVENT_TO_INT_BITMASK(NRF_TWIM_EVENT_STOPPED);
+        while (!__nrfy_internal_twim_events_process(p_reg, evt_mask, p_xfer))
+        {}
+    }
+    nrf_barrier_w();
+}
+
+/**
+ * @brief Function for getting TWIM pins configuration.
+ *
+ * @param[in]  p_reg  Pointer to the structure of registers of the peripheral.
+ * @param[out] p_pins Pointer to the structure to be filled with TWIM pins configuration.
+ */
+NRFY_STATIC_INLINE void nrfy_twim_pins_get(NRF_TWIM_Type const * p_reg,
+                                           nrfy_twim_pins_t *    p_pins)
+{
+    nrf_barrier_rw();
+    p_pins->scl_pin = nrf_twim_scl_pin_get(p_reg);
+    p_pins->sda_pin = nrf_twim_sda_pin_get(p_reg);
+    nrf_barrier_r();
+}
+
+/**
+ * @brief Function for disabling TWIM with all interrupts and shortcuts.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ */
+NRFY_STATIC_INLINE void nrfy_twim_stop(NRF_TWIM_Type * p_reg)
+{
+    nrf_twim_int_disable(p_reg, NRF_TWIM_ALL_INTS_MASK);
+    nrf_twim_shorts_disable(p_reg, NRF_TWIM_ALL_SHORTS_MASK);
+    nrf_twim_disable(p_reg);
+    nrf_barrier_w();
+}
+
+#if NRFY_TWIM_HAS_ARRAY_LIST
+/**
+ * @brief Function for enabling or disabling the TX list feature.
+ *
+ * @param[in] p_reg  Pointer to the structure of registers of the peripheral.
+ * @param[in] enable True if TX list feature is to be enabled, false otherwise.
+ */
+NRFY_STATIC_INLINE void nrfy_twim_tx_list_set(NRF_TWIM_Type * p_reg, bool enable)
+{
+    if (enable)
+    {
+        nrf_twim_tx_list_enable(p_reg);
+    }
+    else
+    {
+        nrf_twim_tx_list_disable(p_reg);
+    }
+    nrf_barrier_w();
+}
+
+/**
+ * @brief Function for enabling or disabling the RX list feature.
+ *
+ * @param[in] p_reg  Pointer to the structure of registers of the peripheral.
+ * @param[in] enable True if RX list feature is to be enabled, false otherwise.
+ */
+NRFY_STATIC_INLINE void nrfy_twim_rx_list_set(NRF_TWIM_Type * p_reg, bool enable)
+{
+    if (enable)
+    {
+        nrf_twim_rx_list_enable(p_reg);
+    }
+    else
+    {
+        nrf_twim_rx_list_disable(p_reg);
+    }
+    nrf_barrier_w();
+}
+#endif
+
+/**
+ * @brief Function for setting the TWIM pins configuration.
+ *
+ * @param[in]  p_reg  Pointer to the structure of registers of the peripheral.
+ * @param[out] p_pins Pointer to the TWIM pin configurartion structure.
+ */
+NRFY_STATIC_INLINE void nrfy_twim_pins_set(NRF_TWIM_Type *          p_reg,
+                                           nrfy_twim_pins_t const * p_pins)
+{
+    nrf_twim_pins_set(p_reg, p_pins->scl_pin, p_pins->sda_pin);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_twim_task_trigger} */
+NRFY_STATIC_INLINE void nrfy_twim_task_trigger(NRF_TWIM_Type * p_reg,
+                                               nrf_twim_task_t task)
+{
+    nrf_twim_task_trigger(p_reg, task);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_twim_task_address_get} */
+NRFY_STATIC_INLINE uint32_t nrfy_twim_task_address_get(NRF_TWIM_Type const * p_reg,
+                                                       nrf_twim_task_t       task)
+{
+    return nrf_twim_task_address_get(p_reg, task);
+}
+
+/** @refhal{nrf_twim_event_clear} */
+NRFY_STATIC_INLINE void nrfy_twim_event_clear(NRF_TWIM_Type *  p_reg,
+                                              nrf_twim_event_t event)
+{
+    nrf_twim_event_clear(p_reg, event);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_twim_event_check} */
+NRFY_STATIC_INLINE bool nrfy_twim_event_check(NRF_TWIM_Type const * p_reg,
+                                              nrf_twim_event_t      event)
+{
+    nrf_barrier_r();
+    bool check = nrf_twim_event_check(p_reg, event);
+    nrf_barrier_r();
+    return check;
+}
+
+/** @refhal{nrf_twim_event_address_get} */
+NRFY_STATIC_INLINE uint32_t nrfy_twim_event_address_get(NRF_TWIM_Type const * p_reg,
+                                                        nrf_twim_event_t      event)
+{
+    return nrf_twim_event_address_get(p_reg, event);
+}
+
+/** @refhal{nrf_twim_shorts_enable} */
+NRFY_STATIC_INLINE void nrfy_twim_shorts_enable(NRF_TWIM_Type * p_reg,
+                                                uint32_t        mask)
+{
+    nrf_twim_shorts_enable(p_reg, mask);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_twim_shorts_disable} */
+NRFY_STATIC_INLINE void nrfy_twim_shorts_disable(NRF_TWIM_Type * p_reg,
+                                                 uint32_t        mask)
+{
+    nrf_twim_shorts_disable(p_reg, mask);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_twim_int_enable} */
+NRFY_STATIC_INLINE void nrfy_twim_int_enable(NRF_TWIM_Type * p_reg,
+                                             uint32_t        mask)
+{
+    nrf_twim_int_enable(p_reg, mask);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_twim_int_disable} */
+NRFY_STATIC_INLINE void nrfy_twim_int_disable(NRF_TWIM_Type * p_reg,
+                                              uint32_t        mask)
+{
+    nrf_twim_int_disable(p_reg, mask);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_twim_int_enable_check} */
+NRFY_STATIC_INLINE uint32_t nrfy_twim_int_enable_check(NRF_TWIM_Type const * p_reg, uint32_t mask)
+{
+    nrf_barrier_rw();
+    uint32_t check = nrf_twim_int_enable_check(p_reg, mask);
+    nrf_barrier_r();
+    return check;
+}
+
+#if defined(DPPI_PRESENT) || defined(__NRFX_DOXYGEN__)
+/** @refhal{nrf_twim_subscribe_set} */
+NRFY_STATIC_INLINE void nrfy_twim_subscribe_set(NRF_TWIM_Type * p_reg,
+                                                nrf_twim_task_t task,
+                                                uint8_t         channel)
+{
+    nrf_twim_subscribe_set(p_reg, task, channel);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_twim_subscribe_clear} */
+NRFY_STATIC_INLINE void nrfy_twim_subscribe_clear(NRF_TWIM_Type * p_reg,
+                                                  nrf_twim_task_t task)
+{
+    nrf_twim_subscribe_clear(p_reg, task);
+    nrf_barrier_w();
+
+}
+
+/** @refhal{nrf_twim_publish_set} */
+NRFY_STATIC_INLINE void nrfy_twim_publish_set(NRF_TWIM_Type *  p_reg,
+                                              nrf_twim_event_t event,
+                                              uint8_t          channel)
+{
+    nrf_twim_publish_set(p_reg, event, channel);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_twim_publish_clear} */
+NRFY_STATIC_INLINE void nrfy_twim_publish_clear(NRF_TWIM_Type *  p_reg,
+                                                nrf_twim_event_t event)
+{
+    nrf_twim_publish_clear(p_reg, event);
+    nrf_barrier_w();
+}
+#endif // defined(DPPI_PRESENT) || defined(__NRFX_DOXYGEN__)
+
+/** @refhal{nrf_twim_enable} */
+NRFY_STATIC_INLINE void nrfy_twim_enable(NRF_TWIM_Type * p_reg)
+{
+    nrf_twim_enable(p_reg);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_twim_disable} */
+NRFY_STATIC_INLINE void nrfy_twim_disable(NRF_TWIM_Type * p_reg)
+{
+    nrf_twim_disable(p_reg);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_twim_scl_pin_get} */
+NRFY_STATIC_INLINE uint32_t nrfy_twim_scl_pin_get(NRF_TWIM_Type const * p_reg)
+{
+    nrf_barrier_rw();
+    uint32_t scl_pin = nrf_twim_scl_pin_get(p_reg);
+    nrf_barrier_r();
+    return scl_pin;
+}
+
+/** @refhal{nrf_twim_sda_pin_get} */
+NRFY_STATIC_INLINE uint32_t nrfy_twim_sda_pin_get(NRF_TWIM_Type const * p_reg)
+{
+    nrf_barrier_rw();
+    uint32_t sda_pin = nrf_twim_sda_pin_get(p_reg);
+    nrf_barrier_r();
+    return sda_pin;
+}
+
+/** @refhal{nrf_twim_frequency_set} */
+NRFY_STATIC_INLINE void nrfy_twim_frequency_set(NRF_TWIM_Type *      p_reg,
+                                                nrf_twim_frequency_t frequency)
+{
+    nrf_twim_frequency_set(p_reg, frequency);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_twim_errorsrc_get_and_clear} */
+NRFY_STATIC_INLINE uint32_t nrfy_twim_errorsrc_get_and_clear(NRF_TWIM_Type * p_reg)
+{
+    nrf_barrier_rw();
+    uint32_t errorsrc = nrf_twim_errorsrc_get_and_clear(p_reg);
+    nrf_barrier_rw();
+    return errorsrc;
+}
+
+/** @refhal{nrf_twim_address_set} */
+NRFY_STATIC_INLINE void nrfy_twim_address_set(NRF_TWIM_Type * p_reg,
+                                              uint8_t         address)
+{
+    nrf_twim_address_set(p_reg, address);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_twim_shorts_set} */
+NRFY_STATIC_INLINE void nrfy_twim_shorts_set(NRF_TWIM_Type * p_reg,
+                                             uint32_t        mask)
+{
+    nrf_twim_shorts_set(p_reg, mask);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_twim_shorts_get} */
+NRFY_STATIC_INLINE uint32_t nrfy_twim_shorts_get(NRF_TWIM_Type const * p_reg)
+{
+    nrf_barrier_rw();
+    uint32_t shorts = nrf_twim_shorts_get(p_reg);
+    nrf_barrier_r();
+    return shorts;
+}
+
+/** @refhal{nrf_twim_txd_amount_get} */
+NRFY_STATIC_INLINE size_t nrfy_twim_txd_amount_get(NRF_TWIM_Type const * p_reg)
+{
+    nrf_barrier_r();
+    size_t amount = nrf_twim_txd_amount_get(p_reg);
+    nrf_barrier_r();
+    return amount;
+}
+
+/** @refhal{nrf_twim_rxd_amount_get} */
+NRFY_STATIC_INLINE size_t nrfy_twim_rxd_amount_get(NRF_TWIM_Type const * p_reg)
+{
+    nrf_barrier_r();
+    size_t amount = nrf_twim_rxd_amount_get(p_reg);
+    nrf_barrier_r();
+    return amount;
+}
+
+#if NRFY_TWIM_HAS_ARRAY_LIST
+/** @refhal{nrf_twim_tx_list_enable} */
+NRFY_STATIC_INLINE void nrfy_twim_tx_list_enable(NRF_TWIM_Type * p_reg)
+{
+    nrf_twim_tx_list_enable(p_reg);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_twim_tx_list_disable} */
+NRFY_STATIC_INLINE void nrfy_twim_tx_list_disable(NRF_TWIM_Type * p_reg)
+{
+    nrf_twim_tx_list_disable(p_reg);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_twim_rx_list_enable} */
+NRFY_STATIC_INLINE void nrfy_twim_rx_list_enable(NRF_TWIM_Type * p_reg)
+{
+    nrf_twim_rx_list_enable(p_reg);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_twim_rx_list_disable} */
+NRFY_STATIC_INLINE void nrfy_twim_rx_list_disable(NRF_TWIM_Type * p_reg)
+{
+    nrf_twim_rx_list_disable(p_reg);
+    nrf_barrier_w();
+}
+#endif
+
+/** @} */
+
+NRFY_STATIC_INLINE void __nrfy_internal_twim_event_enabled_clear(NRF_TWIM_Type *  p_reg,
+                                                                 uint32_t         mask,
+                                                                 nrf_twim_event_t event)
+{
+    if (mask & NRFY_EVENT_TO_INT_BITMASK(event))
+    {
+        nrf_twim_event_clear(p_reg, event);
+    }
+}
+
+NRFY_STATIC_INLINE bool __nrfy_internal_twim_event_handle(NRF_TWIM_Type *  p_reg,
+                                                          uint32_t         mask,
+                                                          nrf_twim_event_t event,
+                                                          uint32_t *       p_evt_mask)
+{
+    if ((mask & NRFY_EVENT_TO_INT_BITMASK(event)) && nrf_twim_event_check(p_reg, event))
+    {
+        nrf_twim_event_clear(p_reg, event);
+        if (p_evt_mask)
+        {
+            *p_evt_mask |= NRFY_EVENT_TO_INT_BITMASK(event);
+        }
+        return true;
+    }
+    return false;
+}
+
+NRFY_STATIC_INLINE
+uint32_t __nrfy_internal_twim_events_process(NRF_TWIM_Type *               p_reg,
+                                             uint32_t                      mask,
+                                             nrfy_twim_xfer_desc_t const * p_xfer)
+{
+    uint32_t evt_mask = 0;
+
+    nrf_barrier_r();
+    (void)__nrfy_internal_twim_event_handle(p_reg, mask, NRF_TWIM_EVENT_SUSPENDED, &evt_mask);
+    (void)__nrfy_internal_twim_event_handle(p_reg, mask, NRF_TWIM_EVENT_STOPPED, &evt_mask);
+    (void)__nrfy_internal_twim_event_handle(p_reg, mask, NRF_TWIM_EVENT_ERROR, &evt_mask);
+    (void)__nrfy_internal_twim_event_handle(p_reg, mask, NRF_TWIM_EVENT_TXSTARTED, &evt_mask);
+    (void)__nrfy_internal_twim_event_handle(p_reg, mask, NRF_TWIM_EVENT_RXSTARTED, &evt_mask);
+    (void)__nrfy_internal_twim_event_handle(p_reg, mask, NRF_TWIM_EVENT_LASTTX, &evt_mask);
+    (void)__nrfy_internal_twim_event_handle(p_reg, mask, NRF_TWIM_EVENT_LASTRX, &evt_mask);
+
+    if (p_xfer && (mask & NRFY_EVENT_TO_INT_BITMASK(NRF_TWIM_EVENT_STOPPED)))
+    {
+        NRFY_CACHE_INV(p_xfer->p_buffer, p_xfer->length);
+    }
+    else if (p_xfer && (mask & NRFY_EVENT_TO_INT_BITMASK(NRF_TWIM_EVENT_LASTRX)))
+    {
+        NRFY_CACHE_INV(p_xfer->p_buffer, p_xfer->length);
+    }
+    nrf_barrier_w();
+    return evt_mask;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // NRFY_TWIM_H__

--- a/nrfx/haly/nrfy_uarte.h
+++ b/nrfx/haly/nrfy_uarte.h
@@ -1,0 +1,644 @@
+/*
+ * Copyright (c) 2021 - 2023, Nordic Semiconductor ASA
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef NRFY_UARTE_H__
+#define NRFY_UARTE_H__
+
+#include <nrfx.h>
+#include <hal/nrf_uarte.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct nrfy_uarte_xfer_desc_t nrfy_uarte_xfer_desc_t;
+
+NRFY_STATIC_INLINE void __nrfy_internal_uarte_event_enabled_clear(NRF_UARTE_Type *  p_reg,
+                                                                  uint32_t          mask,
+                                                                  nrf_uarte_event_t event);
+
+NRFY_STATIC_INLINE bool __nrfy_internal_uarte_event_handle(NRF_UARTE_Type *  p_reg,
+                                                           uint32_t          mask,
+                                                           nrf_uarte_event_t event,
+                                                           uint32_t *        p_evt_mask);
+
+NRFY_STATIC_INLINE
+uint32_t __nrfy_internal_uarte_events_process(NRF_UARTE_Type *               p_reg,
+                                              uint32_t                       mask,
+                                              nrfy_uarte_xfer_desc_t const * p_xfer);
+
+/**
+ * @defgroup nrfy_uarte UARTE HALY
+ * @{
+ * @ingroup nrf_uarte
+ * @brief   Hardware access layer with cache and barrier support for managing the UARTE peripheral.
+ */
+
+/** @brief UARTE pins configuration structure. */
+typedef struct
+{
+    uint32_t txd_pin; ///< TXD pin number.
+    uint32_t rxd_pin; ///< RXD pin number.
+    uint32_t rts_pin; ///< RTS pin number.
+    uint32_t cts_pin; ///< CTS pin number.
+} nrfy_uarte_pins_t;
+
+/** @brief UARTE configuration structure. */
+typedef struct
+{
+    nrfy_uarte_pins_t    pins;          ///< Pin configuration structure.
+    nrf_uarte_baudrate_t baudrate;      ///< Baud rate.
+    nrf_uarte_config_t   config;        ///< Peripheral configuration.
+    bool                 skip_psel_cfg; ///< Skip pin selection configuration.
+                                        /**< When set to true, the driver does not modify
+                                         *   pin select registers in the peripheral.
+                                         *   Those registers are supposed to be set up
+                                         *   externally before the driver is initialized.
+                                         *   @note When both GPIO configuration and pin
+                                         *   selection are to be skipped, the structure
+                                         *   fields that specify pins can be omitted,
+                                         *   as they are ignored anyway. */
+} nrfy_uarte_config_t;
+
+/** @brief Structure describing an UARTE transfer. */
+struct nrfy_uarte_xfer_desc_t
+{
+    uint8_t * p_buffer; ///< Pointer to transferred data.
+    size_t    length;   ///< Number of bytes transferred.
+};
+
+/**
+ * @brief Function for configuring the UARTE.
+ *
+ * @param[in] p_reg    Pointer to the structure of registers of the peripheral.
+ * @param[in] p_config Pointer to the peripheral configuration structure.
+ */
+NRFY_STATIC_INLINE void nrfy_uarte_periph_configure(NRF_UARTE_Type *            p_reg,
+                                                    nrfy_uarte_config_t const * p_config)
+{
+    nrf_uarte_baudrate_set(p_reg, p_config->baudrate);
+    nrf_uarte_configure(p_reg, &p_config->config);
+    if (!p_config->skip_psel_cfg)
+    {
+        nrf_uarte_txrx_pins_set(p_reg, p_config->pins.txd_pin, p_config->pins.rxd_pin);
+    }
+
+    if (p_config->config.hwfc == NRF_UARTE_HWFC_ENABLED && !p_config->skip_psel_cfg)
+    {
+         nrf_uarte_hwfc_pins_set(p_reg, p_config->pins.rts_pin, p_config->pins.cts_pin);
+    }
+    nrf_barrier_w();
+}
+
+/**
+ * @brief Function for initializing the specified UARTE interrupts.
+ *
+ * @param[in] p_reg        Pointer to the structure of registers of the peripheral.
+ * @param[in] mask         Mask of interrupts to be initialized.
+ * @param[in] irq_priority Interrupt priority.
+ * @param[in] enable       True if interrupts associated with the event mask are to be enabled, false otherwise.
+ */
+NRFY_STATIC_INLINE void nrfy_uarte_int_init(NRF_UARTE_Type * p_reg,
+                                            uint32_t         mask,
+                                            uint8_t          irq_priority,
+                                            bool             enable)
+{
+    __nrfy_internal_uarte_event_enabled_clear(p_reg, mask, NRF_UARTE_EVENT_CTS);
+    __nrfy_internal_uarte_event_enabled_clear(p_reg, mask, NRF_UARTE_EVENT_NCTS);
+    __nrfy_internal_uarte_event_enabled_clear(p_reg, mask, NRF_UARTE_EVENT_RXDRDY);
+    __nrfy_internal_uarte_event_enabled_clear(p_reg, mask, NRF_UARTE_EVENT_ENDRX);
+    __nrfy_internal_uarte_event_enabled_clear(p_reg, mask, NRF_UARTE_EVENT_TXDRDY);
+    __nrfy_internal_uarte_event_enabled_clear(p_reg, mask, NRF_UARTE_EVENT_ENDTX);
+    __nrfy_internal_uarte_event_enabled_clear(p_reg, mask, NRF_UARTE_EVENT_ERROR);
+    __nrfy_internal_uarte_event_enabled_clear(p_reg, mask, NRF_UARTE_EVENT_RXTO);
+    __nrfy_internal_uarte_event_enabled_clear(p_reg, mask, NRF_UARTE_EVENT_RXSTARTED);
+    __nrfy_internal_uarte_event_enabled_clear(p_reg, mask, NRF_UARTE_EVENT_TXSTARTED);
+    __nrfy_internal_uarte_event_enabled_clear(p_reg, mask, NRF_UARTE_EVENT_TXSTOPPED);
+    nrf_barrier_w();
+
+    NRFX_IRQ_PRIORITY_SET(nrfx_get_irq_number(p_reg), irq_priority);
+    NRFX_IRQ_ENABLE(nrfx_get_irq_number(p_reg));
+    if (enable)
+    {
+        nrf_uarte_int_enable(p_reg, mask);
+    }
+    nrf_barrier_w();
+}
+
+/**
+ * @brief Function for uninitializing the UARTE interrupts.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ */
+NRFY_STATIC_INLINE void nrfy_uarte_int_uninit(NRF_UARTE_Type * p_reg)
+{
+    NRFX_IRQ_DISABLE(nrfx_get_irq_number(p_reg));
+    nrf_barrier_w();
+}
+
+/**
+ * @brief Function for processing the specified UARTE events.
+ *
+ * @param[in] p_reg  Pointer to the structure of registers of the peripheral.
+ * @param[in] mask   Mask of events to be processed, created by @ref NRFY_EVENT_TO_INT_BITMASK().
+ * @param[in] p_xfer Pointer to the structure containing buffer associated with the last reception.
+ *                   Can be NULL.
+ *
+ * @return Mask of events that were generated and processed.
+ *         To be checked against the result of @ref NRFY_EVENT_TO_INT_BITMASK().
+ */
+NRFY_STATIC_INLINE uint32_t nrfy_uarte_events_process(NRF_UARTE_Type *               p_reg,
+                                                      uint32_t                       mask,
+                                                      nrfy_uarte_xfer_desc_t const * p_xfer)
+{
+    uint32_t evt_mask = __nrfy_internal_uarte_events_process(p_reg, mask, p_xfer);
+    nrf_barrier_w();
+    return evt_mask;
+}
+
+/**
+ * @brief Function for aborting the ongoing UARTE transmission.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ * @param[in] wait  True if CPU should wait for peripheral to abort transmission, false otherwise.
+ */
+NRFY_STATIC_INLINE void nrfy_uarte_tx_abort(NRF_UARTE_Type * p_reg,
+                                            bool             wait)
+{
+    nrf_uarte_event_clear(p_reg, NRF_UARTE_EVENT_TXSTOPPED);
+    nrf_barrier_w();
+    nrf_uarte_task_trigger(p_reg, NRF_UARTE_TASK_STOPTX);
+    if (wait)
+    {
+        nrf_barrier_w();
+        while (!nrf_uarte_event_check(p_reg, NRF_UARTE_EVENT_TXSTOPPED))
+        {}
+    }
+    nrf_barrier_w();
+}
+
+/**
+ * @brief Function for stopping the UARTE transmitter and receiver.
+ *
+ * @param[in] p_reg  Pointer to the structure of registers of the peripheral.
+ * @param[in] p_xfer Pointer to the structure containing reception buffer. Can be NULL.
+ */
+NRFY_STATIC_INLINE void nrfy_uarte_stop(NRF_UARTE_Type *               p_reg,
+                                        nrfy_uarte_xfer_desc_t const * p_xfer)
+{
+    nrf_uarte_task_trigger(p_reg, NRF_UARTE_TASK_STOPTX);
+    nrf_barrier_w();
+    while (!__nrfy_internal_uarte_events_process(p_reg,
+                                            NRFY_EVENT_TO_INT_BITMASK(NRF_UARTE_EVENT_TXSTOPPED),
+                                            NULL))
+    {}
+    if (p_xfer && p_xfer->length)
+    {
+        nrf_uarte_task_trigger(p_reg, NRF_UARTE_TASK_STOPRX);
+        nrf_barrier_w();
+        while (!__nrfy_internal_uarte_events_process(p_reg,
+                                            NRFY_EVENT_TO_INT_BITMASK(NRF_UARTE_EVENT_RXTO),
+                                            p_xfer))
+        {}
+    }
+}
+
+/**
+ * @brief Function for starting the UARTE transmission.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ * @param[in] wait  True for blocking transmission, false otherwise.
+ *
+ * @return Mask of events occured, created by @ref NRFY_EVENT_TO_INT_BITMASK().
+ *         Always 0 for non-blocking transmission.
+ */
+NRFY_STATIC_INLINE uint32_t nrfy_uarte_tx_start(NRF_UARTE_Type * p_reg,
+                                                bool             wait)
+{
+    uint32_t evt_mask = 0;
+    nrf_uarte_task_trigger(p_reg, NRF_UARTE_TASK_STARTTX);
+    if (wait)
+    {
+        uint32_t mask = NRFY_EVENT_TO_INT_BITMASK(NRF_UARTE_EVENT_ENDTX) |
+                        NRFY_EVENT_TO_INT_BITMASK(NRF_UARTE_EVENT_TXSTOPPED);
+        nrf_barrier_w();
+        do {
+            evt_mask = nrfy_uarte_events_process(p_reg, mask, NULL);
+        } while (!evt_mask);
+    }
+    nrf_barrier_w();
+    return evt_mask;
+}
+
+/**
+ * @brief Function for starting the UARTE reception.
+ *
+ * @param[in] p_reg  Pointer to the structure of registers of the peripheral.
+ * @param[in] p_xfer Pointer to the structure containing reception buffer if the
+ *                   reception is to be blocking. NULL for non-blocking reception.
+ *
+ * @return Mask of events occured, created by @ref NRFY_EVENT_TO_INT_BITMASK().
+ *         Always 0 for non-blocking reception.
+ */
+NRFY_STATIC_INLINE uint32_t nrfy_uarte_rx_start(NRF_UARTE_Type *               p_reg,
+                                                nrfy_uarte_xfer_desc_t const * p_xfer)
+{
+    uint32_t evt_mask = 0;
+    nrf_uarte_task_trigger(p_reg, NRF_UARTE_TASK_STARTRX);
+    if (p_xfer)
+    {
+        uint32_t mask = NRFY_EVENT_TO_INT_BITMASK(NRF_UARTE_EVENT_ENDRX) |
+                        NRFY_EVENT_TO_INT_BITMASK(NRF_UARTE_EVENT_RXTO)  |
+                        NRFY_EVENT_TO_INT_BITMASK(NRF_UARTE_EVENT_ERROR);
+        nrf_barrier_w();
+        do {
+            evt_mask = nrfy_uarte_events_process(p_reg, mask, p_xfer);
+        } while (!evt_mask);
+    }
+    nrf_barrier_w();
+    return evt_mask;
+}
+
+/**
+ * @brief Function for getting UARTE pins configuration.
+ *
+ * @param[in] p_reg  Pointer to the structure of registers of the peripheral.
+ * @param[in] p_pins Pointer to the UARTE pin configurartion structure.
+ */
+NRFY_STATIC_INLINE void nrfy_uarte_pins_get(NRF_UARTE_Type const * p_reg,
+                                            nrfy_uarte_pins_t *    p_pins)
+{
+    nrf_barrier_rw();
+    p_pins->txd_pin = nrf_uarte_tx_pin_get(p_reg);
+    p_pins->rxd_pin = nrf_uarte_rx_pin_get(p_reg);
+    p_pins->rts_pin = nrf_uarte_rts_pin_get(p_reg);
+    p_pins->cts_pin = nrf_uarte_cts_pin_get(p_reg);
+    nrf_barrier_r();
+}
+
+/**
+ * @brief Function for disconnecting UARTE pins.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ */
+NRFY_STATIC_INLINE void nrfy_uarte_pins_disconnect(NRF_UARTE_Type * p_reg)
+{
+    nrf_uarte_txrx_pins_disconnect(p_reg);
+    nrf_uarte_hwfc_pins_disconnect(p_reg);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_uarte_event_clear} */
+NRFY_STATIC_INLINE void nrfy_uarte_event_clear(NRF_UARTE_Type * p_reg, nrf_uarte_event_t event)
+{
+    nrf_uarte_event_clear(p_reg, event);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_uarte_event_check} */
+NRFY_STATIC_INLINE bool nrfy_uarte_event_check(NRF_UARTE_Type const * p_reg,
+                                               nrf_uarte_event_t      event)
+{
+    nrf_barrier_r();
+    bool check = nrf_uarte_event_check(p_reg, event);
+    nrf_barrier_r();
+    return check;
+}
+
+/** @refhal{nrf_uarte_event_address_get} */
+NRFY_STATIC_INLINE uint32_t nrfy_uarte_event_address_get(NRF_UARTE_Type const * p_reg,
+                                                         nrf_uarte_event_t      event)
+{
+    return nrf_uarte_event_address_get(p_reg, event);
+}
+
+/** @refhal{nrf_uarte_shorts_enable} */
+NRFY_STATIC_INLINE void nrfy_uarte_shorts_enable(NRF_UARTE_Type * p_reg, uint32_t mask)
+{
+    nrf_uarte_shorts_enable(p_reg, mask);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_uarte_shorts_disable} */
+NRFY_STATIC_INLINE void nrfy_uarte_shorts_disable(NRF_UARTE_Type * p_reg, uint32_t mask)
+{
+    nrf_uarte_shorts_disable(p_reg, mask);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_uarte_int_enable} */
+NRFY_STATIC_INLINE void nrfy_uarte_int_enable(NRF_UARTE_Type * p_reg, uint32_t mask)
+{
+    nrf_uarte_int_enable(p_reg, mask);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_uarte_int_enable_check} */
+NRFY_STATIC_INLINE uint32_t nrfy_uarte_int_enable_check(NRF_UARTE_Type const * p_reg,
+                                                        uint32_t               mask)
+{
+    nrf_barrier_rw();
+    uint32_t check = nrf_uarte_int_enable_check(p_reg, mask);
+    nrf_barrier_r();
+    return check;
+}
+
+/** @refhal{nrf_uarte_int_disable} */
+NRFY_STATIC_INLINE void nrfy_uarte_int_disable(NRF_UARTE_Type * p_reg, uint32_t mask)
+{
+    nrf_uarte_int_disable(p_reg, mask);
+    nrf_barrier_w();
+}
+
+#if defined(DPPI_PRESENT) || defined(__NRFX_DOXYGEN__)
+/** @refhal{nrf_uarte_subscribe_set} */
+NRFY_STATIC_INLINE void nrfy_uarte_subscribe_set(NRF_UARTE_Type * p_reg,
+                                                 nrf_uarte_task_t task,
+                                                 uint8_t          channel)
+{
+    nrf_uarte_subscribe_set(p_reg, task, channel);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_uarte_subscribe_clear} */
+NRFY_STATIC_INLINE void nrfy_uarte_subscribe_clear(NRF_UARTE_Type * p_reg, nrf_uarte_task_t task)
+{
+    nrf_uarte_subscribe_clear(p_reg, task);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_uarte_publish_set} */
+NRFY_STATIC_INLINE void nrfy_uarte_publish_set(NRF_UARTE_Type *  p_reg,
+                                               nrf_uarte_event_t event,
+                                               uint8_t           channel)
+{
+    nrf_uarte_publish_set(p_reg, event, channel);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_uarte_publish_clear} */
+NRFY_STATIC_INLINE void nrfy_uarte_publish_clear(NRF_UARTE_Type *  p_reg, nrf_uarte_event_t event)
+{
+    nrf_uarte_publish_clear(p_reg, event);
+    nrf_barrier_w();
+}
+#endif // defined(DPPI_PRESENT) || defined(__NRFX_DOXYGEN__)
+
+/** @refhal{nrf_uarte_errorsrc_get_and_clear} */
+NRFY_STATIC_INLINE uint32_t nrfy_uarte_errorsrc_get_and_clear(NRF_UARTE_Type * p_reg)
+{
+    nrf_barrier_rw();
+    uint32_t errorsrc = nrf_uarte_errorsrc_get_and_clear(p_reg);
+    nrf_barrier_rw();
+    return errorsrc;
+}
+
+/** @refhal{nrf_uarte_enable} */
+NRFY_STATIC_INLINE void nrfy_uarte_enable(NRF_UARTE_Type * p_reg)
+{
+    nrf_uarte_enable(p_reg);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_uarte_disable} */
+NRFY_STATIC_INLINE void nrfy_uarte_disable(NRF_UARTE_Type * p_reg)
+{
+    nrf_uarte_disable(p_reg);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_uarte_txrx_pins_set} */
+NRFY_STATIC_INLINE void nrfy_uarte_txrx_pins_set(NRF_UARTE_Type * p_reg,
+                                                 uint32_t         pseltxd,
+                                                 uint32_t         pselrxd)
+{
+    nrf_uarte_txrx_pins_set(p_reg, pseltxd, pselrxd);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_uarte_txrx_pins_disconnect} */
+NRFY_STATIC_INLINE void nrfy_uarte_txrx_pins_disconnect(NRF_UARTE_Type * p_reg)
+{
+    nrf_uarte_txrx_pins_disconnect(p_reg);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_uarte_tx_pin_get} */
+NRFY_STATIC_INLINE uint32_t nrfy_uarte_tx_pin_get(NRF_UARTE_Type const * p_reg)
+{
+    nrf_barrier_rw();
+    uint32_t pin = nrf_uarte_tx_pin_get(p_reg);
+    nrf_barrier_r();
+    return pin;
+}
+
+/** @refhal{nrf_uarte_rx_pin_get} */
+NRFY_STATIC_INLINE uint32_t nrfy_uarte_rx_pin_get(NRF_UARTE_Type const * p_reg)
+{
+    nrf_barrier_rw();
+    uint32_t pin = nrf_uarte_rx_pin_get(p_reg);
+    nrf_barrier_r();
+    return pin;
+}
+
+/** @refhal{nrf_uarte_rts_pin_get} */
+NRFY_STATIC_INLINE uint32_t nrfy_uarte_rts_pin_get(NRF_UARTE_Type const * p_reg)
+{
+    nrf_barrier_rw();
+    uint32_t pin = nrf_uarte_rts_pin_get(p_reg);
+    nrf_barrier_r();
+    return pin;
+}
+
+/** @refhal{nrf_uarte_cts_pin_get} */
+NRFY_STATIC_INLINE uint32_t nrfy_uarte_cts_pin_get(NRF_UARTE_Type const * p_reg)
+{
+    nrf_barrier_rw();
+    uint32_t pin = nrf_uarte_cts_pin_get(p_reg);
+    nrf_barrier_r();
+    return pin;
+}
+
+/** @refhal{nrf_uarte_hwfc_pins_set} */
+NRFY_STATIC_INLINE void nrfy_uarte_hwfc_pins_set(NRF_UARTE_Type * p_reg,
+                                                 uint32_t         pselrts,
+                                                 uint32_t         pselcts)
+{
+    nrf_uarte_hwfc_pins_set(p_reg, pselrts, pselcts);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_uarte_hwfc_pins_disconnect} */
+NRFY_STATIC_INLINE void nrfy_uarte_hwfc_pins_disconnect(NRF_UARTE_Type * p_reg)
+{
+    nrf_uarte_hwfc_pins_disconnect(p_reg);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_uarte_task_trigger} */
+NRFY_STATIC_INLINE void nrfy_uarte_task_trigger(NRF_UARTE_Type * p_reg, nrf_uarte_task_t task)
+{
+    nrf_uarte_task_trigger(p_reg, task);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_uarte_task_address_get} */
+NRFY_STATIC_INLINE uint32_t nrfy_uarte_task_address_get(NRF_UARTE_Type const * p_reg,
+                                                        nrf_uarte_task_t       task)
+{
+    return nrf_uarte_task_address_get(p_reg, task);
+}
+
+/** @refhal{nrf_uarte_configure} */
+NRFY_STATIC_INLINE void nrfy_uarte_configure(NRF_UARTE_Type           * p_reg,
+                                             nrf_uarte_config_t const * p_cfg)
+{
+    nrf_uarte_configure(p_reg, p_cfg);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_uarte_baudrate_set} */
+NRFY_STATIC_INLINE void nrfy_uarte_baudrate_set(NRF_UARTE_Type *     p_reg,
+                                                nrf_uarte_baudrate_t baudrate)
+{
+    nrf_uarte_baudrate_set(p_reg, baudrate);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_uarte_tx_buffer_set} */
+NRFY_STATIC_INLINE void nrfy_uarte_tx_buffer_set(NRF_UARTE_Type * p_reg,
+                                                 uint8_t  const * p_buffer,
+                                                 size_t           length)
+{
+    if (p_buffer)
+    {
+        NRFY_CACHE_WB(p_buffer, length);
+        nrf_uarte_tx_buffer_set(p_reg, p_buffer, length);
+        nrf_barrier_w();
+    }
+}
+
+/** @refhal{nrf_uarte_tx_amount_get} */
+NRFY_STATIC_INLINE uint32_t nrfy_uarte_tx_amount_get(NRF_UARTE_Type const * p_reg)
+{
+    nrf_barrier_r();
+    uint32_t amount = nrf_uarte_tx_amount_get(p_reg);
+    nrf_barrier_r();
+    return amount;
+}
+
+/** @refhal{nrf_uarte_rx_buffer_set} */
+NRFY_STATIC_INLINE void nrfy_uarte_rx_buffer_set(NRF_UARTE_Type * p_reg,
+                                                 uint8_t *        p_buffer,
+                                                 size_t           length)
+{
+    nrf_uarte_rx_buffer_set(p_reg, p_buffer, length);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_uarte_rx_amount_get} */
+NRFY_STATIC_INLINE uint32_t nrfy_uarte_rx_amount_get(NRF_UARTE_Type const * p_reg)
+{
+    nrf_barrier_r();
+    uint32_t amount = nrf_uarte_rx_amount_get(p_reg);
+    nrf_barrier_r();
+    return amount;
+}
+/** @} */
+
+NRFY_STATIC_INLINE void __nrfy_internal_uarte_event_enabled_clear(NRF_UARTE_Type *  p_reg,
+                                                                  uint32_t          mask,
+                                                                  nrf_uarte_event_t event)
+{
+    if (mask & NRFY_EVENT_TO_INT_BITMASK(event))
+    {
+        nrf_uarte_event_clear(p_reg, event);
+    }
+}
+
+NRFY_STATIC_INLINE bool __nrfy_internal_uarte_event_handle(NRF_UARTE_Type *  p_reg,
+                                                           uint32_t          mask,
+                                                           nrf_uarte_event_t event,
+                                                           uint32_t  *       p_evt_mask)
+{
+    if ((mask & NRFY_EVENT_TO_INT_BITMASK(event)) && nrf_uarte_event_check(p_reg, event))
+    {
+        nrf_uarte_event_clear(p_reg, event);
+        if (p_evt_mask)
+        {
+            *p_evt_mask |= NRFY_EVENT_TO_INT_BITMASK(event);
+        }
+        return true;
+    }
+    return false;
+}
+
+NRFY_STATIC_INLINE
+uint32_t __nrfy_internal_uarte_events_process(NRF_UARTE_Type *               p_reg,
+                                              uint32_t                       mask,
+                                              nrfy_uarte_xfer_desc_t const * p_xfer)
+{
+    uint32_t evt_mask = 0;
+
+    nrf_barrier_r();
+    (void)__nrfy_internal_uarte_event_handle(p_reg, mask, NRF_UARTE_EVENT_CTS,       &evt_mask);
+    (void)__nrfy_internal_uarte_event_handle(p_reg, mask, NRF_UARTE_EVENT_NCTS,      &evt_mask);
+    (void)__nrfy_internal_uarte_event_handle(p_reg, mask, NRF_UARTE_EVENT_RXDRDY,    &evt_mask);
+    (void)__nrfy_internal_uarte_event_handle(p_reg, mask, NRF_UARTE_EVENT_ENDRX,     &evt_mask);
+    (void)__nrfy_internal_uarte_event_handle(p_reg, mask, NRF_UARTE_EVENT_TXDRDY,    &evt_mask);
+    (void)__nrfy_internal_uarte_event_handle(p_reg, mask, NRF_UARTE_EVENT_ENDTX,     &evt_mask);
+    (void)__nrfy_internal_uarte_event_handle(p_reg, mask, NRF_UARTE_EVENT_ERROR,     &evt_mask);
+    (void)__nrfy_internal_uarte_event_handle(p_reg, mask, NRF_UARTE_EVENT_RXTO,      &evt_mask);
+    (void)__nrfy_internal_uarte_event_handle(p_reg, mask, NRF_UARTE_EVENT_RXSTARTED, &evt_mask);
+    (void)__nrfy_internal_uarte_event_handle(p_reg, mask, NRF_UARTE_EVENT_TXSTARTED, &evt_mask);
+    (void)__nrfy_internal_uarte_event_handle(p_reg, mask, NRF_UARTE_EVENT_TXSTOPPED, &evt_mask);
+
+    if (mask & NRFY_EVENT_TO_INT_BITMASK(NRF_UARTE_EVENT_ENDRX))
+    {
+        NRFY_CACHE_INV(p_xfer->p_buffer, p_xfer->length);
+    }
+    else if (mask & NRFY_EVENT_TO_INT_BITMASK(NRF_UARTE_EVENT_RXTO))
+    {
+        size_t size = nrf_uarte_rx_amount_get(p_reg);
+        nrf_barrier_rw();
+        NRFY_CACHE_INV(p_xfer->p_buffer, size);
+    }
+    nrf_barrier_w();
+    return evt_mask;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // NRFY_UARTE_H__

--- a/nrfx/haly/nrfy_wdt.h
+++ b/nrfx/haly/nrfy_wdt.h
@@ -1,0 +1,358 @@
+/*
+ * Copyright (c) 2021 - 2023, Nordic Semiconductor ASA
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef NRFY_WDT_H__
+#define NRFY_WDT_H__
+
+#include <nrfx.h>
+#include <hal/nrf_wdt.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+NRFY_STATIC_INLINE bool __nrfy_internal_wdt_event_handle(NRF_WDT_Type *  p_reg,
+                                                         uint32_t        mask,
+                                                         nrf_wdt_event_t event,
+                                                         uint32_t *      p_evt_mask);
+
+NRFY_STATIC_INLINE uint32_t __nrfy_internal_wdt_events_process(NRF_WDT_Type * p_reg, uint32_t mask);
+
+NRFY_STATIC_INLINE void __nrfy_internal_wdt_event_enabled_clear(NRF_WDT_Type *  p_reg,
+                                                                uint32_t        mask,
+                                                                nrf_wdt_event_t event);
+
+/**
+ * @defgroup nrfy_wdt WDT HALY
+ * @{
+ * @ingroup nrf_wdt
+ * @brief   Hardware access layer with cache and barrier support for managing the WDT peripheral.
+ */
+
+/** @brief WDT configuration structure. */
+typedef struct
+{
+    uint32_t behaviour;    ///< Watchdog behaviour flags bitmask, constructed from @ref nrf_wdt_behaviour_mask_t.
+    uint32_t reload_value; ///< Watchdog counter initial value.
+} nrfy_wdt_config_t;
+
+/**
+ * @brief Function for configuring the WDT.
+ *
+ * @param[in] p_reg    Pointer to the structure of registers of the peripheral.
+ * @param[in] p_config Pointer to the peripheral configuration structure.
+ */
+NRFY_STATIC_INLINE void nrfy_wdt_periph_configure(NRF_WDT_Type *            p_reg,
+                                                  nrfy_wdt_config_t const * p_config)
+{
+    nrf_wdt_behaviour_set(p_reg, p_config->behaviour);
+    nrf_wdt_reload_value_set(p_reg, p_config->reload_value);
+    nrf_barrier_w();
+}
+
+/**
+ * @brief Function for initializing the specified WDT interrupts.
+ *
+ * @param[in] p_reg        Pointer to the structure of registers of the peripheral.
+ * @param[in] mask         Mask of interrupts to be initialized.
+ * @param[in] irq_priority Interrupt priority.
+ * @param[in] enable       True if interrupts are to be enabled, false otherwise.
+ */
+NRFY_STATIC_INLINE void nrfy_wdt_int_init(NRF_WDT_Type * p_reg,
+                                          uint32_t       mask,
+                                          uint8_t        irq_priority,
+                                          bool           enable)
+{
+    __nrfy_internal_wdt_event_enabled_clear(p_reg, mask, NRF_WDT_EVENT_TIMEOUT);
+    nrf_barrier_w();
+
+    NRFX_IRQ_PRIORITY_SET(nrfx_get_irq_number(p_reg), irq_priority);
+    NRFX_IRQ_ENABLE(nrfx_get_irq_number(p_reg));
+
+    if (enable)
+    {
+        nrf_wdt_int_enable(p_reg, mask);
+    }
+    nrf_barrier_w();
+}
+
+/**
+ * @brief Function for uninitializing the WDT interrupts.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ */
+NRFY_STATIC_INLINE void nrfy_wdt_int_uninit(NRF_WDT_Type * p_reg)
+{
+    NRFX_IRQ_DISABLE(nrfx_get_irq_number(p_reg));
+    nrf_barrier_w();
+}
+
+/**
+ * @brief Function for processing the specified WDT events.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ * @param[in] mask  Mask of events to be processed, created by @ref NRFY_EVENT_TO_INT_BITMASK.
+ *
+ * @return Mask of events that were generated and processed.
+ *         To be checked against the result of @ref NRFY_EVENT_TO_INT_BITMASK().
+ */
+NRFY_STATIC_INLINE uint32_t nrfy_wdt_events_process(NRF_WDT_Type * p_reg, uint32_t mask)
+{
+    uint32_t evt_mask = __nrfy_internal_wdt_events_process(p_reg, mask);
+    nrf_barrier_w();
+    return evt_mask;
+}
+
+/** @refhal{nrf_wdt_task_trigger} */
+NRFY_STATIC_INLINE void nrfy_wdt_task_trigger(NRF_WDT_Type * p_reg, nrf_wdt_task_t task)
+{
+    nrf_wdt_task_trigger(p_reg, task);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_wdt_task_address_get} */
+NRFY_STATIC_INLINE uint32_t nrfy_wdt_task_address_get(NRF_WDT_Type const * p_reg,
+                                                      nrf_wdt_task_t       task)
+{
+    return nrf_wdt_task_address_get(p_reg, task);
+}
+
+/** @refhal{nrf_wdt_event_clear} */
+NRFY_STATIC_INLINE void nrfy_wdt_event_clear(NRF_WDT_Type * p_reg, nrf_wdt_event_t event)
+{
+    nrf_wdt_event_clear(p_reg, event);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_wdt_event_check} */
+NRFY_STATIC_INLINE bool nrfy_wdt_event_check(NRF_WDT_Type const * p_reg, nrf_wdt_event_t event)
+{
+    nrf_barrier_r();
+    bool check = nrf_wdt_event_check(p_reg, event);
+    nrf_barrier_r();
+    return check;
+}
+
+/** @refhal{nrf_wdt_event_address_get} */
+NRFY_STATIC_INLINE uint32_t nrfy_wdt_event_address_get(NRF_WDT_Type const * p_reg,
+                                                       nrf_wdt_event_t      event)
+{
+    return nrf_wdt_event_address_get(p_reg, event);
+}
+
+/** @refhal{nrf_wdt_int_enable} */
+NRFY_STATIC_INLINE void nrfy_wdt_int_enable(NRF_WDT_Type * p_reg, uint32_t mask)
+{
+    nrf_wdt_int_enable(p_reg, mask);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_wdt_int_enable_check} */
+NRFY_STATIC_INLINE uint32_t nrfy_wdt_int_enable_check(NRF_WDT_Type const * p_reg, uint32_t mask)
+{
+    nrf_barrier_rw();
+    uint32_t check = nrf_wdt_int_enable_check(p_reg, mask);
+    nrf_barrier_r();
+    return check;
+}
+
+/** @refhal{nrf_wdt_int_disable} */
+NRFY_STATIC_INLINE void nrfy_wdt_int_disable(NRF_WDT_Type * p_reg, uint32_t mask)
+{
+    nrf_wdt_int_disable(p_reg, mask);
+    nrf_barrier_w();
+}
+
+#if defined(DPPI_PRESENT) || defined(__NRFX_DOXYGEN__)
+/** @refhal{nrf_wdt_subscribe_set} */
+NRFY_STATIC_INLINE void nrfy_wdt_subscribe_set(NRF_WDT_Type * p_reg,
+                                               nrf_wdt_task_t task,
+                                               uint8_t        channel)
+{
+    nrf_wdt_subscribe_set(p_reg, task, channel);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_wdt_subscribe_clear} */
+NRFY_STATIC_INLINE void nrfy_wdt_subscribe_clear(NRF_WDT_Type * p_reg, nrf_wdt_task_t task)
+{
+    nrf_wdt_subscribe_clear(p_reg, task);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_wdt_publish_set} */
+NRFY_STATIC_INLINE void nrfy_wdt_publish_set(NRF_WDT_Type *  p_reg,
+                                             nrf_wdt_event_t event,
+                                             uint8_t         channel)
+{
+    nrf_wdt_publish_set(p_reg, event, channel);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_wdt_publish_clear} */
+NRFY_STATIC_INLINE void nrfy_wdt_publish_clear(NRF_WDT_Type * p_reg, nrf_wdt_event_t event)
+{
+    nrf_wdt_publish_clear(p_reg, event);
+    nrf_barrier_w();
+}
+#endif // defined(DPPI_PRESENT) || defined(__NRFX_DOXYGEN__)
+
+/** @refhal{nrf_wdt_behaviour_set} */
+NRFY_STATIC_INLINE void nrfy_wdt_behaviour_set(NRF_WDT_Type * p_reg, uint32_t mask)
+{
+    nrf_wdt_behaviour_set(p_reg, mask);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_wdt_started_check} */
+NRFY_STATIC_INLINE bool nrfy_wdt_started_check(NRF_WDT_Type const * p_reg)
+{
+    nrf_barrier_r();
+    bool check = nrf_wdt_started_check(p_reg);
+    nrf_barrier_r();
+    return check;
+}
+
+/** @refhal{nrf_wdt_request_status_check} */
+NRFY_STATIC_INLINE bool nrfy_wdt_request_status_check(NRF_WDT_Type const *  p_reg,
+                                                      nrf_wdt_rr_register_t rr_register)
+{
+    nrf_barrier_r();
+    bool check = nrf_wdt_request_status_check(p_reg, rr_register);
+    nrf_barrier_r();
+    return check;
+}
+
+/** @refhal{nrf_wdt_request_status_get} */
+NRFY_STATIC_INLINE uint32_t nrfy_wdt_request_status_get(NRF_WDT_Type const * p_reg)
+{
+    nrf_barrier_r();
+    uint32_t ret = nrf_wdt_request_status_get(p_reg);
+    nrf_barrier_r();
+    return ret;
+}
+
+/** @refhal{nrf_wdt_reload_value_set} */
+NRFY_STATIC_INLINE void nrfy_wdt_reload_value_set(NRF_WDT_Type * p_reg, uint32_t reload_value)
+{
+    nrf_wdt_reload_value_set(p_reg, reload_value);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_wdt_reload_value_get} */
+NRFY_STATIC_INLINE uint32_t nrfy_wdt_reload_value_get(NRF_WDT_Type const * p_reg)
+{
+    nrf_barrier_rw();
+    uint32_t ret = nrf_wdt_reload_value_get(p_reg);
+    nrf_barrier_r();
+    return ret;
+}
+
+/** @refhal{nrf_wdt_reload_request_enable} */
+NRFY_STATIC_INLINE void nrfy_wdt_reload_request_enable(NRF_WDT_Type *       p_reg,
+                                                       nrf_wdt_rr_register_t rr_register)
+{
+    nrf_wdt_reload_request_enable(p_reg, rr_register);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_wdt_reload_request_disable} */
+NRFY_STATIC_INLINE void nrfy_wdt_reload_request_disable(NRF_WDT_Type *       p_reg,
+                                                        nrf_wdt_rr_register_t rr_register)
+{
+    nrf_wdt_reload_request_disable(p_reg, rr_register);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_wdt_reload_request_enable_check} */
+NRFY_STATIC_INLINE bool nrfy_wdt_reload_request_enable_check(NRF_WDT_Type const *  p_reg,
+                                                             nrf_wdt_rr_register_t rr_register)
+{
+    nrf_barrier_rw();
+    bool check = nrf_wdt_reload_request_enable_check(p_reg, rr_register);
+    nrf_barrier_r();
+    return check;
+}
+
+/** @refhal{nrf_wdt_reload_request_set} */
+NRFY_STATIC_INLINE void nrfy_wdt_reload_request_set(NRF_WDT_Type *        p_reg,
+                                                    nrf_wdt_rr_register_t rr_register)
+{
+    nrf_wdt_reload_request_set(p_reg, rr_register);
+    nrf_barrier_w();
+}
+
+/** @} */
+
+NRFY_STATIC_INLINE bool __nrfy_internal_wdt_event_handle(NRF_WDT_Type *  p_reg,
+                                                         uint32_t        mask,
+                                                         nrf_wdt_event_t event,
+                                                         uint32_t *      p_evt_mask)
+{
+    if ((mask & NRFY_EVENT_TO_INT_BITMASK(event)) && nrf_wdt_event_check(p_reg, event))
+    {
+        nrf_wdt_event_clear(p_reg, event);
+        if (p_evt_mask)
+        {
+            *p_evt_mask |= NRFY_EVENT_TO_INT_BITMASK(event);
+        }
+        return true;
+    }
+    return false;
+}
+
+NRFY_STATIC_INLINE uint32_t __nrfy_internal_wdt_events_process(NRF_WDT_Type * p_reg, uint32_t mask)
+{
+    uint32_t evt_mask = 0;
+
+    nrf_barrier_r();
+    (void)__nrfy_internal_wdt_event_handle(p_reg, mask, NRF_WDT_EVENT_TIMEOUT, &evt_mask);
+
+    return evt_mask;
+}
+
+NRFY_STATIC_INLINE void __nrfy_internal_wdt_event_enabled_clear(NRF_WDT_Type *  p_reg,
+                                                                uint32_t        mask,
+                                                                nrf_wdt_event_t event)
+{
+    if (mask & NRFY_EVENT_TO_INT_BITMASK(event))
+    {
+        nrf_wdt_event_clear(p_reg, event);
+    }
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // NRFY_WDT_H__

--- a/nrfx/helpers/nrfx_flag32_allocator.c
+++ b/nrfx/helpers/nrfx_flag32_allocator.c
@@ -62,11 +62,12 @@ nrfx_err_t nrfx_flag32_alloc(nrfx_atomic_t * p_mask, uint8_t *p_flag)
 
     do {
         prev_mask = *p_mask;
-        idx = 31 - NRF_CLZ(prev_mask);
-        if (idx < 0) {
+        if (prev_mask == 0)
+        {
             return NRFX_ERROR_NO_MEM;
         }
 
+        idx = 31 - NRF_CLZ(prev_mask);
         new_mask = prev_mask & ~NRFX_BIT(idx);
     } while (!NRFX_ATOMIC_CAS(p_mask, prev_mask, new_mask));
 

--- a/nrfx/helpers/nrfx_gppi.h
+++ b/nrfx/helpers/nrfx_gppi.h
@@ -36,14 +36,6 @@
 
 #include <nrfx.h>
 
-#if NRFX_CHECK(NRFX_DPPI_ENABLED)
-#include <nrfx_dppi.h>
-#endif
-
-#if NRFX_CHECK(NRFX_PPI_ENABLED)
-#include <nrfx_ppi.h>
-#endif
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -80,7 +72,13 @@ extern "C" {
  */
 
 #if defined(PPI_PRESENT)
-#include <hal/nrf_ppi.h>
+#include <nrfx_ppi.h>
+
+#define NRFX_GPPI_GROUP_NUM              PPI_GROUP_NUM
+#define NRFX_GPPI_GROUPS_USED            NRFX_PPI_GROUPS_USED
+#define NRFX_GPPI_ALL_APP_GROUPS_MASK    (((1uL << PPI_GROUP_NUM) - 1) & ~(NRFX_PPI_GROUPS_USED))
+#define NRFX_GPPI_ALL_APP_CHANNELS_MASK  NRFX_PPI_ALL_APP_CHANNELS_MASK
+#define NRFX_GPPI_PROG_APP_CHANNELS_MASK NRFX_PPI_PROG_APP_CHANNELS_MASK
 
 typedef enum
 {
@@ -113,16 +111,26 @@ typedef enum
 } nrfx_gppi_task_t;
 
 #elif defined(DPPI_PRESENT)
-#include <hal/nrf_dppi.h>
+#include <haly/nrfy_dppi.h>
+
+#define NRFX_GPPI_GROUP_NUM              DPPI_GROUP_NUM
+#define NRFX_GPPI_GROUPS_USED            NRFX_DPPI_GROUPS_USED
+#define NRFX_GPPI_ALL_APP_GROUPS_MASK    (NRFX_BIT_MASK(DPPI_GROUP_NUM) & ~NRFX_DPPI_GROUPS_USED)
+#define NRFX_GPPI_ALL_APP_CHANNELS_MASK  (NRFX_BIT_MASK(DPPI_CH_NUM) & ~NRFX_DPPI_CHANNELS_USED)
+#if !defined(NRFX_GPPI_PROG_APP_CHANNELS_MASK)
+#define NRFX_GPPI_PROG_APP_CHANNELS_MASK NRFX_GPPI_ALL_APP_CHANNELS_MASK
+#endif
 
 typedef enum
 {
     NRFX_GPPI_CHANNEL_GROUP0 = NRF_DPPI_CHANNEL_GROUP0,
     NRFX_GPPI_CHANNEL_GROUP1 = NRF_DPPI_CHANNEL_GROUP1,
+#if DPPI_GROUP_NUM > 2
     NRFX_GPPI_CHANNEL_GROUP2 = NRF_DPPI_CHANNEL_GROUP2,
     NRFX_GPPI_CHANNEL_GROUP3 = NRF_DPPI_CHANNEL_GROUP3,
     NRFX_GPPI_CHANNEL_GROUP4 = NRF_DPPI_CHANNEL_GROUP4,
     NRFX_GPPI_CHANNEL_GROUP5 = NRF_DPPI_CHANNEL_GROUP5,
+#endif
 } nrfx_gppi_channel_group_t;
 
 typedef enum
@@ -131,6 +139,7 @@ typedef enum
     NRFX_GPPI_TASK_CHG0_DIS = NRF_DPPI_TASK_CHG0_DIS,
     NRFX_GPPI_TASK_CHG1_EN  = NRF_DPPI_TASK_CHG1_EN,
     NRFX_GPPI_TASK_CHG1_DIS = NRF_DPPI_TASK_CHG1_DIS,
+#if DPPI_GROUP_NUM > 2
     NRFX_GPPI_TASK_CHG2_EN  = NRF_DPPI_TASK_CHG2_EN,
     NRFX_GPPI_TASK_CHG2_DIS = NRF_DPPI_TASK_CHG2_DIS,
     NRFX_GPPI_TASK_CHG3_EN  = NRF_DPPI_TASK_CHG3_EN,
@@ -139,6 +148,7 @@ typedef enum
     NRFX_GPPI_TASK_CHG4_DIS = NRF_DPPI_TASK_CHG4_DIS,
     NRFX_GPPI_TASK_CHG5_EN  = NRF_DPPI_TASK_CHG5_EN,
     NRFX_GPPI_TASK_CHG5_DIS = NRF_DPPI_TASK_CHG5_DIS
+#endif
 } nrfx_gppi_task_t;
 
 #elif defined(__NRFX_DOXYGEN__)
@@ -148,10 +158,12 @@ typedef enum
 {
     NRFX_GPPI_CHANNEL_GROUP0, /**< Channel group 0.*/
     NRFX_GPPI_CHANNEL_GROUP1, /**< Channel group 1.*/
+#if NRFX_GPPI_GROUP_NUM > 2 || defined(__NRFX_DOXYGEN__)
     NRFX_GPPI_CHANNEL_GROUP2, /**< Channel group 2.*/
     NRFX_GPPI_CHANNEL_GROUP3, /**< Channel group 3.*/
     NRFX_GPPI_CHANNEL_GROUP4, /**< Channel group 4.*/
     NRFX_GPPI_CHANNEL_GROUP5, /**< Channel group 5.*/
+#endif
 } nrfx_gppi_channel_group_t;
 
 /** @brief Generic PPI tasks. */
@@ -161,6 +173,7 @@ typedef enum
     NRFX_GPPI_TASK_CHG0_DIS, /**< Task for disabling channel group 0 */
     NRFX_GPPI_TASK_CHG1_EN,  /**< Task for enabling channel group 1 */
     NRFX_GPPI_TASK_CHG1_DIS, /**< Task for disabling channel group 1 */
+#if NRFX_GPPI_GROUP_NUM > 2 || defined(__NRFX_DOXYGEN__)
     NRFX_GPPI_TASK_CHG2_EN,  /**< Task for enabling channel group 2 */
     NRFX_GPPI_TASK_CHG2_DIS, /**< Task for disabling channel group 2 */
     NRFX_GPPI_TASK_CHG3_EN,  /**< Task for enabling channel group 3 */
@@ -169,6 +182,7 @@ typedef enum
     NRFX_GPPI_TASK_CHG4_DIS, /**< Task for disabling channel group 4 */
     NRFX_GPPI_TASK_CHG5_EN,  /**< Task for enabling channel group 5 */
     NRFX_GPPI_TASK_CHG5_DIS, /**< Task for disabling channel group 5 */
+#endif
 } nrfx_gppi_task_t;
 #endif // defined(__NRFX_DOXYGEN__)
 
@@ -180,10 +194,10 @@ typedef enum
  * @retval true  The channel is enabled.
  * @retval false The channel is not enabled.
  */
-__STATIC_INLINE bool nrfx_gppi_channel_check(uint8_t channel);
+bool nrfx_gppi_channel_check(uint8_t channel);
 
 /** @brief Function for disabling all channels. */
-__STATIC_INLINE void nrfx_gppi_channels_disable_all(void);
+void nrfx_gppi_channels_disable_all(void);
 
 /**
  * @brief Function for enabling multiple channels.
@@ -193,7 +207,7 @@ __STATIC_INLINE void nrfx_gppi_channels_disable_all(void);
  *
  * @param[in] mask Channel mask.
  */
-__STATIC_INLINE void nrfx_gppi_channels_enable(uint32_t mask);
+void nrfx_gppi_channels_enable(uint32_t mask);
 
 /**
  * @brief Function for disabling multiple channels.
@@ -203,7 +217,7 @@ __STATIC_INLINE void nrfx_gppi_channels_enable(uint32_t mask);
  *
  * @param[in] mask Channel mask.
  */
-__STATIC_INLINE void nrfx_gppi_channels_disable(uint32_t mask);
+void nrfx_gppi_channels_disable(uint32_t mask);
 
 /**
  * @brief Function for associating a given channel with the specified event register.
@@ -214,7 +228,7 @@ __STATIC_INLINE void nrfx_gppi_channels_disable(uint32_t mask);
  * @param[in] channel Channel to which to assign the event.
  * @param[in] eep     Address of the event register.
  */
-__STATIC_INLINE void nrfx_gppi_event_endpoint_setup(uint8_t channel, uint32_t eep);
+void nrfx_gppi_event_endpoint_setup(uint8_t channel, uint32_t eep);
 
 /**
  * @brief Function for associating a given channel with the specified task register.
@@ -225,7 +239,7 @@ __STATIC_INLINE void nrfx_gppi_event_endpoint_setup(uint8_t channel, uint32_t ee
  * @param[in] channel Channel to which to assign the task.
  * @param[in] tep     Address of the task register.
  */
-__STATIC_INLINE void nrfx_gppi_task_endpoint_setup(uint8_t channel, uint32_t tep);
+void nrfx_gppi_task_endpoint_setup(uint8_t channel, uint32_t tep);
 
 /**
  * @brief Function for setting up the event and task endpoints for a given channel.
@@ -234,9 +248,16 @@ __STATIC_INLINE void nrfx_gppi_task_endpoint_setup(uint8_t channel, uint32_t tep
  * @param[in] eep     Address of the event register.
  * @param[in] tep     Address of the task register.
  */
-__STATIC_INLINE void nrfx_gppi_channel_endpoints_setup(uint8_t  channel,
-                                                       uint32_t eep,
-                                                       uint32_t tep);
+void nrfx_gppi_channel_endpoints_setup(uint8_t channel, uint32_t eep, uint32_t tep);
+
+/**
+ * @brief Function for clearing the event and task endpoints for a given channel.
+ *
+ * @param[in] channel Channel to which the given endpoints are assigned.
+ * @param[in] eep     Address of the event register.
+ * @param[in] tep     Address of the task register.
+ */
+void nrfx_gppi_channel_endpoints_clear(uint8_t  channel, uint32_t eep, uint32_t tep);
 
 /**
  * @brief Function for clearing the DPPI publish configuration for a given event
@@ -245,7 +266,7 @@ __STATIC_INLINE void nrfx_gppi_channel_endpoints_setup(uint8_t  channel,
  * @param[in] channel Channel for which to clear the event endpoint. Not used in DPPI.
  * @param[in] eep     Address of the event register. Not used in PPI.
  */
-__STATIC_INLINE void nrfx_gppi_event_endpoint_clear(uint8_t channel, uint32_t eep);
+void nrfx_gppi_event_endpoint_clear(uint8_t channel, uint32_t eep);
 
 /**
  * @brief Function for clearing the DPPI subscribe configuration for a given task
@@ -254,8 +275,7 @@ __STATIC_INLINE void nrfx_gppi_event_endpoint_clear(uint8_t channel, uint32_t ee
  * @param[in] channel Channel from which to disconnect the task enpoint. Not used in DPPI.
  * @param[in] tep     Address of the task register. Not used in PPI.
  */
-__STATIC_INLINE void nrfx_gppi_task_endpoint_clear(uint8_t channel, uint32_t tep);
-
+void nrfx_gppi_task_endpoint_clear(uint8_t channel, uint32_t tep);
 
 #if defined(PPI_FEATURE_FORKS_PRESENT) || defined(DPPI_PRESENT) || defined(__NRFX_DOXYGEN__)
 /**
@@ -265,7 +285,7 @@ __STATIC_INLINE void nrfx_gppi_task_endpoint_clear(uint8_t channel, uint32_t tep
  * @param[in] channel  Channel to which the given fork endpoint is assigned.
  * @param[in] fork_tep Address of the task register.
  */
-__STATIC_INLINE void nrfx_gppi_fork_endpoint_setup(uint8_t channel, uint32_t fork_tep);
+void nrfx_gppi_fork_endpoint_setup(uint8_t channel, uint32_t fork_tep);
 
 /**
  * @brief Function for clearing the task endpoint for a given PPI fork or for clearing
@@ -274,7 +294,7 @@ __STATIC_INLINE void nrfx_gppi_fork_endpoint_setup(uint8_t channel, uint32_t for
  * @param[in] channel  Channel for which to clear the fork endpoint. Not used in DPPI.
  * @param[in] fork_tep Address of the task register. Not used in PPI.
  */
-__STATIC_INLINE void nrfx_gppi_fork_endpoint_clear(uint8_t channel, uint32_t fork_tep);
+void nrfx_gppi_fork_endpoint_clear(uint8_t channel, uint32_t fork_tep);
 #endif // defined(PPI_FEATURE_FORKS_PRESENT) || defined(DPPI_PRESENT) || defined(__NRFX_DOXYGEN__)
 
 /**
@@ -283,8 +303,8 @@ __STATIC_INLINE void nrfx_gppi_fork_endpoint_clear(uint8_t channel, uint32_t for
  * @param[in] channel_mask  Channels to be included in the group.
  * @param[in] channel_group Channel group.
  */
-__STATIC_INLINE void nrfx_gppi_channels_include_in_group(uint32_t                  channel_mask,
-                                                         nrfx_gppi_channel_group_t channel_group);
+void nrfx_gppi_channels_include_in_group(uint32_t                  channel_mask,
+                                         nrfx_gppi_channel_group_t channel_group);
 
 /**
  * @brief Function for removing multiple channels from a channel group.
@@ -292,36 +312,36 @@ __STATIC_INLINE void nrfx_gppi_channels_include_in_group(uint32_t               
  * @param[in] channel_mask  Channels to be removed from the group.
  * @param[in] channel_group Channel group.
  */
-__STATIC_INLINE void nrfx_gppi_channels_remove_from_group(uint32_t                  channel_mask,
-                                                          nrfx_gppi_channel_group_t channel_group);
+void nrfx_gppi_channels_remove_from_group(uint32_t                  channel_mask,
+                                          nrfx_gppi_channel_group_t channel_group);
 
 /**
  * @brief Function for removing all channels from a channel group.
  *
  * @param[in] channel_group Channel group.
  */
-__STATIC_INLINE void nrfx_gppi_group_clear(nrfx_gppi_channel_group_t channel_group);
+void nrfx_gppi_group_clear(nrfx_gppi_channel_group_t channel_group);
 
 /**
  * @brief Function for enabling a channel group.
  *
  * @param[in] channel_group Channel group.
  */
-__STATIC_INLINE void nrfx_gppi_group_enable(nrfx_gppi_channel_group_t channel_group);
+void nrfx_gppi_group_enable(nrfx_gppi_channel_group_t channel_group);
 
 /**
  * @brief Function for disabling a group.
  *
  * @param[in] channel_group Channel group.
  */
-__STATIC_INLINE void nrfx_gppi_group_disable(nrfx_gppi_channel_group_t channel_group);
+void nrfx_gppi_group_disable(nrfx_gppi_channel_group_t channel_group);
 
 /**
  * @brief Function for activating a task.
  *
  * @param[in] task Task to be activated.
  */
-__STATIC_INLINE void nrfx_gppi_task_trigger(nrfx_gppi_task_t task);
+void nrfx_gppi_task_trigger(nrfx_gppi_task_t task);
 
 /**
  * @brief Function for returning the address of a specific task register.
@@ -330,7 +350,7 @@ __STATIC_INLINE void nrfx_gppi_task_trigger(nrfx_gppi_task_t task);
  *
  * @return Address of the requested task register.
  */
-__STATIC_INLINE uint32_t nrfx_gppi_task_address_get(nrfx_gppi_task_t task);
+uint32_t nrfx_gppi_task_address_get(nrfx_gppi_task_t task);
 
 /**
  * @brief Function for returning the address of a channel group disable task.
@@ -339,7 +359,7 @@ __STATIC_INLINE uint32_t nrfx_gppi_task_address_get(nrfx_gppi_task_t task);
  *
  * @return Disable task address of the specified group.
  */
-__STATIC_INLINE nrfx_gppi_task_t nrfx_gppi_group_disable_task_get(nrfx_gppi_channel_group_t group);
+nrfx_gppi_task_t nrfx_gppi_group_disable_task_get(nrfx_gppi_channel_group_t group);
 
 /**
  * @brief Function for returning the address of a channel group enable task.
@@ -348,7 +368,7 @@ __STATIC_INLINE nrfx_gppi_task_t nrfx_gppi_group_disable_task_get(nrfx_gppi_chan
  *
  * @return Enable task address of the specified group.
  */
-__STATIC_INLINE nrfx_gppi_task_t nrfx_gppi_group_enable_task_get(nrfx_gppi_channel_group_t group);
+nrfx_gppi_task_t nrfx_gppi_group_enable_task_get(nrfx_gppi_channel_group_t group);
 
 /**
  * @brief Function for allocating a channel.
@@ -359,7 +379,7 @@ __STATIC_INLINE nrfx_gppi_task_t nrfx_gppi_group_enable_task_get(nrfx_gppi_chann
  * @retval NRFX_ERROR_NO_MEM        There is no available channel to be used.
  * @retval NRFX_ERROR_NOT_SUPPORTED Driver is not enabled.
  */
-__STATIC_INLINE nrfx_err_t nrfx_gppi_channel_alloc(uint8_t * p_channel);
+nrfx_err_t nrfx_gppi_channel_alloc(uint8_t * p_channel);
 
 /**
  * @brief Function for freeing a channel.
@@ -371,7 +391,7 @@ __STATIC_INLINE nrfx_err_t nrfx_gppi_channel_alloc(uint8_t * p_channel);
  *                                  is not user-configurable.
  * @retval NRFX_ERROR_NOT_SUPPORTED Driver is not enabled.
  */
-__STATIC_INLINE nrfx_err_t nrfx_gppi_channel_free(uint8_t channel);
+nrfx_err_t nrfx_gppi_channel_free(uint8_t channel);
 
 /**
  * @brief Function for allocating a channel group.
@@ -382,7 +402,7 @@ __STATIC_INLINE nrfx_err_t nrfx_gppi_channel_free(uint8_t channel);
  * @retval NRFX_ERROR_NO_MEM        There is no available channel group to be used.
  * @retval NRFX_ERROR_NOT_SUPPORTED Driver is not enabled.
  */
-__STATIC_INLINE nrfx_err_t nrfx_gppi_group_alloc(nrfx_gppi_channel_group_t * p_group);
+nrfx_err_t nrfx_gppi_group_alloc(nrfx_gppi_channel_group_t * p_group);
 
 /**
  * @brief Function for freeing a channel group.
@@ -394,323 +414,8 @@ __STATIC_INLINE nrfx_err_t nrfx_gppi_group_alloc(nrfx_gppi_channel_group_t * p_g
  *                                  is not user-configurable.
  * @retval NRFX_ERROR_NOT_SUPPORTED Driver is not enabled.
  */
-__STATIC_INLINE nrfx_err_t nrfx_gppi_group_free(nrfx_gppi_channel_group_t group);
+nrfx_err_t nrfx_gppi_group_free(nrfx_gppi_channel_group_t group);
 /** @} */
-
-#if defined(PPI_PRESENT)
-
-__STATIC_INLINE bool nrfx_gppi_channel_check(uint8_t channel)
-{
-    return (nrf_ppi_channel_enable_get(NRF_PPI, (nrf_ppi_channel_t)channel) ==
-            NRF_PPI_CHANNEL_ENABLED);
-}
-
-__STATIC_INLINE void nrfx_gppi_channels_disable_all(void)
-{
-    nrf_ppi_channels_disable_all(NRF_PPI);
-}
-
-__STATIC_INLINE void nrfx_gppi_channels_enable(uint32_t mask)
-{
-    nrf_ppi_channels_enable(NRF_PPI, mask);
-}
-
-__STATIC_INLINE void nrfx_gppi_channels_disable(uint32_t mask)
-{
-    nrf_ppi_channels_disable(NRF_PPI, mask);
-}
-
-__STATIC_INLINE void nrfx_gppi_event_endpoint_setup(uint8_t channel, uint32_t eep)
-{
-    nrf_ppi_event_endpoint_setup(NRF_PPI, (nrf_ppi_channel_t)channel, eep);
-}
-
-__STATIC_INLINE void nrfx_gppi_task_endpoint_setup(uint8_t channel, uint32_t tep)
-{
-    nrf_ppi_task_endpoint_setup(NRF_PPI, (nrf_ppi_channel_t)channel, tep);
-}
-
-__STATIC_INLINE void nrfx_gppi_channel_endpoints_setup(uint8_t  channel,
-                                                       uint32_t eep,
-                                                       uint32_t tep)
-{
-    nrf_ppi_channel_endpoint_setup(NRF_PPI, (nrf_ppi_channel_t)channel, eep, tep);
-}
-
-__STATIC_INLINE void nrfx_gppi_event_endpoint_clear(uint8_t channel, uint32_t eep)
-{
-    (void)eep;
-     nrf_ppi_event_endpoint_setup(NRF_PPI, (nrf_ppi_channel_t)channel, 0);
-}
-
-__STATIC_INLINE void nrfx_gppi_task_endpoint_clear(uint8_t channel, uint32_t tep)
-{
-    (void)tep;
-    nrf_ppi_task_endpoint_setup(NRF_PPI, (nrf_ppi_channel_t)channel, 0);
-}
-
-#if defined(PPI_FEATURE_FORKS_PRESENT)
-__STATIC_INLINE void nrfx_gppi_fork_endpoint_setup(uint8_t channel, uint32_t fork_tep)
-{
-    nrf_ppi_fork_endpoint_setup(NRF_PPI, (nrf_ppi_channel_t)channel, fork_tep);
-}
-
-__STATIC_INLINE void nrfx_gppi_fork_endpoint_clear(uint8_t channel, uint32_t fork_tep)
-{
-    (void)fork_tep;
-    nrf_ppi_fork_endpoint_setup(NRF_PPI, (nrf_ppi_channel_t)channel, 0);
-}
-#endif
-
-__STATIC_INLINE void nrfx_gppi_channels_include_in_group(uint32_t                  channel_mask,
-                                                         nrfx_gppi_channel_group_t channel_group)
-{
-    nrf_ppi_channels_include_in_group(NRF_PPI,
-                                      channel_mask,
-                                      (nrf_ppi_channel_group_t)channel_group);
-}
-
-__STATIC_INLINE void nrfx_gppi_channels_remove_from_group(uint32_t                  channel_mask,
-                                                          nrfx_gppi_channel_group_t channel_group)
-{
-    nrf_ppi_channels_remove_from_group(NRF_PPI,
-                                       channel_mask,
-                                       (nrf_ppi_channel_group_t)channel_group);
-}
-
-__STATIC_INLINE void nrfx_gppi_group_clear(nrfx_gppi_channel_group_t channel_group)
-{
-    nrf_ppi_group_clear(NRF_PPI, (nrf_ppi_channel_group_t)channel_group);
-}
-
-__STATIC_INLINE void nrfx_gppi_group_enable(nrfx_gppi_channel_group_t channel_group)
-{
-    nrf_ppi_group_enable(NRF_PPI, (nrf_ppi_channel_group_t)channel_group);
-}
-
-__STATIC_INLINE void nrfx_gppi_group_disable(nrfx_gppi_channel_group_t channel_group)
-{
-    nrf_ppi_group_disable(NRF_PPI, (nrf_ppi_channel_group_t)channel_group);
-}
-
-__STATIC_INLINE void nrfx_gppi_task_trigger(nrfx_gppi_task_t task)
-{
-    nrf_ppi_task_trigger(NRF_PPI, (nrf_ppi_task_t)task);
-}
-
-__STATIC_INLINE uint32_t nrfx_gppi_task_address_get(nrfx_gppi_task_t task)
-{
-    return (uint32_t)nrf_ppi_task_address_get(NRF_PPI, (nrf_ppi_task_t)task);
-}
-
-__STATIC_INLINE nrfx_gppi_task_t nrfx_gppi_group_disable_task_get(nrfx_gppi_channel_group_t group)
-{
-    return (nrfx_gppi_task_t)nrf_ppi_group_disable_task_get(NRF_PPI, (uint8_t)group);
-}
-
-__STATIC_INLINE nrfx_gppi_task_t nrfx_gppi_group_enable_task_get(nrfx_gppi_channel_group_t group)
-{
-    return (nrfx_gppi_task_t)nrf_ppi_group_enable_task_get(NRF_PPI, (uint8_t)group);
-}
-
-__STATIC_INLINE nrfx_err_t nrfx_gppi_channel_alloc(uint8_t * p_channel)
-{
-#if NRFX_CHECK(NRFX_PPI_ENABLED)
-    return nrfx_ppi_channel_alloc((nrf_ppi_channel_t *)p_channel);
-#else
-    (void)p_channel;
-    return NRFX_ERROR_NOT_SUPPORTED;
-#endif
-}
-
-__STATIC_INLINE nrfx_err_t nrfx_gppi_channel_free(uint8_t channel)
-{
-#if NRFX_CHECK(NRFX_PPI_ENABLED)
-    return nrfx_ppi_channel_free((nrf_ppi_channel_t)channel);
-#else
-    (void)channel;
-    return NRFX_ERROR_NOT_SUPPORTED;
-#endif
-}
-
-__STATIC_INLINE nrfx_err_t nrfx_gppi_group_alloc(nrfx_gppi_channel_group_t * p_group)
-{
-#if NRFX_CHECK(NRFX_PPI_ENABLED)
-    return nrfx_ppi_group_alloc((nrf_ppi_channel_group_t *)p_group);
-#else
-    (void)p_group;
-    return NRFX_ERROR_NOT_SUPPORTED;
-#endif
-}
-
-__STATIC_INLINE nrfx_err_t nrfx_gppi_group_free(nrfx_gppi_channel_group_t group)
-{
-#if NRFX_CHECK(NRFX_PPI_ENABLED)
-    return nrfx_ppi_group_free((nrf_ppi_channel_group_t)group);
-#else
-    (void)group;
-    return NRFX_ERROR_NOT_SUPPORTED;
-#endif
-}
-#elif defined(DPPI_PRESENT)
-
-__STATIC_INLINE bool nrfx_gppi_channel_check(uint8_t channel)
-{
-    return nrf_dppi_channel_check(NRF_DPPIC, channel);
-}
-
-__STATIC_INLINE void nrfx_gppi_channels_disable_all(void)
-{
-    nrf_dppi_channels_disable_all(NRF_DPPIC);
-}
-
-__STATIC_INLINE void nrfx_gppi_channels_enable(uint32_t mask)
-{
-    nrf_dppi_channels_enable(NRF_DPPIC, mask);
-}
-
-__STATIC_INLINE void nrfx_gppi_channels_disable(uint32_t mask)
-{
-    nrf_dppi_channels_disable(NRF_DPPIC, mask);
-}
-
-__STATIC_INLINE void nrfx_gppi_task_trigger(nrfx_gppi_task_t task)
-{
-    nrf_dppi_task_trigger(NRF_DPPIC, (nrf_dppi_task_t)task);
-}
-
-__STATIC_INLINE void nrfx_gppi_event_endpoint_setup(uint8_t channel, uint32_t eep)
-{
-    NRFX_ASSERT(eep);
-    *((volatile uint32_t *)(eep + 0x80uL)) = ((uint32_t)channel | DPPIC_SUBSCRIBE_CHG_EN_EN_Msk);
-}
-
-__STATIC_INLINE void nrfx_gppi_task_endpoint_setup(uint8_t channel, uint32_t tep)
-{
-    NRFX_ASSERT(tep);
-    *((volatile uint32_t *)(tep + 0x80uL)) = ((uint32_t)channel | DPPIC_SUBSCRIBE_CHG_EN_EN_Msk);
-}
-
-__STATIC_INLINE void nrfx_gppi_channel_endpoints_setup(uint8_t  channel,
-                                                       uint32_t eep,
-                                                       uint32_t tep)
-{
-    nrfx_gppi_event_endpoint_setup(channel, eep);
-    nrfx_gppi_task_endpoint_setup(channel, tep);
-}
-
-__STATIC_INLINE void nrfx_gppi_event_endpoint_clear(uint8_t channel, uint32_t eep)
-{
-    NRFX_ASSERT(eep);
-    (void)channel;
-    *((volatile uint32_t *)(eep + 0x80uL)) = 0;
-}
-
-__STATIC_INLINE void nrfx_gppi_task_endpoint_clear(uint8_t channel, uint32_t tep)
-{
-    NRFX_ASSERT(tep);
-    (void)channel;
-    *((volatile uint32_t *)(tep + 0x80uL)) = 0;
-}
-
-__STATIC_INLINE void nrfx_gppi_fork_endpoint_setup(uint8_t channel, uint32_t fork_tep)
-{
-    nrfx_gppi_task_endpoint_setup(channel, fork_tep);
-}
-
-__STATIC_INLINE void nrfx_gppi_fork_endpoint_clear(uint8_t channel, uint32_t fork_tep)
-{
-    nrfx_gppi_task_endpoint_clear(channel, fork_tep);
-}
-
-__STATIC_INLINE void nrfx_gppi_channels_include_in_group(uint32_t                  channel_mask,
-                                                         nrfx_gppi_channel_group_t channel_group)
-{
-    nrf_dppi_channels_include_in_group(NRF_DPPIC,
-                                       channel_mask,
-                                       (nrf_dppi_channel_group_t)channel_group);
-}
-
-__STATIC_INLINE void nrfx_gppi_channels_remove_from_group(uint32_t                  channel_mask,
-                                                          nrfx_gppi_channel_group_t channel_group)
-{
-    nrf_dppi_channels_remove_from_group(NRF_DPPIC,
-                                        channel_mask,
-                                        (nrf_dppi_channel_group_t)channel_group);
-}
-
-__STATIC_INLINE void nrfx_gppi_group_clear(nrfx_gppi_channel_group_t channel_group)
-{
-    nrf_dppi_group_clear(NRF_DPPIC, (nrf_dppi_channel_group_t)channel_group);
-}
-
-__STATIC_INLINE void nrfx_gppi_group_enable(nrfx_gppi_channel_group_t channel_group)
-{
-    nrf_dppi_group_enable(NRF_DPPIC, (nrf_dppi_channel_group_t)channel_group);
-}
-
-__STATIC_INLINE void nrfx_gppi_group_disable(nrfx_gppi_channel_group_t channel_group)
-{
-    nrf_dppi_group_disable(NRF_DPPIC, (nrf_dppi_channel_group_t)channel_group);
-}
-
-__STATIC_INLINE uint32_t nrfx_gppi_task_address_get(nrfx_gppi_task_t gppi_task)
-{
-    return nrf_dppi_task_address_get(NRF_DPPIC, (nrf_dppi_task_t)gppi_task);
-}
-
-__STATIC_INLINE nrfx_gppi_task_t nrfx_gppi_group_disable_task_get(nrfx_gppi_channel_group_t group)
-{
-    return (nrfx_gppi_task_t) nrf_dppi_group_disable_task_get((uint8_t)group);
-}
-
-__STATIC_INLINE nrfx_gppi_task_t nrfx_gppi_group_enable_task_get(nrfx_gppi_channel_group_t group)
-{
-    return (nrfx_gppi_task_t) nrf_dppi_group_enable_task_get((uint8_t)group);
-}
-
-__STATIC_INLINE nrfx_err_t nrfx_gppi_channel_alloc(uint8_t * p_channel)
-{
-#if NRFX_CHECK(NRFX_DPPI_ENABLED)
-    return nrfx_dppi_channel_alloc(p_channel);
-#else
-    (void)p_channel;
-    return NRFX_ERROR_NOT_SUPPORTED;
-#endif
-}
-
-__STATIC_INLINE nrfx_err_t nrfx_gppi_channel_free(uint8_t channel)
-{
-#if NRFX_CHECK(NRFX_DPPI_ENABLED)
-    return nrfx_dppi_channel_free(channel);
-#else
-    (void)channel;
-    return NRFX_ERROR_NOT_SUPPORTED;
-#endif
-}
-
-__STATIC_INLINE nrfx_err_t nrfx_gppi_group_alloc(nrfx_gppi_channel_group_t * p_group)
-{
-#if NRFX_CHECK(NRFX_DPPI_ENABLED)
-    return nrfx_dppi_group_alloc((nrf_dppi_channel_group_t *)p_group);
-#else
-    (void)p_group;
-    return NRFX_ERROR_NOT_SUPPORTED;
-#endif
-}
-
-__STATIC_INLINE nrfx_err_t nrfx_gppi_group_free(nrfx_gppi_channel_group_t group)
-{
-#if NRFX_CHECK(NRFX_DPPI_ENABLED)
-    return nrfx_dppi_group_free((nrf_dppi_channel_group_t)group);
-#else
-    (void)group;
-    return NRFX_ERROR_NOT_SUPPORTED;
-#endif
-}
-#else
-#error "Neither PPI nor DPPI is present in the SoC currently in use."
-#endif
 
 #ifdef __cplusplus
 }

--- a/nrfx/helpers/nrfx_gppi_dppi.c
+++ b/nrfx/helpers/nrfx_gppi_dppi.c
@@ -1,0 +1,199 @@
+/*
+ * Copyright (c) 2022 - 2023, Nordic Semiconductor ASA
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <helpers/nrfx_gppi.h>
+
+#if NRFX_CHECK(NRFX_DPPI_ENABLED) && (!defined(DPPIC_COUNT) || (DPPIC_COUNT == 1))
+#include <nrfx_dppi.h>
+#endif
+
+#if defined(DPPI_PRESENT) && !defined(NRF_DPPI_EXT)
+bool nrfx_gppi_channel_check(uint8_t channel)
+{
+    return nrfy_dppi_channel_check(NRF_DPPIC, channel);
+}
+
+void nrfx_gppi_channels_disable_all(void)
+{
+    nrfy_dppi_channels_disable_all(NRF_DPPIC);
+}
+
+void nrfx_gppi_channels_enable(uint32_t mask)
+{
+    nrfy_dppi_channels_enable(NRF_DPPIC, mask);
+}
+
+void nrfx_gppi_channels_disable(uint32_t mask)
+{
+    nrfy_dppi_channels_disable(NRF_DPPIC, mask);
+}
+
+void nrfx_gppi_task_trigger(nrfx_gppi_task_t task)
+{
+    nrfy_dppi_task_trigger(NRF_DPPIC, (nrf_dppi_task_t)task);
+}
+
+void nrfx_gppi_event_endpoint_setup(uint8_t channel, uint32_t eep)
+{
+    NRFX_ASSERT(eep);
+    NRF_DPPI_ENDPOINT_SETUP(eep, channel);
+}
+
+void nrfx_gppi_task_endpoint_setup(uint8_t channel, uint32_t tep)
+{
+    NRFX_ASSERT(tep);
+    NRF_DPPI_ENDPOINT_SETUP(tep, channel);
+}
+
+void nrfx_gppi_channel_endpoints_setup(uint8_t  channel, uint32_t eep, uint32_t tep)
+{
+    nrfx_gppi_event_endpoint_setup(channel, eep);
+    nrfx_gppi_task_endpoint_setup(channel, tep);
+}
+
+void nrfx_gppi_channel_endpoints_clear(uint8_t channel, uint32_t eep, uint32_t tep)
+{
+    nrfx_gppi_event_endpoint_clear(channel, eep);
+    nrfx_gppi_task_endpoint_clear(channel, tep);
+}
+
+void nrfx_gppi_event_endpoint_clear(uint8_t channel, uint32_t eep)
+{
+    NRFX_ASSERT(eep);
+    (void)channel;
+    NRF_DPPI_ENDPOINT_CLEAR(eep);
+}
+
+void nrfx_gppi_task_endpoint_clear(uint8_t channel, uint32_t tep)
+{
+    NRFX_ASSERT(tep);
+    (void)channel;
+    NRF_DPPI_ENDPOINT_CLEAR(tep);
+}
+
+void nrfx_gppi_fork_endpoint_setup(uint8_t channel, uint32_t fork_tep)
+{
+    nrfx_gppi_task_endpoint_setup(channel, fork_tep);
+}
+
+void nrfx_gppi_fork_endpoint_clear(uint8_t channel, uint32_t fork_tep)
+{
+    nrfx_gppi_task_endpoint_clear(channel, fork_tep);
+}
+
+void nrfx_gppi_channels_include_in_group(uint32_t                  channel_mask,
+                                         nrfx_gppi_channel_group_t channel_group)
+{
+    nrfy_dppi_channels_include_in_group(NRF_DPPIC,
+                                        channel_mask,
+                                        (nrf_dppi_channel_group_t)channel_group);
+}
+
+void nrfx_gppi_channels_remove_from_group(uint32_t                  channel_mask,
+                                          nrfx_gppi_channel_group_t channel_group)
+{
+    nrfy_dppi_channels_remove_from_group(NRF_DPPIC,
+                                         channel_mask,
+                                         (nrf_dppi_channel_group_t)channel_group);
+}
+
+void nrfx_gppi_group_clear(nrfx_gppi_channel_group_t channel_group)
+{
+    nrfy_dppi_group_clear(NRF_DPPIC, (nrf_dppi_channel_group_t)channel_group);
+}
+
+void nrfx_gppi_group_enable(nrfx_gppi_channel_group_t channel_group)
+{
+    nrfy_dppi_group_enable(NRF_DPPIC, (nrf_dppi_channel_group_t)channel_group);
+}
+
+void nrfx_gppi_group_disable(nrfx_gppi_channel_group_t channel_group)
+{
+    nrfy_dppi_group_disable(NRF_DPPIC, (nrf_dppi_channel_group_t)channel_group);
+}
+
+uint32_t nrfx_gppi_task_address_get(nrfx_gppi_task_t gppi_task)
+{
+    return nrfy_dppi_task_address_get(NRF_DPPIC, (nrf_dppi_task_t)gppi_task);
+}
+
+nrfx_gppi_task_t nrfx_gppi_group_disable_task_get(nrfx_gppi_channel_group_t group)
+{
+    return (nrfx_gppi_task_t) nrfy_dppi_group_disable_task_get((uint8_t)group);
+}
+
+nrfx_gppi_task_t nrfx_gppi_group_enable_task_get(nrfx_gppi_channel_group_t group)
+{
+    return (nrfx_gppi_task_t) nrfy_dppi_group_enable_task_get((uint8_t)group);
+}
+
+nrfx_err_t nrfx_gppi_channel_alloc(uint8_t * p_channel)
+{
+#if NRFX_CHECK(NRFX_DPPI_ENABLED) && (!defined(DPPIC_COUNT) || (DPPIC_COUNT == 1))
+    return nrfx_dppi_channel_alloc(p_channel);
+#else
+    (void)p_channel;
+    return NRFX_ERROR_NOT_SUPPORTED;
+#endif
+}
+
+nrfx_err_t nrfx_gppi_channel_free(uint8_t channel)
+{
+#if NRFX_CHECK(NRFX_DPPI_ENABLED) && (!defined(DPPIC_COUNT) || (DPPIC_COUNT == 1))
+    return nrfx_dppi_channel_free(channel);
+#else
+    (void)channel;
+    return NRFX_ERROR_NOT_SUPPORTED;
+#endif
+}
+
+nrfx_err_t nrfx_gppi_group_alloc(nrfx_gppi_channel_group_t * p_group)
+{
+#if NRFX_CHECK(NRFX_DPPI_ENABLED) && (!defined(DPPIC_COUNT) || (DPPIC_COUNT == 1))
+    return nrfx_dppi_group_alloc((nrf_dppi_channel_group_t *)p_group);
+#else
+    (void)p_group;
+    return NRFX_ERROR_NOT_SUPPORTED;
+#endif
+}
+
+nrfx_err_t nrfx_gppi_group_free(nrfx_gppi_channel_group_t group)
+{
+#if NRFX_CHECK(NRFX_DPPI_ENABLED) && (!defined(DPPIC_COUNT) || (DPPIC_COUNT == 1))
+    return nrfx_dppi_group_free((nrf_dppi_channel_group_t)group);
+#else
+    (void)group;
+    return NRFX_ERROR_NOT_SUPPORTED;
+#endif
+}
+#endif // defined(DPPI_PRESENT) && !defined(NRF_DPPI_EXT)

--- a/nrfx/helpers/nrfx_gppi_ppi.c
+++ b/nrfx/helpers/nrfx_gppi_ppi.c
@@ -1,0 +1,199 @@
+/*
+ * Copyright (c) 2022 - 2023, Nordic Semiconductor ASA
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <helpers/nrfx_gppi.h>
+
+#if NRFX_CHECK(NRFX_PPI_ENABLED)
+#include <nrfx_ppi.h>
+#endif
+
+#if defined(PPI_PRESENT)
+
+bool nrfx_gppi_channel_check(uint8_t channel)
+{
+    return (nrf_ppi_channel_enable_get(NRF_PPI, (nrf_ppi_channel_t)channel) ==
+            NRF_PPI_CHANNEL_ENABLED);
+}
+
+void nrfx_gppi_channels_disable_all(void)
+{
+    nrf_ppi_channels_disable_all(NRF_PPI);
+}
+
+void nrfx_gppi_channels_enable(uint32_t mask)
+{
+    nrf_ppi_channels_enable(NRF_PPI, mask);
+}
+
+void nrfx_gppi_channels_disable(uint32_t mask)
+{
+    nrf_ppi_channels_disable(NRF_PPI, mask);
+}
+
+void nrfx_gppi_event_endpoint_setup(uint8_t channel, uint32_t eep)
+{
+    nrf_ppi_event_endpoint_setup(NRF_PPI, (nrf_ppi_channel_t)channel, eep);
+}
+
+void nrfx_gppi_task_endpoint_setup(uint8_t channel, uint32_t tep)
+{
+    nrf_ppi_task_endpoint_setup(NRF_PPI, (nrf_ppi_channel_t)channel, tep);
+}
+
+void nrfx_gppi_channel_endpoints_setup(uint8_t  channel, uint32_t eep, uint32_t tep)
+{
+    nrf_ppi_channel_endpoint_setup(NRF_PPI, (nrf_ppi_channel_t)channel, eep, tep);
+}
+
+void nrfx_gppi_channel_endpoints_clear(uint8_t channel, uint32_t eep, uint32_t tep)
+{
+    nrfx_gppi_event_endpoint_clear(channel, eep);
+    nrfx_gppi_task_endpoint_clear(channel, tep);
+}
+
+void nrfx_gppi_event_endpoint_clear(uint8_t channel, uint32_t eep)
+{
+    (void)eep;
+     nrf_ppi_event_endpoint_setup(NRF_PPI, (nrf_ppi_channel_t)channel, 0);
+}
+
+void nrfx_gppi_task_endpoint_clear(uint8_t channel, uint32_t tep)
+{
+    (void)tep;
+    nrf_ppi_task_endpoint_setup(NRF_PPI, (nrf_ppi_channel_t)channel, 0);
+}
+
+#if defined(PPI_FEATURE_FORKS_PRESENT)
+void nrfx_gppi_fork_endpoint_setup(uint8_t channel, uint32_t fork_tep)
+{
+    nrf_ppi_fork_endpoint_setup(NRF_PPI, (nrf_ppi_channel_t)channel, fork_tep);
+}
+
+void nrfx_gppi_fork_endpoint_clear(uint8_t channel, uint32_t fork_tep)
+{
+    (void)fork_tep;
+    nrf_ppi_fork_endpoint_setup(NRF_PPI, (nrf_ppi_channel_t)channel, 0);
+}
+#endif
+
+void nrfx_gppi_channels_include_in_group(uint32_t                  channel_mask,
+                                         nrfx_gppi_channel_group_t channel_group)
+{
+    nrf_ppi_channels_include_in_group(NRF_PPI,
+                                      channel_mask,
+                                      (nrf_ppi_channel_group_t)channel_group);
+}
+
+void nrfx_gppi_channels_remove_from_group(uint32_t                  channel_mask,
+                                          nrfx_gppi_channel_group_t channel_group)
+{
+    nrf_ppi_channels_remove_from_group(NRF_PPI,
+                                       channel_mask,
+                                       (nrf_ppi_channel_group_t)channel_group);
+}
+
+void nrfx_gppi_group_clear(nrfx_gppi_channel_group_t channel_group)
+{
+    nrf_ppi_group_clear(NRF_PPI, (nrf_ppi_channel_group_t)channel_group);
+}
+
+void nrfx_gppi_group_enable(nrfx_gppi_channel_group_t channel_group)
+{
+    nrf_ppi_group_enable(NRF_PPI, (nrf_ppi_channel_group_t)channel_group);
+}
+
+void nrfx_gppi_group_disable(nrfx_gppi_channel_group_t channel_group)
+{
+    nrf_ppi_group_disable(NRF_PPI, (nrf_ppi_channel_group_t)channel_group);
+}
+
+void nrfx_gppi_task_trigger(nrfx_gppi_task_t task)
+{
+    nrf_ppi_task_trigger(NRF_PPI, (nrf_ppi_task_t)task);
+}
+
+uint32_t nrfx_gppi_task_address_get(nrfx_gppi_task_t task)
+{
+    return (uint32_t)nrf_ppi_task_address_get(NRF_PPI, (nrf_ppi_task_t)task);
+}
+
+nrfx_gppi_task_t nrfx_gppi_group_disable_task_get(nrfx_gppi_channel_group_t group)
+{
+    return (nrfx_gppi_task_t)nrf_ppi_group_disable_task_get(NRF_PPI, (uint8_t)group);
+}
+
+nrfx_gppi_task_t nrfx_gppi_group_enable_task_get(nrfx_gppi_channel_group_t group)
+{
+    return (nrfx_gppi_task_t)nrf_ppi_group_enable_task_get(NRF_PPI, (uint8_t)group);
+}
+
+nrfx_err_t nrfx_gppi_channel_alloc(uint8_t * p_channel)
+{
+#if NRFX_CHECK(NRFX_PPI_ENABLED)
+    return nrfx_ppi_channel_alloc((nrf_ppi_channel_t *)p_channel);
+#else
+    (void)p_channel;
+    return NRFX_ERROR_NOT_SUPPORTED;
+#endif
+}
+
+nrfx_err_t nrfx_gppi_channel_free(uint8_t channel)
+{
+#if NRFX_CHECK(NRFX_PPI_ENABLED)
+    return nrfx_ppi_channel_free((nrf_ppi_channel_t)channel);
+#else
+    (void)channel;
+    return NRFX_ERROR_NOT_SUPPORTED;
+#endif
+}
+
+nrfx_err_t nrfx_gppi_group_alloc(nrfx_gppi_channel_group_t * p_group)
+{
+#if NRFX_CHECK(NRFX_PPI_ENABLED)
+    return nrfx_ppi_group_alloc((nrf_ppi_channel_group_t *)p_group);
+#else
+    (void)p_group;
+    return NRFX_ERROR_NOT_SUPPORTED;
+#endif
+}
+
+nrfx_err_t nrfx_gppi_group_free(nrfx_gppi_channel_group_t group)
+{
+#if NRFX_CHECK(NRFX_PPI_ENABLED)
+    return nrfx_ppi_group_free((nrf_ppi_channel_group_t)group);
+#else
+    (void)group;
+    return NRFX_ERROR_NOT_SUPPORTED;
+#endif
+}
+#endif // defined(PPI_PRESENT)

--- a/nrfx/nrfx.h
+++ b/nrfx/nrfx.h
@@ -38,6 +38,7 @@
 #include <drivers/nrfx_common.h>
 #include <nrfx_glue.h>
 #include <hal/nrf_common.h>
+#include <haly/nrfy_common.h>
 #include <drivers/nrfx_errors.h>
 
 #endif // NRFX_H__

--- a/nrfx/samples/CHANGELOG.md
+++ b/nrfx/samples/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 All notable changes to this project are documented in this file.
 
+## [3.0.0] - 2023-04-21
+### Changed
+- Applied nrfx 3.0 changes to existing samples for the following drivers: GPPI, SAADC, SPIM, TIMER, TWIM, TWIS.
+- Removed support for the nRF5340 in the maximum performance SAADC sample.
+
 ## [2.11.0] - 2023-04-07
 ### Added
 - Added `pinctrl` definitions to align with pin handling changes introduced in the Zephyr RTOS. Pins utilized by samples are still defined through symbols from the `nrfx_examples.h` file.

--- a/nrfx/samples/doc/nrfx_examples.doxyfile
+++ b/nrfx/samples/doc/nrfx_examples.doxyfile
@@ -50,7 +50,7 @@ PROJECT_NAME           = "nrfx-examples"
 
 ### EDIT THIS ###
 
-PROJECT_NUMBER         = "2.11"
+PROJECT_NUMBER         = "3.0"
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/nrfx/samples/src/nrfx_gppi/fork/main.c
+++ b/nrfx/samples/src/nrfx_gppi/fork/main.c
@@ -162,7 +162,8 @@ int main(void)
     nrfx_gpiote_out_task_enable(OUTPUT_PIN_FORK);
 
     nrfx_timer_t timer_inst = NRFX_TIMER_INSTANCE(TIMER_INST_IDX);
-    nrfx_timer_config_t timer_config = NRFX_TIMER_DEFAULT_CONFIG;
+    uint32_t base_frequency = NRF_TIMER_BASE_FREQUENCY_GET(timer_inst.p_reg);
+    nrfx_timer_config_t timer_config = NRFX_TIMER_DEFAULT_CONFIG(base_frequency);
     timer_config.bit_width = NRF_TIMER_BIT_WIDTH_32;
     timer_config.p_context = "Some context";
 
@@ -192,14 +193,14 @@ int main(void)
     */
     nrfx_gppi_channel_endpoints_setup(gppi_channel,
         nrfx_timer_compare_event_address_get(&timer_inst, NRF_TIMER_CC_CHANNEL0),
-        nrfx_gpiote_out_task_addr_get(OUTPUT_PIN_PRIMARY));
+        nrfx_gpiote_out_task_address_get(OUTPUT_PIN_PRIMARY));
 
     /*
      * Set up the task endpoint for a given PPI fork or for associating the DPPI channel
      * with an additional task register depending on which driver the GPPI helper is using.
     */
     nrfx_gppi_fork_endpoint_setup(gppi_channel,
-                                  nrfx_gpiote_out_task_addr_get(OUTPUT_PIN_FORK));
+                                  nrfx_gpiote_out_task_address_get(OUTPUT_PIN_FORK));
 
     nrfx_gppi_channels_enable(BIT(gppi_channel));
 

--- a/nrfx/samples/src/nrfx_gppi/one_to_one/main.c
+++ b/nrfx/samples/src/nrfx_gppi/one_to_one/main.c
@@ -136,7 +136,8 @@ int main(void)
     nrfx_gpiote_out_task_enable(OUTPUT_PIN);
 
     nrfx_timer_t timer_inst = NRFX_TIMER_INSTANCE(TIMER_INST_IDX);
-    nrfx_timer_config_t timer_config = NRFX_TIMER_DEFAULT_CONFIG;
+    uint32_t base_frequency = NRF_TIMER_BASE_FREQUENCY_GET(timer_inst.p_reg);
+    nrfx_timer_config_t timer_config = NRFX_TIMER_DEFAULT_CONFIG(base_frequency);
     timer_config.bit_width = NRF_TIMER_BIT_WIDTH_32;
     timer_config.p_context = "Some context";
 
@@ -166,7 +167,7 @@ int main(void)
      */
     nrfx_gppi_channel_endpoints_setup(gppi_channel,
         nrfx_timer_compare_event_address_get(&timer_inst, NRF_TIMER_CC_CHANNEL0),
-        nrfx_gpiote_out_task_addr_get(OUTPUT_PIN));
+        nrfx_gpiote_out_task_address_get(OUTPUT_PIN));
 
     nrfx_gppi_channels_enable(BIT(gppi_channel));
 

--- a/nrfx/samples/src/nrfx_saadc/common/saadc_examples_common.c
+++ b/nrfx/samples/src/nrfx_saadc/common/saadc_examples_common.c
@@ -78,7 +78,7 @@ void pin_on_event_toggle_setup(nrfx_gpiote_pin_t pin,
     status = nrfx_gppi_channel_alloc(&gppi_channel);
     NRFX_ASSERT(status == NRFX_SUCCESS);
 
-    nrfx_gppi_channel_endpoints_setup(gppi_channel, eep, nrfx_gpiote_out_task_addr_get(pin));
+    nrfx_gppi_channel_endpoints_setup(gppi_channel, eep, nrfx_gpiote_out_task_address_get(pin));
 
     nrfx_gppi_channels_enable(NRFX_BIT(gppi_channel));
 }

--- a/nrfx/samples/src/nrfx_saadc/maximum_performance/README.md
+++ b/nrfx/samples/src/nrfx_saadc/maximum_performance/README.md
@@ -11,7 +11,7 @@ The sample supports the following development kits:
 | nrf52dk_nrf52832    |      No     |
 | nrf52833dk_nrf52833 |     Yes     |
 | nrf52840dk_nrf52840 |     Yes     |
-| nrf5340dk_nrf5340   |     Yes     |
+| nrf5340dk_nrf5340   |     No      |
 | nrf9160dk_nrf9160   |     Yes     |
 
 ## Overview

--- a/nrfx/samples/src/nrfx_saadc/maximum_performance/main.c
+++ b/nrfx/samples/src/nrfx_saadc/maximum_performance/main.c
@@ -226,7 +226,8 @@ int main(void)
     NRFX_ASSERT(status == NRFX_SUCCESS);
 
     nrfx_timer_t timer_inst = NRFX_TIMER_INSTANCE(TIMER_INST_IDX);
-    nrfx_timer_config_t timer_config = NRFX_TIMER_DEFAULT_CONFIG;
+    uint32_t base_frequency = NRF_TIMER_BASE_FREQUENCY_GET(timer_inst.p_reg);
+    nrfx_timer_config_t timer_config = NRFX_TIMER_DEFAULT_CONFIG(base_frequency);
     timer_config.bit_width = NRF_TIMER_BIT_WIDTH_32;
     timer_config.p_context = &timer_inst;
 

--- a/nrfx/samples/src/nrfx_saadc/maximum_performance/sample.yaml
+++ b/nrfx/samples/src/nrfx_saadc/maximum_performance/sample.yaml
@@ -7,11 +7,10 @@ tests:
     filter: dt_compat_enabled("nordic,nrf-saadc")
     platform_allow: |
       nrf52833dk_nrf52833 nrf52840dk_nrf52840
-      nrf5340dk_nrf5340_cpuapp nrf9160dk_nrf9160
+      nrf9160dk_nrf9160
     integration_platforms:
       - nrf52833dk_nrf52833
       - nrf52840dk_nrf52840
-      - nrf5340dk_nrf5340_cpuapp
       - nrf9160dk_nrf9160
     harness: console
     harness_config:

--- a/nrfx/samples/src/nrfx_spim/blocking/main.c
+++ b/nrfx/samples/src/nrfx_spim/blocking/main.c
@@ -92,7 +92,7 @@ int main(void)
     nrfx_spim_config_t spim_config = NRFX_SPIM_DEFAULT_CONFIG(SCK_PIN,
                                                               MOSI_PIN,
                                                               MISO_PIN,
-                                                              NRFX_SPIM_PIN_NOT_USED);
+                                                              NRF_SPIM_PIN_NOT_CONNECTED);
 
     status = nrfx_spim_init(&spim_inst, &spim_config, NULL, NULL);
     NRFX_ASSERT(status == NRFX_SUCCESS);

--- a/nrfx/samples/src/nrfx_spim/non_blocking/main.c
+++ b/nrfx/samples/src/nrfx_spim/non_blocking/main.c
@@ -108,7 +108,7 @@ int main(void)
     nrfx_spim_config_t spim_config = NRFX_SPIM_DEFAULT_CONFIG(SCK_PIN,
                                                               MOSI_PIN,
                                                               MISO_PIN,
-                                                              NRFX_SPIM_PIN_NOT_USED);
+                                                              NRF_SPIM_PIN_NOT_CONNECTED);
 
     void * p_context = "Some context";
     status = nrfx_spim_init(&spim_inst, &spim_config, spim_handler, p_context);

--- a/nrfx/samples/src/nrfx_timer/counter/main.c
+++ b/nrfx/samples/src/nrfx_timer/counter/main.c
@@ -128,16 +128,19 @@ int main(void)
 
     /* Configuring timer instances, one in timer mode and one in counter mode.
      * Assigning their own addresses to p_context variable - in order to reference them
-     * in timer_handler() function.
+     * in timer_handler() function. Setting frequency to the base frequency value of the
+     * specified timer instance.
      */
     nrfx_timer_t timer_t_inst = NRFX_TIMER_INSTANCE(TIMER_T_INST_IDX);
-    nrfx_timer_config_t config = NRFX_TIMER_DEFAULT_CONFIG;
+    uint32_t base_frequency = NRF_TIMER_BASE_FREQUENCY_GET(timer_t_inst.p_reg);
+    nrfx_timer_config_t config = NRFX_TIMER_DEFAULT_CONFIG(base_frequency);
     config.bit_width = NRF_TIMER_BIT_WIDTH_32;
     config.p_context = &timer_t_inst;
     status = nrfx_timer_init(&timer_t_inst, &config, timer_handler);
     NRFX_ASSERT(status == NRFX_SUCCESS);
 
     nrfx_timer_t timer_c_inst = NRFX_TIMER_INSTANCE(TIMER_C_INST_IDX);
+    config.frequency = NRF_TIMER_BASE_FREQUENCY_GET(timer_c_inst.p_reg);
     config.mode = NRF_TIMER_MODE_COUNTER;
     config.p_context = &timer_c_inst;
     status = nrfx_timer_init(&timer_c_inst, &config, timer_handler);

--- a/nrfx/samples/src/nrfx_timer/timer/main.c
+++ b/nrfx/samples/src/nrfx_timer/timer/main.c
@@ -90,8 +90,8 @@ int main(void)
     NRFX_EXAMPLE_LOG_PROCESS();
 
     nrfx_timer_t timer_inst = NRFX_TIMER_INSTANCE(TIMER_INST_IDX);
-
-    nrfx_timer_config_t config = NRFX_TIMER_DEFAULT_CONFIG;
+    uint32_t base_frequency = NRF_TIMER_BASE_FREQUENCY_GET(timer_inst.p_reg);
+    nrfx_timer_config_t config = NRFX_TIMER_DEFAULT_CONFIG(base_frequency);
     config.bit_width = NRF_TIMER_BIT_WIDTH_32;
     config.p_context = "Some context";
 

--- a/nrfx/samples/src/nrfx_twim_twis/tx_rx_blocking/main.c
+++ b/nrfx/samples/src/nrfx_twim_twis/tx_rx_blocking/main.c
@@ -139,6 +139,7 @@ int main(void)
 
     twim_xfer_desc.type = NRFX_TWIM_XFER_RX;
     twim_xfer_desc.p_primary_buf = m_rx_buffer_master;
+    twim_xfer_desc.primary_length = sizeof(m_rx_buffer_master);
 
     status = nrfx_twis_tx_prepare(&twis_inst, m_rx_buffer_slave, sizeof(m_rx_buffer_slave));
     NRFX_ASSERT(status == NRFX_SUCCESS);

--- a/nrfx/samples/src/nrfx_twim_twis/tx_rx_non_blocking/main.c
+++ b/nrfx/samples/src/nrfx_twim_twis/tx_rx_non_blocking/main.c
@@ -121,6 +121,7 @@ static void twim_handler(nrfx_twim_evt_t const * p_event, void * p_context)
         NRFX_LOG_INFO("--> Master event: done - transfer completed");
         twim_desc->type = NRFX_TWIM_XFER_RX;
         twim_desc->p_primary_buf = m_rx_buffer_master;
+        twim_desc->primary_length = sizeof(m_rx_buffer_master);
 
         if (!m_master_done)
         {

--- a/nrfx/samples/src/nrfx_uarte/rx_double_buffered/main.c
+++ b/nrfx/samples/src/nrfx_uarte/rx_double_buffered/main.c
@@ -147,7 +147,7 @@ static void uarte_handler(nrfx_uarte_event_t const * p_event, void * p_context)
     if (p_event->type == NRFX_UARTE_EVT_TX_DONE)
     {
         NRFX_LOG_INFO("--> TX done");
-        NRFX_LOG_INFO("--> Bytes transfered: %u", p_event->data.error.rxtx.bytes);
+        NRFX_LOG_INFO("--> Bytes transfered: %u", p_event->data.tx.bytes);
         nrfx_uarte_uninit(p_inst);
     }
 }
@@ -191,7 +191,7 @@ int main(void)
                            NRFX_ARRAY_SIZE(m_rx_buffers.buff_1) - 1);
     NRFX_ASSERT(status == NRFX_SUCCESS);
 
-    status = nrfx_uarte_tx(&uarte_inst, m_tx_buffer, NRFX_ARRAY_SIZE(m_tx_buffer));
+    status = nrfx_uarte_tx(&uarte_inst, m_tx_buffer, NRFX_ARRAY_SIZE(m_tx_buffer), 0);
     NRFX_ASSERT(status == NRFX_SUCCESS);
 
     while (nrfx_uarte_tx_in_progress(&uarte_inst))

--- a/nrfx/samples/src/nrfx_uarte/tx_rx_non_blocking/main.c
+++ b/nrfx/samples/src/nrfx_uarte/tx_rx_non_blocking/main.c
@@ -130,7 +130,7 @@ int main(void)
     status = nrfx_uarte_rx(&uarte_inst, m_rx_buffer, sizeof(m_rx_buffer));
     NRFX_ASSERT(status == NRFX_SUCCESS);
 
-    status = nrfx_uarte_tx(&uarte_inst, m_tx_buffer, sizeof(m_tx_buffer));
+    status = nrfx_uarte_tx(&uarte_inst, m_tx_buffer, sizeof(m_tx_buffer), 0);
     NRFX_ASSERT(status == NRFX_SUCCESS);
 
     while (1)

--- a/nrfx/templates/nrfx_config.h
+++ b/nrfx/templates/nrfx_config.h
@@ -58,7 +58,7 @@
 #elif defined(NRF9120_XXAA) || defined(NRF9160_XXAA)
     #include <nrfx_config_nrf91.h>
 #else
-    #error "Unknown device."
+    #include "nrfx_config_ext.h"
 #endif
 
 #endif // NRFX_CONFIG_H__

--- a/nrfx/templates/nrfx_config_common.h
+++ b/nrfx/templates/nrfx_config_common.h
@@ -38,20 +38,19 @@
 #error "This file should not be included directly. Include nrfx_config.h instead."
 #endif
 
+/** @brief Symbol specifying major version of the nrfx API to be used. */
+#ifndef NRFX_CONFIG_API_VER_MAJOR
+#define NRFX_CONFIG_API_VER_MAJOR 3
+#endif
 
-// <i> NRFX API version 2.9 flag.
-#define NRFX_CONFIG_API_VER_2_9 1
+/** @brief Symbol specifying minor version of the nrfx API to be used. */
+#ifndef NRFX_CONFIG_API_VER_MINOR
+#define NRFX_CONFIG_API_VER_MINOR 0
+#endif
 
-// <i> NRFX API version 2.10 flag.
-/* When this flag is set the following changes to the nrfx API will be introduced:
- *
- * 1. IPC driver:
- *  - Change input parameters for @ref nrfx_ipc_handler_t
- *  - Rename function **nrfx_ipc_mem_get** to **nrfx_ipc_gpmem_get**.
- */
-#define NRFX_CONFIG_API_VER_2_10 0
-
-// <i> NRFX API version 2.11 flag.
-#define NRFX_CONFIG_API_VER_2_11 0
+/** @brief Symbol specifying micro version of the nrfx API to be used. */
+#ifndef NRFX_CONFIG_API_VER_MICRO
+#define NRFX_CONFIG_API_VER_MICRO 0
+#endif
 
 #endif /* NRFX_CONFIG_COMMON_H__ */

--- a/nrfx/templates/nrfx_config_ext.h
+++ b/nrfx/templates/nrfx_config_ext.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2023, Nordic Semiconductor ASA
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef NRFX_CONFIG_EXT_H__
+#define NRFX_CONFIG_EXT_H__
+
+#error "Unknown device."
+
+#endif // NRFX_CONFIG_EXT_H__

--- a/nrfx/templates/nrfx_config_nrf51.h
+++ b/nrfx/templates/nrfx_config_nrf51.h
@@ -38,1212 +38,810 @@
 #error "This file should not be included directly. Include nrfx_config.h instead."
 #endif
 
-// <<< Use Configuration Wizard in Context Menu >>>\n
 
-// <h> nRF_Drivers
+/**
+ * @brief NRFX_DEFAULT_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 3
+ */
+#ifndef NRFX_DEFAULT_IRQ_PRIORITY
+#define NRFX_DEFAULT_IRQ_PRIORITY 3
+#endif
 
-// <e> NRFX_ADC_ENABLED - nrfx_adc - ADC peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_ADC_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_ADC_ENABLED
 #define NRFX_ADC_ENABLED 0
 #endif
-// <o> NRFX_ADC_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
 
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-
+/**
+ * @brief NRFX_ADC_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 3
+ */
 #ifndef NRFX_ADC_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_ADC_DEFAULT_CONFIG_IRQ_PRIORITY 3
+#define NRFX_ADC_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_ADC_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_ADC_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_ADC_CONFIG_LOG_ENABLED
 #define NRFX_ADC_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_ADC_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_ADC_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_ADC_CONFIG_LOG_LEVEL
 #define NRFX_ADC_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_ADC_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_ADC_CONFIG_INFO_COLOR
-#define NRFX_ADC_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_ADC_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_ADC_CONFIG_DEBUG_COLOR
-#define NRFX_ADC_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_CLOCK_ENABLED - nrfx_clock - CLOCK peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_CLOCK_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_CLOCK_ENABLED
 #define NRFX_CLOCK_ENABLED 0
 #endif
-// <o> NRFX_CLOCK_CONFIG_LF_SRC  - LF Clock Source
 
-// <0=> RC
-// <1=> XTAL
-// <2=> Synth
-
+/**
+ * @brief NRFX_CLOCK_CONFIG_LF_SRC
+ *
+ * Integer value.
+ * Supported values:
+ * - RC    = 0
+ * - XTAL  = 1
+ * - Synth = 2
+ */
 #ifndef NRFX_CLOCK_CONFIG_LF_SRC
 #define NRFX_CLOCK_CONFIG_LF_SRC 1
 #endif
 
-// <q> NRFX_CLOCK_CONFIG_LF_CAL_ENABLED  - Enables LF Clock Calibration Support
-
-#ifndef NRFX_CLOCK_CONFIG_LF_CAL_ENABLED
-#define NRFX_CLOCK_CONFIG_LF_CAL_ENABLED 0
-#endif
-
-// <q> NRFX_CLOCK_CONFIG_CT_ENABLED  - Enables Calibration Timer Support
-
-#ifndef NRFX_CLOCK_CONFIG_CT_ENABLED
-#define NRFX_CLOCK_CONFIG_CT_ENABLED 1
-#endif
-
-// <q> NRFX_CLOCK_CONFIG_LFXO_TWO_STAGE_ENABLED - Enables two-stage LFXO start procedure
-
-// <i> If set to a non-zero value, LFRC will be started before LFXO and corresponding
-// <i> event will be generated. It means that CPU will be woken up when LFRC
-// <i> oscillator starts, but user callback will be invoked only after LFXO
-// <i> finally starts.
-
+/**
+ * @brief NRFX_CLOCK_CONFIG_LFXO_TWO_STAGE_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_CLOCK_CONFIG_LFXO_TWO_STAGE_ENABLED
 #define NRFX_CLOCK_CONFIG_LFXO_TWO_STAGE_ENABLED 0
 #endif
 
-// <o> NRFX_CLOCK_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-
+/**
+ * @brief NRFX_CLOCK_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 3
+ */
 #ifndef NRFX_CLOCK_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_CLOCK_DEFAULT_CONFIG_IRQ_PRIORITY 3
+#define NRFX_CLOCK_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_CLOCK_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_CLOCK_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_CLOCK_CONFIG_LOG_ENABLED
 #define NRFX_CLOCK_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_CLOCK_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_CLOCK_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_CLOCK_CONFIG_LOG_LEVEL
 #define NRFX_CLOCK_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_CLOCK_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_CLOCK_CONFIG_INFO_COLOR
-#define NRFX_CLOCK_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_CLOCK_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_CLOCK_CONFIG_DEBUG_COLOR
-#define NRFX_CLOCK_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_GPIOTE_ENABLED - nrfx_gpiote - GPIOTE peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_GPIOTE_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_GPIOTE_ENABLED
 #define NRFX_GPIOTE_ENABLED 0
 #endif
 
-// <o> NRFX_GPIOTE_CONFIG_NUM_OF_EVT_HANDLERS - Number of dedicated handlers
+/**
+ * @brief NRFX_GPIOTE_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 3
+ */
+#ifndef NRFX_GPIOTE_DEFAULT_CONFIG_IRQ_PRIORITY
+#define NRFX_GPIOTE_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
+#endif
+
+/**
+ * @brief NRFX_GPIOTE_CONFIG_NUM_OF_EVT_HANDLERS
+ *
+ * Integer value. Minimum: 0 Maximum: 15
+ */
 #ifndef NRFX_GPIOTE_CONFIG_NUM_OF_EVT_HANDLERS
 #define NRFX_GPIOTE_CONFIG_NUM_OF_EVT_HANDLERS 2
 #endif
 
-// <o> NRFX_GPIOTE_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-
-#ifndef NRFX_GPIOTE_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_GPIOTE_DEFAULT_CONFIG_IRQ_PRIORITY 3
-#endif
-
-// <e> NRFX_GPIOTE_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_GPIOTE_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_GPIOTE_CONFIG_LOG_ENABLED
 #define NRFX_GPIOTE_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_GPIOTE_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_GPIOTE_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_GPIOTE_CONFIG_LOG_LEVEL
 #define NRFX_GPIOTE_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_GPIOTE_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_GPIOTE_CONFIG_INFO_COLOR
-#define NRFX_GPIOTE_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_GPIOTE_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_GPIOTE_CONFIG_DEBUG_COLOR
-#define NRFX_GPIOTE_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_LPCOMP_ENABLED - nrfx_lpcomp - LPCOMP peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_LPCOMP_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_LPCOMP_ENABLED
 #define NRFX_LPCOMP_ENABLED 0
 #endif
 
-// <o> NRFX_LPCOMP_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-
+/**
+ * @brief NRFX_LPCOMP_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 3
+ */
 #ifndef NRFX_LPCOMP_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_LPCOMP_DEFAULT_CONFIG_IRQ_PRIORITY 3
+#define NRFX_LPCOMP_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_LPCOMP_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_LPCOMP_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_LPCOMP_CONFIG_LOG_ENABLED
 #define NRFX_LPCOMP_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_LPCOMP_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_LPCOMP_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_LPCOMP_CONFIG_LOG_LEVEL
 #define NRFX_LPCOMP_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_LPCOMP_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_LPCOMP_CONFIG_INFO_COLOR
-#define NRFX_LPCOMP_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_LPCOMP_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_LPCOMP_CONFIG_DEBUG_COLOR
-#define NRFX_LPCOMP_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_NVMC_ENABLED - nrfx_nvmc - NVMC peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_NVMC_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_NVMC_ENABLED
 #define NRFX_NVMC_ENABLED 0
 #endif
 
-// </e>
-
-// <e> NRFX_POWER_ENABLED - nrfx_power - POWER peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_POWER_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_POWER_ENABLED
 #define NRFX_POWER_ENABLED 0
 #endif
-// <o> NRFX_POWER_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
 
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-
+/**
+ * @brief NRFX_POWER_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 3
+ */
 #ifndef NRFX_POWER_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_POWER_DEFAULT_CONFIG_IRQ_PRIORITY 3
+#define NRFX_POWER_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// </e>
-
-// <e> NRFX_PPI_ENABLED - nrfx_ppi - PPI peripheral allocator
-//==========================================================
+/**
+ * @brief NRFX_PPI_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_PPI_ENABLED
 #define NRFX_PPI_ENABLED 0
 #endif
-// <e> NRFX_PPI_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+
+/**
+ * @brief NRFX_PPI_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_PPI_CONFIG_LOG_ENABLED
 #define NRFX_PPI_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_PPI_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_PPI_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_PPI_CONFIG_LOG_LEVEL
 #define NRFX_PPI_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_PPI_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_PPI_CONFIG_INFO_COLOR
-#define NRFX_PPI_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_PPI_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_PPI_CONFIG_DEBUG_COLOR
-#define NRFX_PPI_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_PRS_ENABLED - nrfx_prs - Peripheral Resource Sharing module
-//==========================================================
-#ifndef NRFX_PRS_ENABLED
-#define NRFX_PRS_ENABLED 0
-#endif
-// <q> NRFX_PRS_BOX_0_ENABLED  - Enables box 0 in the module.
-
-
-#ifndef NRFX_PRS_BOX_0_ENABLED
-#define NRFX_PRS_BOX_0_ENABLED 0
-#endif
-
-// <q> NRFX_PRS_BOX_1_ENABLED  - Enables box 1 in the module.
-
-
-#ifndef NRFX_PRS_BOX_1_ENABLED
-#define NRFX_PRS_BOX_1_ENABLED 0
-#endif
-
-// <e> NRFX_PRS_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
-#ifndef NRFX_PRS_CONFIG_LOG_ENABLED
-#define NRFX_PRS_CONFIG_LOG_ENABLED 0
-#endif
-// <o> NRFX_PRS_CONFIG_LOG_LEVEL  - Default Severity level
-
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
-#ifndef NRFX_PRS_CONFIG_LOG_LEVEL
-#define NRFX_PRS_CONFIG_LOG_LEVEL 3
-#endif
-
-// <o> NRFX_PRS_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_PRS_CONFIG_INFO_COLOR
-#define NRFX_PRS_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_PRS_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_PRS_CONFIG_DEBUG_COLOR
-#define NRFX_PRS_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_QDEC_ENABLED - nrfx_qdec - QDEC peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_QDEC_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_QDEC_ENABLED
 #define NRFX_QDEC_ENABLED 0
 #endif
 
-// <o> NRFX_QDEC_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-
+/**
+ * @brief NRFX_QDEC_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 3
+ */
 #ifndef NRFX_QDEC_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_QDEC_DEFAULT_CONFIG_IRQ_PRIORITY 3
+#define NRFX_QDEC_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_QDEC_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_QDEC_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_QDEC_CONFIG_LOG_ENABLED
 #define NRFX_QDEC_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_QDEC_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_QDEC_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_QDEC_CONFIG_LOG_LEVEL
 #define NRFX_QDEC_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_QDEC_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_QDEC_CONFIG_INFO_COLOR
-#define NRFX_QDEC_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_QDEC_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_QDEC_CONFIG_DEBUG_COLOR
-#define NRFX_QDEC_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_RNG_ENABLED - nrfx_rng - RNG peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_RNG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_RNG_ENABLED
 #define NRFX_RNG_ENABLED 0
 #endif
 
-// <o> NRFX_RNG_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-
+/**
+ * @brief NRFX_RNG_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 3
+ */
 #ifndef NRFX_RNG_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_RNG_DEFAULT_CONFIG_IRQ_PRIORITY 3
+#define NRFX_RNG_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_RNG_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_RNG_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_RNG_CONFIG_LOG_ENABLED
 #define NRFX_RNG_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_RNG_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_RNG_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_RNG_CONFIG_LOG_LEVEL
 #define NRFX_RNG_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_RNG_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_RNG_CONFIG_INFO_COLOR
-#define NRFX_RNG_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_RNG_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_RNG_CONFIG_DEBUG_COLOR
-#define NRFX_RNG_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_RTC_ENABLED - nrfx_rtc - RTC peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_RTC_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_RTC_ENABLED
 #define NRFX_RTC_ENABLED 0
 #endif
-// <q> NRFX_RTC0_ENABLED  - Enable RTC0 instance
 
-#ifndef NRFX_RTC0_ENABLED
-#define NRFX_RTC0_ENABLED 0
-#endif
-
-// <q> NRFX_RTC1_ENABLED  - Enable RTC1 instance
-
-#ifndef NRFX_RTC1_ENABLED
-#define NRFX_RTC1_ENABLED 0
-#endif
-
-// <o> NRFX_RTC_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-
+/**
+ * @brief NRFX_RTC_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 3
+ */
 #ifndef NRFX_RTC_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_RTC_DEFAULT_CONFIG_IRQ_PRIORITY 3
+#define NRFX_RTC_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_RTC_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_RTC_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_RTC_CONFIG_LOG_ENABLED
 #define NRFX_RTC_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_RTC_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_RTC_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_RTC_CONFIG_LOG_LEVEL
 #define NRFX_RTC_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_RTC_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_RTC_CONFIG_INFO_COLOR
-#define NRFX_RTC_CONFIG_INFO_COLOR 0
+/**
+ * @brief NRFX_RTC0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_RTC0_ENABLED
+#define NRFX_RTC0_ENABLED 0
 #endif
 
-// <o> NRFX_RTC_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_RTC_CONFIG_DEBUG_COLOR
-#define NRFX_RTC_CONFIG_DEBUG_COLOR 0
+/**
+ * @brief NRFX_RTC1_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_RTC1_ENABLED
+#define NRFX_RTC1_ENABLED 0
 #endif
 
-// </e>
-
-// </e>
-
-// <e> NRFX_SPIS_ENABLED - nrfx_spis - SPIS peripheral driver
-//==========================================================
-#ifndef NRFX_SPIS_ENABLED
-#define NRFX_SPIS_ENABLED 0
-#endif
-// <q> NRFX_SPIS1_ENABLED  - Enable SPIS1 instance
-
-
-#ifndef NRFX_SPIS1_ENABLED
-#define NRFX_SPIS1_ENABLED 0
-#endif
-
-// <o> NRFX_SPIS_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-
-#ifndef NRFX_SPIS_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_SPIS_DEFAULT_CONFIG_IRQ_PRIORITY 3
-#endif
-
-// <e> NRFX_SPIS_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
-#ifndef NRFX_SPIS_CONFIG_LOG_ENABLED
-#define NRFX_SPIS_CONFIG_LOG_ENABLED 0
-#endif
-// <o> NRFX_SPIS_CONFIG_LOG_LEVEL  - Default Severity level
-
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
-#ifndef NRFX_SPIS_CONFIG_LOG_LEVEL
-#define NRFX_SPIS_CONFIG_LOG_LEVEL 3
-#endif
-
-// <o> NRFX_SPIS_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_SPIS_CONFIG_INFO_COLOR
-#define NRFX_SPIS_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_SPIS_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_SPIS_CONFIG_DEBUG_COLOR
-#define NRFX_SPIS_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_SPI_ENABLED - nrfx_spi - SPI peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_SPI_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_SPI_ENABLED
 #define NRFX_SPI_ENABLED 0
 #endif
-// <q> NRFX_SPI0_ENABLED  - Enable SPI0 instance
 
-
-#ifndef NRFX_SPI0_ENABLED
-#define NRFX_SPI0_ENABLED 0
-#endif
-
-// <q> NRFX_SPI1_ENABLED  - Enable SPI1 instance
-
-
-#ifndef NRFX_SPI1_ENABLED
-#define NRFX_SPI1_ENABLED 0
-#endif
-
-// <o> NRFX_SPI_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-
+/**
+ * @brief NRFX_SPI_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 3
+ */
 #ifndef NRFX_SPI_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_SPI_DEFAULT_CONFIG_IRQ_PRIORITY 3
+#define NRFX_SPI_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_SPI_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_SPI_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_SPI_CONFIG_LOG_ENABLED
 #define NRFX_SPI_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_SPI_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_SPI_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_SPI_CONFIG_LOG_LEVEL
 #define NRFX_SPI_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_SPI_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_SPI_CONFIG_INFO_COLOR
-#define NRFX_SPI_CONFIG_INFO_COLOR 0
+/**
+ * @brief NRFX_SPI0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPI0_ENABLED
+#define NRFX_SPI0_ENABLED 0
 #endif
 
-// <o> NRFX_SPI_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_SPI_CONFIG_DEBUG_COLOR
-#define NRFX_SPI_CONFIG_DEBUG_COLOR 0
+/**
+ * @brief NRFX_SPI1_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPI1_ENABLED
+#define NRFX_SPI1_ENABLED 0
 #endif
 
-// </e>
+/**
+ * @brief NRFX_SPIS_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPIS_ENABLED
+#define NRFX_SPIS_ENABLED 0
+#endif
 
-// </e>
+/**
+ * @brief NRFX_SPIS_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 3
+ */
+#ifndef NRFX_SPIS_DEFAULT_CONFIG_IRQ_PRIORITY
+#define NRFX_SPIS_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
+#endif
 
-// <e> NRFX_TEMP_ENABLED - nrfx_temp - TEMP peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_SPIS_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPIS_CONFIG_LOG_ENABLED
+#define NRFX_SPIS_CONFIG_LOG_ENABLED 0
+#endif
+
+/**
+ * @brief NRFX_SPIS_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
+#ifndef NRFX_SPIS_CONFIG_LOG_LEVEL
+#define NRFX_SPIS_CONFIG_LOG_LEVEL 3
+#endif
+
+/**
+ * @brief NRFX_SPIS1_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPIS1_ENABLED
+#define NRFX_SPIS1_ENABLED 0
+#endif
+
+/**
+ * @brief NRFX_SYSTICK_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SYSTICK_ENABLED
+#define NRFX_SYSTICK_ENABLED 0
+#endif
+
+/**
+ * @brief NRFX_TEMP_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_TEMP_ENABLED
 #define NRFX_TEMP_ENABLED 0
 #endif
 
-// <o> NRFX_TEMP_DEFAULT_CONFIG_IRQ_PRIORITY - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-
+/**
+ * @brief NRFX_TEMP_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 3
+ */
 #ifndef NRFX_TEMP_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_TEMP_DEFAULT_CONFIG_IRQ_PRIORITY 3
+#define NRFX_TEMP_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// </e>
+/**
+ * @brief NRFX_TEMP_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TEMP_CONFIG_LOG_ENABLED
+#define NRFX_TEMP_CONFIG_LOG_ENABLED 0
+#endif
 
-// <e> NRFX_TIMER_ENABLED - nrfx_timer - TIMER periperal driver
-//==========================================================
+/**
+ * @brief NRFX_TEMP_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
+#ifndef NRFX_TEMP_CONFIG_LOG_LEVEL
+#define NRFX_TEMP_CONFIG_LOG_LEVEL 3
+#endif
+
+/**
+ * @brief NRFX_TIMER_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_TIMER_ENABLED
 #define NRFX_TIMER_ENABLED 0
 #endif
 
-// <q> NRFX_TIMER0_ENABLED  - Enable TIMER0 instance
-
-#ifndef NRFX_TIMER0_ENABLED
-#define NRFX_TIMER0_ENABLED 0
-#endif
-
-// <q> NRFX_TIMER1_ENABLED  - Enable TIMER1 instance
-
-#ifndef NRFX_TIMER1_ENABLED
-#define NRFX_TIMER1_ENABLED 0
-#endif
-
-// <q> NRFX_TIMER2_ENABLED  - Enable TIMER2 instance
-
-#ifndef NRFX_TIMER2_ENABLED
-#define NRFX_TIMER2_ENABLED 0
-#endif
-
-// <o> NRFX_TIMER_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-
+/**
+ * @brief NRFX_TIMER_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 3
+ */
 #ifndef NRFX_TIMER_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_TIMER_DEFAULT_CONFIG_IRQ_PRIORITY 3
+#define NRFX_TIMER_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_TIMER_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_TIMER_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_TIMER_CONFIG_LOG_ENABLED
 #define NRFX_TIMER_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_TIMER_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_TIMER_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_TIMER_CONFIG_LOG_LEVEL
 #define NRFX_TIMER_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_TIMER_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_TIMER_CONFIG_INFO_COLOR
-#define NRFX_TIMER_CONFIG_INFO_COLOR 0
+/**
+ * @brief NRFX_TIMER0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TIMER0_ENABLED
+#define NRFX_TIMER0_ENABLED 0
 #endif
 
-// <o> NRFX_TIMER_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_TIMER_CONFIG_DEBUG_COLOR
-#define NRFX_TIMER_CONFIG_DEBUG_COLOR 0
+/**
+ * @brief NRFX_TIMER1_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TIMER1_ENABLED
+#define NRFX_TIMER1_ENABLED 0
 #endif
 
-// </e>
+/**
+ * @brief NRFX_TIMER2_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TIMER2_ENABLED
+#define NRFX_TIMER2_ENABLED 0
+#endif
 
-// </e>
-
-// <e> NRFX_TWI_ENABLED - nrfx_twi - TWI peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_TWI_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_TWI_ENABLED
 #define NRFX_TWI_ENABLED 0
 #endif
 
-// <q> NRFX_TWI0_ENABLED  - Enable TWI0 instance
-
-#ifndef NRFX_TWI0_ENABLED
-#define NRFX_TWI0_ENABLED 0
-#endif
-
-// <q> NRFX_TWI1_ENABLED  - Enable TWI1 instance
-
-#ifndef NRFX_TWI1_ENABLED
-#define NRFX_TWI1_ENABLED 0
-#endif
-
-// <o> NRFX_TWI_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-
+/**
+ * @brief NRFX_TWI_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 3
+ */
 #ifndef NRFX_TWI_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_TWI_DEFAULT_CONFIG_IRQ_PRIORITY 3
+#define NRFX_TWI_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_TWI_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_TWI_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_TWI_CONFIG_LOG_ENABLED
 #define NRFX_TWI_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_TWI_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_TWI_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_TWI_CONFIG_LOG_LEVEL
 #define NRFX_TWI_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_TWI_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_TWI_CONFIG_INFO_COLOR
-#define NRFX_TWI_CONFIG_INFO_COLOR 0
+/**
+ * @brief NRFX_TWI0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWI0_ENABLED
+#define NRFX_TWI0_ENABLED 0
 #endif
 
-// <o> NRFX_TWI_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_TWI_CONFIG_DEBUG_COLOR
-#define NRFX_TWI_CONFIG_DEBUG_COLOR 0
+/**
+ * @brief NRFX_TWI1_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWI1_ENABLED
+#define NRFX_TWI1_ENABLED 0
 #endif
 
-// </e>
-
-// </e>
-
-// <e> NRFX_UART_ENABLED - nrfx_uart - UART peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_UART_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_UART_ENABLED
 #define NRFX_UART_ENABLED 0
 #endif
 
-// <q> NRFX_UART0_ENABLED - Enable UART0 instance
-
-#ifndef NRFX_UART0_ENABLED
-#define NRFX_UART0_ENABLED 0
-#endif
-
-// <o> NRFX_UART_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-
+/**
+ * @brief NRFX_UART_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 3
+ */
 #ifndef NRFX_UART_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_UART_DEFAULT_CONFIG_IRQ_PRIORITY 3
+#define NRFX_UART_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_UART_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_UART_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_UART_CONFIG_LOG_ENABLED
 #define NRFX_UART_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_UART_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_UART_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_UART_CONFIG_LOG_LEVEL
 #define NRFX_UART_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_UART_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_UART_CONFIG_INFO_COLOR
-#define NRFX_UART_CONFIG_INFO_COLOR 0
+/**
+ * @brief NRFX_UART0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_UART0_ENABLED
+#define NRFX_UART0_ENABLED 0
 #endif
 
-// <o> NRFX_UART_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_UART_CONFIG_DEBUG_COLOR
-#define NRFX_UART_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_WDT_ENABLED - nrfx_wdt - WDT peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_WDT_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_WDT_ENABLED
 #define NRFX_WDT_ENABLED 0
 #endif
 
-// <q> NRFX_WDT0_ENABLED  - Enable WDT0 instance
-
-#ifndef NRFX_WDT0_ENABLED
-#define NRFX_WDT0_ENABLED 0
+/**
+ * @brief NRFX_WDT_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 3
+ */
+#ifndef NRFX_WDT_DEFAULT_CONFIG_IRQ_PRIORITY
+#define NRFX_WDT_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <o> NRFX_WDT_CONFIG_NO_IRQ  - Remove WDT IRQ handling from WDT driver
-
-// <0=> Include WDT IRQ handling
-// <1=> Remove WDT IRQ handling
-
+/**
+ * @brief NRFX_WDT_CONFIG_NO_IRQ - Remove WDT IRQ handling from WDT driver
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_WDT_CONFIG_NO_IRQ
 #define NRFX_WDT_CONFIG_NO_IRQ 0
 #endif
 
-// <o> NRFX_WDT_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-
-#ifndef NRFX_WDT_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_WDT_DEFAULT_CONFIG_IRQ_PRIORITY 3
-#endif
-
-// <e> NRFX_WDT_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_WDT_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_WDT_CONFIG_LOG_ENABLED
 #define NRFX_WDT_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_WDT_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_WDT_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_WDT_CONFIG_LOG_LEVEL
 #define NRFX_WDT_CONFIG_LOG_LEVEL 3
 #endif
-
-// <o> NRFX_WDT_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_WDT_CONFIG_INFO_COLOR
-#define NRFX_WDT_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_WDT_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_WDT_CONFIG_DEBUG_COLOR
-#define NRFX_WDT_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// </h>
 
 #endif // NRFX_CONFIG_NRF51_H__

--- a/nrfx/templates/nrfx_config_nrf52805.h
+++ b/nrfx/templates/nrfx_config_nrf52805.h
@@ -38,1575 +38,1097 @@
 #error "This file should not be included directly. Include nrfx_config.h instead."
 #endif
 
-// <<< Use Configuration Wizard in Context Menu >>>\n
 
-// <h> nRF_Drivers
+/**
+ * @brief NRFX_DEFAULT_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
+#ifndef NRFX_DEFAULT_IRQ_PRIORITY
+#define NRFX_DEFAULT_IRQ_PRIORITY 7
+#endif
 
-// <e> NRFX_CLOCK_ENABLED - nrfx_clock - CLOCK peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_CLOCK_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_CLOCK_ENABLED
 #define NRFX_CLOCK_ENABLED 0
 #endif
-// <o> NRFX_CLOCK_CONFIG_LF_SRC  - LF Clock Source
 
-// <0=> RC
-// <1=> XTAL
-// <2=> Synth
-// <131073=> External Low Swing
-// <196609=> External Full Swing
-
+/**
+ * @brief NRFX_CLOCK_CONFIG_LF_SRC
+ *
+ * Integer value.
+ * Supported values:
+ * - RC                  = 0
+ * - XTAL                = 1
+ * - Synth               = 2
+ * - External Low Swing  = 131073
+ * - External Full Swing = 196609
+ */
 #ifndef NRFX_CLOCK_CONFIG_LF_SRC
 #define NRFX_CLOCK_CONFIG_LF_SRC 1
 #endif
 
-// <q> NRFX_CLOCK_CONFIG_LF_CAL_ENABLED  - Enables LF Clock Calibration Support
-
+/**
+ * @brief NRFX_CLOCK_CONFIG_LF_CAL_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_CLOCK_CONFIG_LF_CAL_ENABLED
 #define NRFX_CLOCK_CONFIG_LF_CAL_ENABLED 0
 #endif
 
-// <q> NRFX_CLOCK_CONFIG_CT_ENABLED  - Enables Calibration Timer Support
-
+/**
+ * @brief NRFX_CLOCK_CONFIG_CT_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_CLOCK_CONFIG_CT_ENABLED
 #define NRFX_CLOCK_CONFIG_CT_ENABLED 1
 #endif
 
-// <q> NRFX_CLOCK_CONFIG_LFXO_TWO_STAGE_ENABLED - Enables two-stage LFXO start procedure
-
-// <i> If set to a non-zero value, LFRC will be started before LFXO and corresponding
-// <i> event will be generated. It means that CPU will be woken up when LFRC
-// <i> oscillator starts, but user callback will be invoked only after LFXO
-// <i> finally starts.
-
+/**
+ * @brief NRFX_CLOCK_CONFIG_LFXO_TWO_STAGE_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_CLOCK_CONFIG_LFXO_TWO_STAGE_ENABLED
 #define NRFX_CLOCK_CONFIG_LFXO_TWO_STAGE_ENABLED 0
 #endif
 
-// <o> NRFX_CLOCK_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_CLOCK_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_CLOCK_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_CLOCK_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_CLOCK_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_CLOCK_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_CLOCK_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_CLOCK_CONFIG_LOG_ENABLED
 #define NRFX_CLOCK_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_CLOCK_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_CLOCK_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_CLOCK_CONFIG_LOG_LEVEL
 #define NRFX_CLOCK_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_CLOCK_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_CLOCK_CONFIG_INFO_COLOR
-#define NRFX_CLOCK_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_CLOCK_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_CLOCK_CONFIG_DEBUG_COLOR
-#define NRFX_CLOCK_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_EGU_ENABLED - nrfx_egu - EGU peripheral driver.
-//==========================================================
+/**
+ * @brief NRFX_EGU_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_EGU_ENABLED
 #define NRFX_EGU_ENABLED 0
 #endif
 
-// <q> NRFX_EGU0_ENABLED  - Enable EGU0 instance.
+/**
+ * @brief NRFX_EGU_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
+#ifndef NRFX_EGU_DEFAULT_CONFIG_IRQ_PRIORITY
+#define NRFX_EGU_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
+#endif
 
+/**
+ * @brief NRFX_EGU0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_EGU0_ENABLED
 #define NRFX_EGU0_ENABLED 0
 #endif
 
-// <q> NRFX_EGU1_ENABLED  - Enable EGU1 instance.
-
+/**
+ * @brief NRFX_EGU1_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_EGU1_ENABLED
 #define NRFX_EGU1_ENABLED 0
 #endif
 
-// <o> NRFX_EGU_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority.
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
-#ifndef NRFX_EGU_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_EGU_DEFAULT_CONFIG_IRQ_PRIORITY 7
-#endif
-
-// </e>
-
-// <e> NRFX_GPIOTE_ENABLED - nrfx_gpiote - GPIOTE peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_GPIOTE_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_GPIOTE_ENABLED
 #define NRFX_GPIOTE_ENABLED 0
 #endif
 
-// <o> NRFX_GPIOTE_CONFIG_NUM_OF_EVT_HANDLERS - Number of dedicated handlers
+/**
+ * @brief NRFX_GPIOTE_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
+#ifndef NRFX_GPIOTE_DEFAULT_CONFIG_IRQ_PRIORITY
+#define NRFX_GPIOTE_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
+#endif
+
+/**
+ * @brief NRFX_GPIOTE_CONFIG_NUM_OF_EVT_HANDLERS
+ *
+ * Integer value. Minimum: 0 Maximum: 15
+ */
 #ifndef NRFX_GPIOTE_CONFIG_NUM_OF_EVT_HANDLERS
 #define NRFX_GPIOTE_CONFIG_NUM_OF_EVT_HANDLERS 2
 #endif
 
-// <o> NRFX_GPIOTE_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
-#ifndef NRFX_GPIOTE_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_GPIOTE_DEFAULT_CONFIG_IRQ_PRIORITY 7
-#endif
-
-// <e> NRFX_GPIOTE_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_GPIOTE_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_GPIOTE_CONFIG_LOG_ENABLED
 #define NRFX_GPIOTE_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_GPIOTE_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_GPIOTE_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_GPIOTE_CONFIG_LOG_LEVEL
 #define NRFX_GPIOTE_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_GPIOTE_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_GPIOTE_CONFIG_INFO_COLOR
-#define NRFX_GPIOTE_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_GPIOTE_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_GPIOTE_CONFIG_DEBUG_COLOR
-#define NRFX_GPIOTE_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_NVMC_ENABLED - nrfx_nvmc - NVMC peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_NVMC_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_NVMC_ENABLED
 #define NRFX_NVMC_ENABLED 0
 #endif
 
-// </e>
-
-// <e> NRFX_POWER_ENABLED - nrfx_power - POWER peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_POWER_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_POWER_ENABLED
 #define NRFX_POWER_ENABLED 0
 #endif
-// <o> NRFX_POWER_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
 
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_POWER_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_POWER_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_POWER_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_POWER_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// </e>
-
-// <e> NRFX_PPI_ENABLED - nrfx_ppi - PPI peripheral allocator
-//==========================================================
+/**
+ * @brief NRFX_PPI_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_PPI_ENABLED
 #define NRFX_PPI_ENABLED 0
 #endif
-// <e> NRFX_PPI_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+
+/**
+ * @brief NRFX_PPI_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_PPI_CONFIG_LOG_ENABLED
 #define NRFX_PPI_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_PPI_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_PPI_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_PPI_CONFIG_LOG_LEVEL
 #define NRFX_PPI_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_PPI_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_PPI_CONFIG_INFO_COLOR
-#define NRFX_PPI_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_PPI_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_PPI_CONFIG_DEBUG_COLOR
-#define NRFX_PPI_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_PRS_ENABLED - nrfx_prs - Peripheral Resource Sharing module
-//==========================================================
+/**
+ * @brief NRFX_PRS_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_PRS_ENABLED
 #define NRFX_PRS_ENABLED 0
 #endif
-// <q> NRFX_PRS_BOX_0_ENABLED  - Enables box 0 in the module.
 
-
-#ifndef NRFX_PRS_BOX_0_ENABLED
-#define NRFX_PRS_BOX_0_ENABLED 0
-#endif
-
-// <q> NRFX_PRS_BOX_1_ENABLED  - Enables box 1 in the module.
-
-
-#ifndef NRFX_PRS_BOX_1_ENABLED
-#define NRFX_PRS_BOX_1_ENABLED 0
-#endif
-
-// <q> NRFX_PRS_BOX_2_ENABLED  - Enables box 2 in the module.
-
-
-#ifndef NRFX_PRS_BOX_2_ENABLED
-#define NRFX_PRS_BOX_2_ENABLED 0
-#endif
-
-
-// <e> NRFX_PRS_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_PRS_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_PRS_CONFIG_LOG_ENABLED
 #define NRFX_PRS_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_PRS_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_PRS_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_PRS_CONFIG_LOG_LEVEL
 #define NRFX_PRS_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_PRS_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_PRS_CONFIG_INFO_COLOR
-#define NRFX_PRS_CONFIG_INFO_COLOR 0
+/**
+ * @brief NRFX_PRS_BOX_0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_PRS_BOX_0_ENABLED
+#define NRFX_PRS_BOX_0_ENABLED 0
 #endif
 
-// <o> NRFX_PRS_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_PRS_CONFIG_DEBUG_COLOR
-#define NRFX_PRS_CONFIG_DEBUG_COLOR 0
+/**
+ * @brief NRFX_PRS_BOX_1_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_PRS_BOX_1_ENABLED
+#define NRFX_PRS_BOX_1_ENABLED 0
 #endif
 
-// </e>
+/**
+ * @brief NRFX_PRS_BOX_2_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_PRS_BOX_2_ENABLED
+#define NRFX_PRS_BOX_2_ENABLED 0
+#endif
 
-// </e>
+/**
+ * @brief NRFX_PRS_BOX_4_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_PRS_BOX_4_ENABLED
+#define NRFX_PRS_BOX_4_ENABLED 0
+#endif
 
-// <e> NRFX_QDEC_ENABLED - nrfx_qdec - QDEC peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_QDEC_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_QDEC_ENABLED
 #define NRFX_QDEC_ENABLED 0
 #endif
 
-// <o> NRFX_QDEC_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_QDEC_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_QDEC_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_QDEC_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_QDEC_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_QDEC_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_QDEC_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_QDEC_CONFIG_LOG_ENABLED
 #define NRFX_QDEC_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_QDEC_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_QDEC_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_QDEC_CONFIG_LOG_LEVEL
 #define NRFX_QDEC_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_QDEC_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_QDEC_CONFIG_INFO_COLOR
-#define NRFX_QDEC_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_QDEC_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_QDEC_CONFIG_DEBUG_COLOR
-#define NRFX_QDEC_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_RNG_ENABLED - nrfx_rng - RNG peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_RNG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_RNG_ENABLED
 #define NRFX_RNG_ENABLED 0
 #endif
 
-// <o> NRFX_RNG_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_RNG_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_RNG_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_RNG_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_RNG_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_RNG_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_RNG_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_RNG_CONFIG_LOG_ENABLED
 #define NRFX_RNG_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_RNG_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_RNG_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_RNG_CONFIG_LOG_LEVEL
 #define NRFX_RNG_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_RNG_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_RNG_CONFIG_INFO_COLOR
-#define NRFX_RNG_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_RNG_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_RNG_CONFIG_DEBUG_COLOR
-#define NRFX_RNG_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_RTC_ENABLED - nrfx_rtc - RTC peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_RTC_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_RTC_ENABLED
 #define NRFX_RTC_ENABLED 0
 #endif
-// <q> NRFX_RTC0_ENABLED  - Enable RTC0 instance
 
-#ifndef NRFX_RTC0_ENABLED
-#define NRFX_RTC0_ENABLED 0
-#endif
-
-// <q> NRFX_RTC1_ENABLED  - Enable RTC1 instance
-
-#ifndef NRFX_RTC1_ENABLED
-#define NRFX_RTC1_ENABLED 0
-#endif
-
-// <o> NRFX_RTC_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_RTC_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_RTC_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_RTC_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_RTC_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_RTC_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_RTC_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_RTC_CONFIG_LOG_ENABLED
 #define NRFX_RTC_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_RTC_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_RTC_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_RTC_CONFIG_LOG_LEVEL
 #define NRFX_RTC_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_RTC_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_RTC_CONFIG_INFO_COLOR
-#define NRFX_RTC_CONFIG_INFO_COLOR 0
+/**
+ * @brief NRFX_RTC0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_RTC0_ENABLED
+#define NRFX_RTC0_ENABLED 0
 #endif
 
-// <o> NRFX_RTC_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_RTC_CONFIG_DEBUG_COLOR
-#define NRFX_RTC_CONFIG_DEBUG_COLOR 0
+/**
+ * @brief NRFX_RTC1_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_RTC1_ENABLED
+#define NRFX_RTC1_ENABLED 0
 #endif
 
-// </e>
-
-// </e>
-
-// <e> NRFX_SAADC_ENABLED - nrfx_saadc - SAADC peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_SAADC_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_SAADC_ENABLED
 #define NRFX_SAADC_ENABLED 0
 #endif
 
-// <o> NRFX_SAADC_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_SAADC_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_SAADC_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_SAADC_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_SAADC_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_SAADC_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_SAADC_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_SAADC_CONFIG_LOG_ENABLED
 #define NRFX_SAADC_CONFIG_LOG_ENABLED 0
 #endif
 
-// <o> NRFX_SAADC_CONFIG_LOG_LEVEL  - Default Severity level
-
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_SAADC_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_SAADC_CONFIG_LOG_LEVEL
 #define NRFX_SAADC_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_SAADC_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_SAADC_CONFIG_INFO_COLOR
-#define NRFX_SAADC_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_SAADC_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_SAADC_CONFIG_DEBUG_COLOR
-#define NRFX_SAADC_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_SPIM_ENABLED - nrfx_spim - SPIM peripheral driver
-//==========================================================
-#ifndef NRFX_SPIM_ENABLED
-#define NRFX_SPIM_ENABLED 0
-#endif
-
-// <q> NRFX_SPIM0_ENABLED  - Enable SPIM0 instance
-
-#ifndef NRFX_SPIM0_ENABLED
-#define NRFX_SPIM0_ENABLED 0
-#endif
-
-// <o> NRFX_SPIM_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
-#ifndef NRFX_SPIM_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_SPIM_DEFAULT_CONFIG_IRQ_PRIORITY 7
-#endif
-
-// <e> NRFX_SPIM_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
-#ifndef NRFX_SPIM_CONFIG_LOG_ENABLED
-#define NRFX_SPIM_CONFIG_LOG_ENABLED 0
-#endif
-// <o> NRFX_SPIM_CONFIG_LOG_LEVEL  - Default Severity level
-
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
-#ifndef NRFX_SPIM_CONFIG_LOG_LEVEL
-#define NRFX_SPIM_CONFIG_LOG_LEVEL 3
-#endif
-
-// <o> NRFX_SPIM_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_SPIM_CONFIG_INFO_COLOR
-#define NRFX_SPIM_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_SPIM_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_SPIM_CONFIG_DEBUG_COLOR
-#define NRFX_SPIM_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_SPIS_ENABLED - nrfx_spis - SPIS peripheral driver
-//==========================================================
-#ifndef NRFX_SPIS_ENABLED
-#define NRFX_SPIS_ENABLED 0
-#endif
-// <q> NRFX_SPIS0_ENABLED  - Enable SPIS0 instance
-
-
-#ifndef NRFX_SPIS0_ENABLED
-#define NRFX_SPIS0_ENABLED 0
-#endif
-
-// <o> NRFX_SPIS_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
-#ifndef NRFX_SPIS_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_SPIS_DEFAULT_CONFIG_IRQ_PRIORITY 7
-#endif
-
-// <e> NRFX_SPIS_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
-#ifndef NRFX_SPIS_CONFIG_LOG_ENABLED
-#define NRFX_SPIS_CONFIG_LOG_ENABLED 0
-#endif
-// <o> NRFX_SPIS_CONFIG_LOG_LEVEL  - Default Severity level
-
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
-#ifndef NRFX_SPIS_CONFIG_LOG_LEVEL
-#define NRFX_SPIS_CONFIG_LOG_LEVEL 3
-#endif
-
-// <o> NRFX_SPIS_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_SPIS_CONFIG_INFO_COLOR
-#define NRFX_SPIS_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_SPIS_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_SPIS_CONFIG_DEBUG_COLOR
-#define NRFX_SPIS_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_SPI_ENABLED - nrfx_spi - SPI peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_SPI_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_SPI_ENABLED
 #define NRFX_SPI_ENABLED 0
 #endif
-// <q> NRFX_SPI0_ENABLED  - Enable SPI0 instance
 
-
-#ifndef NRFX_SPI0_ENABLED
-#define NRFX_SPI0_ENABLED 0
-#endif
-
-// <o> NRFX_SPI_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_SPI_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_SPI_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_SPI_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_SPI_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_SPI_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_SPI_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_SPI_CONFIG_LOG_ENABLED
 #define NRFX_SPI_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_SPI_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_SPI_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_SPI_CONFIG_LOG_LEVEL
 #define NRFX_SPI_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_SPI_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_SPI_CONFIG_INFO_COLOR
-#define NRFX_SPI_CONFIG_INFO_COLOR 0
+/**
+ * @brief NRFX_SPI0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPI0_ENABLED
+#define NRFX_SPI0_ENABLED 0
 #endif
 
-// <o> NRFX_SPI_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_SPI_CONFIG_DEBUG_COLOR
-#define NRFX_SPI_CONFIG_DEBUG_COLOR 0
+/**
+ * @brief NRFX_SPIM_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPIM_ENABLED
+#define NRFX_SPIM_ENABLED 0
 #endif
 
-// </e>
+/**
+ * @brief NRFX_SPIM_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
+#ifndef NRFX_SPIM_DEFAULT_CONFIG_IRQ_PRIORITY
+#define NRFX_SPIM_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
+#endif
 
-// </e>
+/**
+ * @brief NRFX_SPIM_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPIM_CONFIG_LOG_ENABLED
+#define NRFX_SPIM_CONFIG_LOG_ENABLED 0
+#endif
 
-// <q> NRFX_SYSTICK_ENABLED  - nrfx_systick - ARM(R) SysTick driver
+/**
+ * @brief NRFX_SPIM_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
+#ifndef NRFX_SPIM_CONFIG_LOG_LEVEL
+#define NRFX_SPIM_CONFIG_LOG_LEVEL 3
+#endif
 
+/**
+ * @brief NRFX_SPIM0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPIM0_ENABLED
+#define NRFX_SPIM0_ENABLED 0
+#endif
 
+/**
+ * @brief NRFX_SPIS_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPIS_ENABLED
+#define NRFX_SPIS_ENABLED 0
+#endif
+
+/**
+ * @brief NRFX_SPIS_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
+#ifndef NRFX_SPIS_DEFAULT_CONFIG_IRQ_PRIORITY
+#define NRFX_SPIS_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
+#endif
+
+/**
+ * @brief NRFX_SPIS_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPIS_CONFIG_LOG_ENABLED
+#define NRFX_SPIS_CONFIG_LOG_ENABLED 0
+#endif
+
+/**
+ * @brief NRFX_SPIS_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
+#ifndef NRFX_SPIS_CONFIG_LOG_LEVEL
+#define NRFX_SPIS_CONFIG_LOG_LEVEL 3
+#endif
+
+/**
+ * @brief NRFX_SPIS0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPIS0_ENABLED
+#define NRFX_SPIS0_ENABLED 0
+#endif
+
+/**
+ * @brief NRFX_SYSTICK_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_SYSTICK_ENABLED
 #define NRFX_SYSTICK_ENABLED 0
 #endif
 
-// <e> NRFX_TEMP_ENABLED - nrfx_temp - TEMP peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_TEMP_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_TEMP_ENABLED
 #define NRFX_TEMP_ENABLED 0
 #endif
 
-// <o> NRFX_TEMP_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_TEMP_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_TEMP_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_TEMP_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_TEMP_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// </e>
+/**
+ * @brief NRFX_TEMP_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TEMP_CONFIG_LOG_ENABLED
+#define NRFX_TEMP_CONFIG_LOG_ENABLED 0
+#endif
 
-// <e> NRFX_TIMER_ENABLED - nrfx_timer - TIMER periperal driver
-//==========================================================
+/**
+ * @brief NRFX_TEMP_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
+#ifndef NRFX_TEMP_CONFIG_LOG_LEVEL
+#define NRFX_TEMP_CONFIG_LOG_LEVEL 3
+#endif
+
+/**
+ * @brief NRFX_TIMER_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_TIMER_ENABLED
 #define NRFX_TIMER_ENABLED 0
 #endif
 
-// <q> NRFX_TIMER0_ENABLED  - Enable TIMER0 instance
-
-#ifndef NRFX_TIMER0_ENABLED
-#define NRFX_TIMER0_ENABLED 0
-#endif
-
-// <q> NRFX_TIMER1_ENABLED  - Enable TIMER1 instance
-
-#ifndef NRFX_TIMER1_ENABLED
-#define NRFX_TIMER1_ENABLED 0
-#endif
-
-// <q> NRFX_TIMER2_ENABLED  - Enable TIMER2 instance
-
-#ifndef NRFX_TIMER2_ENABLED
-#define NRFX_TIMER2_ENABLED 0
-#endif
-
-// <o> NRFX_TIMER_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_TIMER_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_TIMER_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_TIMER_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_TIMER_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_TIMER_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_TIMER_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_TIMER_CONFIG_LOG_ENABLED
 #define NRFX_TIMER_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_TIMER_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_TIMER_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_TIMER_CONFIG_LOG_LEVEL
 #define NRFX_TIMER_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_TIMER_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_TIMER_CONFIG_INFO_COLOR
-#define NRFX_TIMER_CONFIG_INFO_COLOR 0
+/**
+ * @brief NRFX_TIMER0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TIMER0_ENABLED
+#define NRFX_TIMER0_ENABLED 0
 #endif
 
-// <o> NRFX_TIMER_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_TIMER_CONFIG_DEBUG_COLOR
-#define NRFX_TIMER_CONFIG_DEBUG_COLOR 0
+/**
+ * @brief NRFX_TIMER1_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TIMER1_ENABLED
+#define NRFX_TIMER1_ENABLED 0
 #endif
 
-// </e>
-
-// </e>
-
-// <e> NRFX_TWIM_ENABLED - nrfx_twim - TWIM peripheral driver
-//==========================================================
-#ifndef NRFX_TWIM_ENABLED
-#define NRFX_TWIM_ENABLED 0
+/**
+ * @brief NRFX_TIMER2_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TIMER2_ENABLED
+#define NRFX_TIMER2_ENABLED 0
 #endif
 
-// <q> NRFX_TWIM0_ENABLED  - Enable TWIM0 instance
-
-#ifndef NRFX_TWIM0_ENABLED
-#define NRFX_TWIM0_ENABLED 0
-#endif
-
-// <o> NRFX_TWIM_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
-#ifndef NRFX_TWIM_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_TWIM_DEFAULT_CONFIG_IRQ_PRIORITY 7
-#endif
-
-// <e> NRFX_TWIM_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
-#ifndef NRFX_TWIM_CONFIG_LOG_ENABLED
-#define NRFX_TWIM_CONFIG_LOG_ENABLED 0
-#endif
-// <o> NRFX_TWIM_CONFIG_LOG_LEVEL  - Default Severity level
-
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
-#ifndef NRFX_TWIM_CONFIG_LOG_LEVEL
-#define NRFX_TWIM_CONFIG_LOG_LEVEL 3
-#endif
-
-// <o> NRFX_TWIM_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_TWIM_CONFIG_INFO_COLOR
-#define NRFX_TWIM_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_TWIM_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_TWIM_CONFIG_DEBUG_COLOR
-#define NRFX_TWIM_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_TWIS_ENABLED - nrfx_twis - TWIS peripheral driver
-//==========================================================
-#ifndef NRFX_TWIS_ENABLED
-#define NRFX_TWIS_ENABLED 0
-#endif
-
-// <q> NRFX_TWIS0_ENABLED  - Enable TWIS0 instance
-
-#ifndef NRFX_TWIS0_ENABLED
-#define NRFX_TWIS0_ENABLED 0
-#endif
-
-// <q> NRFX_TWIS_ASSUME_INIT_AFTER_RESET_ONLY  - Assume that any instance would be initialized only once
-
-// <i> Optimization flag. Registers used by TWIS are shared by other peripherals. Normally, during initialization driver tries to clear all registers to known state before doing the initialization itself. This gives initialization safe procedure, no matter when it would be called. If you activate TWIS only once and do never uninitialize it - set this flag to 1 what gives more optimal code.
-
-#ifndef NRFX_TWIS_ASSUME_INIT_AFTER_RESET_ONLY
-#define NRFX_TWIS_ASSUME_INIT_AFTER_RESET_ONLY 0
-#endif
-
-// <q> NRFX_TWIS_NO_SYNC_MODE  - Remove support for synchronous mode
-
-// <i> Synchronous mode would be used in specific situations. And it uses some additional code and data memory to safely process state machine by polling it in status functions. If this functionality is not required it may be disabled to free some resources.
-
-#ifndef NRFX_TWIS_NO_SYNC_MODE
-#define NRFX_TWIS_NO_SYNC_MODE 0
-#endif
-
-// <o> NRFX_TWIS_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
-#ifndef NRFX_TWIS_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_TWIS_DEFAULT_CONFIG_IRQ_PRIORITY 7
-#endif
-
-// <e> NRFX_TWIS_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
-#ifndef NRFX_TWIS_CONFIG_LOG_ENABLED
-#define NRFX_TWIS_CONFIG_LOG_ENABLED 0
-#endif
-// <o> NRFX_TWIS_CONFIG_LOG_LEVEL  - Default Severity level
-
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
-#ifndef NRFX_TWIS_CONFIG_LOG_LEVEL
-#define NRFX_TWIS_CONFIG_LOG_LEVEL 3
-#endif
-
-// <o> NRFX_TWIS_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_TWIS_CONFIG_INFO_COLOR
-#define NRFX_TWIS_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_TWIS_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_TWIS_CONFIG_DEBUG_COLOR
-#define NRFX_TWIS_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_TWI_ENABLED - nrfx_twi - TWI peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_TWI_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_TWI_ENABLED
 #define NRFX_TWI_ENABLED 0
 #endif
 
-// <q> NRFX_TWI0_ENABLED  - Enable TWI0 instance
-
-#ifndef NRFX_TWI0_ENABLED
-#define NRFX_TWI0_ENABLED 0
-#endif
-
-// <o> NRFX_TWI_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_TWI_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_TWI_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_TWI_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_TWI_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_TWI_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_TWI_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_TWI_CONFIG_LOG_ENABLED
 #define NRFX_TWI_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_TWI_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_TWI_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_TWI_CONFIG_LOG_LEVEL
 #define NRFX_TWI_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_TWI_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_TWI_CONFIG_INFO_COLOR
-#define NRFX_TWI_CONFIG_INFO_COLOR 0
+/**
+ * @brief NRFX_TWI0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWI0_ENABLED
+#define NRFX_TWI0_ENABLED 0
 #endif
 
-// <o> NRFX_TWI_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_TWI_CONFIG_DEBUG_COLOR
-#define NRFX_TWI_CONFIG_DEBUG_COLOR 0
+/**
+ * @brief NRFX_TWIM_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWIM_ENABLED
+#define NRFX_TWIM_ENABLED 0
 #endif
 
-// </e>
-
-// </e>
-
-// <e> NRFX_UARTE_ENABLED - nrfx_uarte - UARTE peripheral driver
-//==========================================================
-#ifndef NRFX_UARTE_ENABLED
-#define NRFX_UARTE_ENABLED 0
+/**
+ * @brief NRFX_TWIM_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
+#ifndef NRFX_TWIM_DEFAULT_CONFIG_IRQ_PRIORITY
+#define NRFX_TWIM_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <q> NRFX_UARTE0_ENABLED - Enable UARTE0 instance
-
-#ifndef NRFX_UARTE0_ENABLED
-#define NRFX_UARTE0_ENABLED 0
+/**
+ * @brief NRFX_TWIM_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWIM_CONFIG_LOG_ENABLED
+#define NRFX_TWIM_CONFIG_LOG_ENABLED 0
 #endif
 
-// <o> NRFX_UARTE_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
-#ifndef NRFX_UARTE_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_UARTE_DEFAULT_CONFIG_IRQ_PRIORITY 7
+/**
+ * @brief NRFX_TWIM_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
+#ifndef NRFX_TWIM_CONFIG_LOG_LEVEL
+#define NRFX_TWIM_CONFIG_LOG_LEVEL 3
 #endif
 
-// <e> NRFX_UARTE_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
-#ifndef NRFX_UARTE_CONFIG_LOG_ENABLED
-#define NRFX_UARTE_CONFIG_LOG_ENABLED 0
-#endif
-// <o> NRFX_UARTE_CONFIG_LOG_LEVEL  - Default Severity level
-
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
-#ifndef NRFX_UARTE_CONFIG_LOG_LEVEL
-#define NRFX_UARTE_CONFIG_LOG_LEVEL 3
+/**
+ * @brief NRFX_TWIM0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWIM0_ENABLED
+#define NRFX_TWIM0_ENABLED 0
 #endif
 
-// <o> NRFX_UARTE_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_UARTE_CONFIG_INFO_COLOR
-#define NRFX_UARTE_CONFIG_INFO_COLOR 0
+/**
+ * @brief NRFX_TWIS_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWIS_ENABLED
+#define NRFX_TWIS_ENABLED 0
 #endif
 
-// <o> NRFX_UARTE_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_UARTE_CONFIG_DEBUG_COLOR
-#define NRFX_UARTE_CONFIG_DEBUG_COLOR 0
+/**
+ * @brief NRFX_TWIS_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
+#ifndef NRFX_TWIS_DEFAULT_CONFIG_IRQ_PRIORITY
+#define NRFX_TWIS_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// </e>
+/**
+ * @brief NRFX_TWIS_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWIS_CONFIG_LOG_ENABLED
+#define NRFX_TWIS_CONFIG_LOG_ENABLED 0
+#endif
 
-// </e>
+/**
+ * @brief NRFX_TWIS_ASSUME_INIT_AFTER_RESET_ONLY - Assume that any instance would be initialized only once.
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWIS_ASSUME_INIT_AFTER_RESET_ONLY
+#define NRFX_TWIS_ASSUME_INIT_AFTER_RESET_ONLY 0
+#endif
 
-// <e> NRFX_UART_ENABLED - nrfx_uart - UART peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_TWIS_NO_SYNC_MODE - Remove support for synchronous mode.
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWIS_NO_SYNC_MODE
+#define NRFX_TWIS_NO_SYNC_MODE 0
+#endif
+
+/**
+ * @brief NRFX_TWIS_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
+#ifndef NRFX_TWIS_CONFIG_LOG_LEVEL
+#define NRFX_TWIS_CONFIG_LOG_LEVEL 3
+#endif
+
+/**
+ * @brief NRFX_TWIS0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWIS0_ENABLED
+#define NRFX_TWIS0_ENABLED 0
+#endif
+
+/**
+ * @brief NRFX_UART_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_UART_ENABLED
 #define NRFX_UART_ENABLED 0
 #endif
 
-// <q> NRFX_UART0_ENABLED - Enable UART0 instance
-
-#ifndef NRFX_UART0_ENABLED
-#define NRFX_UART0_ENABLED 0
-#endif
-
-// <o> NRFX_UART_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_UART_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_UART_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_UART_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_UART_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_UART_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_UART_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_UART_CONFIG_LOG_ENABLED
 #define NRFX_UART_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_UART_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_UART_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_UART_CONFIG_LOG_LEVEL
 #define NRFX_UART_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_UART_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_UART_CONFIG_INFO_COLOR
-#define NRFX_UART_CONFIG_INFO_COLOR 0
+/**
+ * @brief NRFX_UART0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_UART0_ENABLED
+#define NRFX_UART0_ENABLED 0
 #endif
 
-// <o> NRFX_UART_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_UART_CONFIG_DEBUG_COLOR
-#define NRFX_UART_CONFIG_DEBUG_COLOR 0
+/**
+ * @brief NRFX_UARTE_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_UARTE_ENABLED
+#define NRFX_UARTE_ENABLED 0
 #endif
 
-// </e>
+/**
+ * @brief NRFX_UARTE_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
+#ifndef NRFX_UARTE_DEFAULT_CONFIG_IRQ_PRIORITY
+#define NRFX_UARTE_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
+#endif
 
-// </e>
+/**
+ * @brief NRFX_UARTE_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_UARTE_CONFIG_LOG_ENABLED
+#define NRFX_UARTE_CONFIG_LOG_ENABLED 0
+#endif
 
-// <e> NRFX_WDT_ENABLED - nrfx_wdt - WDT peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_UARTE_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
+#ifndef NRFX_UARTE_CONFIG_LOG_LEVEL
+#define NRFX_UARTE_CONFIG_LOG_LEVEL 3
+#endif
+
+/**
+ * @brief NRFX_UARTE0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_UARTE0_ENABLED
+#define NRFX_UARTE0_ENABLED 0
+#endif
+
+/**
+ * @brief NRFX_WDT_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_WDT_ENABLED
 #define NRFX_WDT_ENABLED 0
 #endif
 
-// <q> NRFX_WDT0_ENABLED  - Enable WDT0 instance
-
-#ifndef NRFX_WDT0_ENABLED
-#define NRFX_WDT0_ENABLED 0
+/**
+ * @brief NRFX_WDT_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
+#ifndef NRFX_WDT_DEFAULT_CONFIG_IRQ_PRIORITY
+#define NRFX_WDT_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <o> NRFX_WDT_CONFIG_NO_IRQ  - Remove WDT IRQ handling from WDT driver
-
-// <0=> Include WDT IRQ handling
-// <1=> Remove WDT IRQ handling
-
+/**
+ * @brief NRFX_WDT_CONFIG_NO_IRQ - Remove WDT IRQ handling from WDT driver
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_WDT_CONFIG_NO_IRQ
 #define NRFX_WDT_CONFIG_NO_IRQ 0
 #endif
 
-// <o> NRFX_WDT_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
-#ifndef NRFX_WDT_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_WDT_DEFAULT_CONFIG_IRQ_PRIORITY 7
-#endif
-
-// <e> NRFX_WDT_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_WDT_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_WDT_CONFIG_LOG_ENABLED
 #define NRFX_WDT_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_WDT_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_WDT_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_WDT_CONFIG_LOG_LEVEL
 #define NRFX_WDT_CONFIG_LOG_LEVEL 3
 #endif
-
-// <o> NRFX_WDT_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_WDT_CONFIG_INFO_COLOR
-#define NRFX_WDT_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_WDT_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_WDT_CONFIG_DEBUG_COLOR
-#define NRFX_WDT_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// </h>
 
 #endif // NRFX_CONFIG_NRF52805_H__

--- a/nrfx/templates/nrfx_config_nrf52810.h
+++ b/nrfx/templates/nrfx_config_nrf52810.h
@@ -38,1803 +38,1232 @@
 #error "This file should not be included directly. Include nrfx_config.h instead."
 #endif
 
-// <<< Use Configuration Wizard in Context Menu >>>\n
 
-// <h> nRF_Drivers
+/**
+ * @brief NRFX_DEFAULT_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
+#ifndef NRFX_DEFAULT_IRQ_PRIORITY
+#define NRFX_DEFAULT_IRQ_PRIORITY 7
+#endif
 
-// <e> NRFX_CLOCK_ENABLED - nrfx_clock - CLOCK peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_CLOCK_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_CLOCK_ENABLED
 #define NRFX_CLOCK_ENABLED 0
 #endif
-// <o> NRFX_CLOCK_CONFIG_LF_SRC  - LF Clock Source
 
-// <0=> RC
-// <1=> XTAL
-// <2=> Synth
-// <131073=> External Low Swing
-// <196609=> External Full Swing
-
+/**
+ * @brief NRFX_CLOCK_CONFIG_LF_SRC
+ *
+ * Integer value.
+ * Supported values:
+ * - RC                  = 0
+ * - XTAL                = 1
+ * - Synth               = 2
+ * - External Low Swing  = 131073
+ * - External Full Swing = 196609
+ */
 #ifndef NRFX_CLOCK_CONFIG_LF_SRC
 #define NRFX_CLOCK_CONFIG_LF_SRC 1
 #endif
 
-// <q> NRFX_CLOCK_CONFIG_LF_CAL_ENABLED  - Enables LF Clock Calibration Support
-
+/**
+ * @brief NRFX_CLOCK_CONFIG_LF_CAL_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_CLOCK_CONFIG_LF_CAL_ENABLED
 #define NRFX_CLOCK_CONFIG_LF_CAL_ENABLED 0
 #endif
 
-// <q> NRFX_CLOCK_CONFIG_CT_ENABLED  - Enables Calibration Timer Support
-
+/**
+ * @brief NRFX_CLOCK_CONFIG_CT_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_CLOCK_CONFIG_CT_ENABLED
 #define NRFX_CLOCK_CONFIG_CT_ENABLED 1
 #endif
 
-// <q> NRFX_CLOCK_CONFIG_LFXO_TWO_STAGE_ENABLED - Enables two-stage LFXO start procedure
-
-// <i> If set to a non-zero value, LFRC will be started before LFXO and corresponding
-// <i> event will be generated. It means that CPU will be woken up when LFRC
-// <i> oscillator starts, but user callback will be invoked only after LFXO
-// <i> finally starts.
-
+/**
+ * @brief NRFX_CLOCK_CONFIG_LFXO_TWO_STAGE_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_CLOCK_CONFIG_LFXO_TWO_STAGE_ENABLED
 #define NRFX_CLOCK_CONFIG_LFXO_TWO_STAGE_ENABLED 0
 #endif
 
-// <o> NRFX_CLOCK_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_CLOCK_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_CLOCK_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_CLOCK_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_CLOCK_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_CLOCK_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_CLOCK_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_CLOCK_CONFIG_LOG_ENABLED
 #define NRFX_CLOCK_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_CLOCK_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_CLOCK_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_CLOCK_CONFIG_LOG_LEVEL
 #define NRFX_CLOCK_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_CLOCK_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_CLOCK_CONFIG_INFO_COLOR
-#define NRFX_CLOCK_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_CLOCK_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_CLOCK_CONFIG_DEBUG_COLOR
-#define NRFX_CLOCK_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_COMP_ENABLED - nrfx_comp - COMP peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_COMP_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_COMP_ENABLED
 #define NRFX_COMP_ENABLED 0
 #endif
 
-// <o> NRFX_COMP_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_COMP_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_COMP_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_COMP_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_COMP_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_COMP_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_COMP_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_COMP_CONFIG_LOG_ENABLED
 #define NRFX_COMP_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_COMP_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_COMP_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_COMP_CONFIG_LOG_LEVEL
 #define NRFX_COMP_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_COMP_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_COMP_CONFIG_INFO_COLOR
-#define NRFX_COMP_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_COMP_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_COMP_CONFIG_DEBUG_COLOR
-#define NRFX_COMP_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_EGU_ENABLED - nrfx_egu - EGU peripheral driver.
-//==========================================================
+/**
+ * @brief NRFX_EGU_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_EGU_ENABLED
 #define NRFX_EGU_ENABLED 0
 #endif
 
-// <q> NRFX_EGU0_ENABLED  - Enable EGU0 instance.
+/**
+ * @brief NRFX_EGU_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
+#ifndef NRFX_EGU_DEFAULT_CONFIG_IRQ_PRIORITY
+#define NRFX_EGU_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
+#endif
 
+/**
+ * @brief NRFX_EGU0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_EGU0_ENABLED
 #define NRFX_EGU0_ENABLED 0
 #endif
 
-// <q> NRFX_EGU1_ENABLED  - Enable EGU1 instance.
-
+/**
+ * @brief NRFX_EGU1_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_EGU1_ENABLED
 #define NRFX_EGU1_ENABLED 0
 #endif
 
-// <o> NRFX_EGU_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority.
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
-#ifndef NRFX_EGU_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_EGU_DEFAULT_CONFIG_IRQ_PRIORITY 7
-#endif
-
-// </e>
-
-// <e> NRFX_GPIOTE_ENABLED - nrfx_gpiote - GPIOTE peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_GPIOTE_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_GPIOTE_ENABLED
 #define NRFX_GPIOTE_ENABLED 0
 #endif
 
-// <o> NRFX_GPIOTE_CONFIG_NUM_OF_EVT_HANDLERS - Number of dedicated handlers
+/**
+ * @brief NRFX_GPIOTE_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
+#ifndef NRFX_GPIOTE_DEFAULT_CONFIG_IRQ_PRIORITY
+#define NRFX_GPIOTE_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
+#endif
+
+/**
+ * @brief NRFX_GPIOTE_CONFIG_NUM_OF_EVT_HANDLERS
+ *
+ * Integer value. Minimum: 0 Maximum: 15
+ */
 #ifndef NRFX_GPIOTE_CONFIG_NUM_OF_EVT_HANDLERS
 #define NRFX_GPIOTE_CONFIG_NUM_OF_EVT_HANDLERS 2
 #endif
 
-// <o> NRFX_GPIOTE_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
-#ifndef NRFX_GPIOTE_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_GPIOTE_DEFAULT_CONFIG_IRQ_PRIORITY 7
-#endif
-
-// <e> NRFX_GPIOTE_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_GPIOTE_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_GPIOTE_CONFIG_LOG_ENABLED
 #define NRFX_GPIOTE_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_GPIOTE_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_GPIOTE_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_GPIOTE_CONFIG_LOG_LEVEL
 #define NRFX_GPIOTE_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_GPIOTE_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_GPIOTE_CONFIG_INFO_COLOR
-#define NRFX_GPIOTE_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_GPIOTE_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_GPIOTE_CONFIG_DEBUG_COLOR
-#define NRFX_GPIOTE_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_NVMC_ENABLED - nrfx_nvmc - NVMC peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_NVMC_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_NVMC_ENABLED
 #define NRFX_NVMC_ENABLED 0
 #endif
 
-// </e>
-
-// <e> NRFX_PDM_ENABLED - nrfx_pdm - PDM peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_PDM_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_PDM_ENABLED
 #define NRFX_PDM_ENABLED 0
 #endif
 
-// <o> NRFX_PDM_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_PDM_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_PDM_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_PDM_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_PDM_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_PDM_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_PDM_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_PDM_CONFIG_LOG_ENABLED
 #define NRFX_PDM_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_PDM_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_PDM_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_PDM_CONFIG_LOG_LEVEL
 #define NRFX_PDM_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_PDM_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_PDM_CONFIG_INFO_COLOR
-#define NRFX_PDM_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_PDM_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_PDM_CONFIG_DEBUG_COLOR
-#define NRFX_PDM_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_POWER_ENABLED - nrfx_power - POWER peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_POWER_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_POWER_ENABLED
 #define NRFX_POWER_ENABLED 0
 #endif
-// <o> NRFX_POWER_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
 
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_POWER_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_POWER_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_POWER_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_POWER_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// </e>
-
-// <e> NRFX_PPI_ENABLED - nrfx_ppi - PPI peripheral allocator
-//==========================================================
+/**
+ * @brief NRFX_PPI_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_PPI_ENABLED
 #define NRFX_PPI_ENABLED 0
 #endif
-// <e> NRFX_PPI_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+
+/**
+ * @brief NRFX_PPI_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_PPI_CONFIG_LOG_ENABLED
 #define NRFX_PPI_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_PPI_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_PPI_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_PPI_CONFIG_LOG_LEVEL
 #define NRFX_PPI_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_PPI_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_PPI_CONFIG_INFO_COLOR
-#define NRFX_PPI_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_PPI_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_PPI_CONFIG_DEBUG_COLOR
-#define NRFX_PPI_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_PRS_ENABLED - nrfx_prs - Peripheral Resource Sharing module
-//==========================================================
+/**
+ * @brief NRFX_PRS_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_PRS_ENABLED
 #define NRFX_PRS_ENABLED 0
 #endif
-// <q> NRFX_PRS_BOX_0_ENABLED  - Enables box 0 in the module.
 
-
-#ifndef NRFX_PRS_BOX_0_ENABLED
-#define NRFX_PRS_BOX_0_ENABLED 0
-#endif
-
-// <q> NRFX_PRS_BOX_1_ENABLED  - Enables box 1 in the module.
-
-
-#ifndef NRFX_PRS_BOX_1_ENABLED
-#define NRFX_PRS_BOX_1_ENABLED 0
-#endif
-
-// <q> NRFX_PRS_BOX_2_ENABLED  - Enables box 2 in the module.
-
-
-#ifndef NRFX_PRS_BOX_2_ENABLED
-#define NRFX_PRS_BOX_2_ENABLED 0
-#endif
-
-
-// <e> NRFX_PRS_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_PRS_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_PRS_CONFIG_LOG_ENABLED
 #define NRFX_PRS_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_PRS_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_PRS_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_PRS_CONFIG_LOG_LEVEL
 #define NRFX_PRS_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_PRS_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_PRS_CONFIG_INFO_COLOR
-#define NRFX_PRS_CONFIG_INFO_COLOR 0
+/**
+ * @brief NRFX_PRS_BOX_0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_PRS_BOX_0_ENABLED
+#define NRFX_PRS_BOX_0_ENABLED 0
 #endif
 
-// <o> NRFX_PRS_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_PRS_CONFIG_DEBUG_COLOR
-#define NRFX_PRS_CONFIG_DEBUG_COLOR 0
+/**
+ * @brief NRFX_PRS_BOX_1_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_PRS_BOX_1_ENABLED
+#define NRFX_PRS_BOX_1_ENABLED 0
 #endif
 
-// </e>
+/**
+ * @brief NRFX_PRS_BOX_2_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_PRS_BOX_2_ENABLED
+#define NRFX_PRS_BOX_2_ENABLED 0
+#endif
 
-// </e>
+/**
+ * @brief NRFX_PRS_BOX_4_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_PRS_BOX_4_ENABLED
+#define NRFX_PRS_BOX_4_ENABLED 0
+#endif
 
-// <e> NRFX_PWM_ENABLED - nrfx_pwm - PWM peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_PWM_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_PWM_ENABLED
 #define NRFX_PWM_ENABLED 0
 #endif
 
-// <q> NRFX_PWM0_ENABLED  - Enable PWM0 instance
-
-#ifndef NRFX_PWM0_ENABLED
-#define NRFX_PWM0_ENABLED 0
-#endif
-
-// <o> NRFX_PWM_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_PWM_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_PWM_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_PWM_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_PWM_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_PWM_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_PWM_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_PWM_CONFIG_LOG_ENABLED
 #define NRFX_PWM_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_PWM_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_PWM_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_PWM_CONFIG_LOG_LEVEL
 #define NRFX_PWM_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_PWM_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_PWM_CONFIG_INFO_COLOR
-#define NRFX_PWM_CONFIG_INFO_COLOR 0
+/**
+ * @brief NRFX_PWM0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_PWM0_ENABLED
+#define NRFX_PWM0_ENABLED 0
 #endif
 
-// <o> NRFX_PWM_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_PWM_CONFIG_DEBUG_COLOR
-#define NRFX_PWM_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_QDEC_ENABLED - nrfx_qdec - QDEC peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_QDEC_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_QDEC_ENABLED
 #define NRFX_QDEC_ENABLED 0
 #endif
 
-// <o> NRFX_QDEC_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_QDEC_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_QDEC_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_QDEC_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_QDEC_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_QDEC_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_QDEC_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_QDEC_CONFIG_LOG_ENABLED
 #define NRFX_QDEC_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_QDEC_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_QDEC_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_QDEC_CONFIG_LOG_LEVEL
 #define NRFX_QDEC_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_QDEC_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_QDEC_CONFIG_INFO_COLOR
-#define NRFX_QDEC_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_QDEC_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_QDEC_CONFIG_DEBUG_COLOR
-#define NRFX_QDEC_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_RNG_ENABLED - nrfx_rng - RNG peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_RNG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_RNG_ENABLED
 #define NRFX_RNG_ENABLED 0
 #endif
 
-// <o> NRFX_RNG_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_RNG_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_RNG_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_RNG_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_RNG_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_RNG_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_RNG_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_RNG_CONFIG_LOG_ENABLED
 #define NRFX_RNG_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_RNG_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_RNG_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_RNG_CONFIG_LOG_LEVEL
 #define NRFX_RNG_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_RNG_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_RNG_CONFIG_INFO_COLOR
-#define NRFX_RNG_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_RNG_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_RNG_CONFIG_DEBUG_COLOR
-#define NRFX_RNG_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_RTC_ENABLED - nrfx_rtc - RTC peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_RTC_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_RTC_ENABLED
 #define NRFX_RTC_ENABLED 0
 #endif
-// <q> NRFX_RTC0_ENABLED  - Enable RTC0 instance
 
-#ifndef NRFX_RTC0_ENABLED
-#define NRFX_RTC0_ENABLED 0
-#endif
-
-// <q> NRFX_RTC1_ENABLED  - Enable RTC1 instance
-
-#ifndef NRFX_RTC1_ENABLED
-#define NRFX_RTC1_ENABLED 0
-#endif
-
-// <o> NRFX_RTC_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_RTC_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_RTC_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_RTC_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_RTC_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_RTC_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_RTC_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_RTC_CONFIG_LOG_ENABLED
 #define NRFX_RTC_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_RTC_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_RTC_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_RTC_CONFIG_LOG_LEVEL
 #define NRFX_RTC_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_RTC_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_RTC_CONFIG_INFO_COLOR
-#define NRFX_RTC_CONFIG_INFO_COLOR 0
+/**
+ * @brief NRFX_RTC0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_RTC0_ENABLED
+#define NRFX_RTC0_ENABLED 0
 #endif
 
-// <o> NRFX_RTC_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_RTC_CONFIG_DEBUG_COLOR
-#define NRFX_RTC_CONFIG_DEBUG_COLOR 0
+/**
+ * @brief NRFX_RTC1_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_RTC1_ENABLED
+#define NRFX_RTC1_ENABLED 0
 #endif
 
-// </e>
-
-// </e>
-
-// <e> NRFX_SAADC_ENABLED - nrfx_saadc - SAADC peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_SAADC_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_SAADC_ENABLED
 #define NRFX_SAADC_ENABLED 0
 #endif
 
-// <o> NRFX_SAADC_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_SAADC_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_SAADC_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_SAADC_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_SAADC_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_SAADC_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_SAADC_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_SAADC_CONFIG_LOG_ENABLED
 #define NRFX_SAADC_CONFIG_LOG_ENABLED 0
 #endif
 
-// <o> NRFX_SAADC_CONFIG_LOG_LEVEL  - Default Severity level
-
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_SAADC_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_SAADC_CONFIG_LOG_LEVEL
 #define NRFX_SAADC_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_SAADC_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_SAADC_CONFIG_INFO_COLOR
-#define NRFX_SAADC_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_SAADC_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_SAADC_CONFIG_DEBUG_COLOR
-#define NRFX_SAADC_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_SPIM_ENABLED - nrfx_spim - SPIM peripheral driver
-//==========================================================
-#ifndef NRFX_SPIM_ENABLED
-#define NRFX_SPIM_ENABLED 0
-#endif
-
-// <q> NRFX_SPIM0_ENABLED  - Enable SPIM0 instance
-
-#ifndef NRFX_SPIM0_ENABLED
-#define NRFX_SPIM0_ENABLED 0
-#endif
-
-// <o> NRFX_SPIM_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
-#ifndef NRFX_SPIM_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_SPIM_DEFAULT_CONFIG_IRQ_PRIORITY 7
-#endif
-
-// <e> NRFX_SPIM_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
-#ifndef NRFX_SPIM_CONFIG_LOG_ENABLED
-#define NRFX_SPIM_CONFIG_LOG_ENABLED 0
-#endif
-// <o> NRFX_SPIM_CONFIG_LOG_LEVEL  - Default Severity level
-
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
-#ifndef NRFX_SPIM_CONFIG_LOG_LEVEL
-#define NRFX_SPIM_CONFIG_LOG_LEVEL 3
-#endif
-
-// <o> NRFX_SPIM_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_SPIM_CONFIG_INFO_COLOR
-#define NRFX_SPIM_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_SPIM_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_SPIM_CONFIG_DEBUG_COLOR
-#define NRFX_SPIM_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_SPIS_ENABLED - nrfx_spis - SPIS peripheral driver
-//==========================================================
-#ifndef NRFX_SPIS_ENABLED
-#define NRFX_SPIS_ENABLED 0
-#endif
-// <q> NRFX_SPIS0_ENABLED  - Enable SPIS0 instance
-
-
-#ifndef NRFX_SPIS0_ENABLED
-#define NRFX_SPIS0_ENABLED 0
-#endif
-
-// <o> NRFX_SPIS_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
-#ifndef NRFX_SPIS_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_SPIS_DEFAULT_CONFIG_IRQ_PRIORITY 7
-#endif
-
-// <e> NRFX_SPIS_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
-#ifndef NRFX_SPIS_CONFIG_LOG_ENABLED
-#define NRFX_SPIS_CONFIG_LOG_ENABLED 0
-#endif
-// <o> NRFX_SPIS_CONFIG_LOG_LEVEL  - Default Severity level
-
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
-#ifndef NRFX_SPIS_CONFIG_LOG_LEVEL
-#define NRFX_SPIS_CONFIG_LOG_LEVEL 3
-#endif
-
-// <o> NRFX_SPIS_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_SPIS_CONFIG_INFO_COLOR
-#define NRFX_SPIS_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_SPIS_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_SPIS_CONFIG_DEBUG_COLOR
-#define NRFX_SPIS_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_SPI_ENABLED - nrfx_spi - SPI peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_SPI_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_SPI_ENABLED
 #define NRFX_SPI_ENABLED 0
 #endif
-// <q> NRFX_SPI0_ENABLED  - Enable SPI0 instance
 
-
-#ifndef NRFX_SPI0_ENABLED
-#define NRFX_SPI0_ENABLED 0
-#endif
-
-// <o> NRFX_SPI_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_SPI_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_SPI_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_SPI_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_SPI_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_SPI_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_SPI_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_SPI_CONFIG_LOG_ENABLED
 #define NRFX_SPI_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_SPI_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_SPI_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_SPI_CONFIG_LOG_LEVEL
 #define NRFX_SPI_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_SPI_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_SPI_CONFIG_INFO_COLOR
-#define NRFX_SPI_CONFIG_INFO_COLOR 0
+/**
+ * @brief NRFX_SPI0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPI0_ENABLED
+#define NRFX_SPI0_ENABLED 0
 #endif
 
-// <o> NRFX_SPI_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_SPI_CONFIG_DEBUG_COLOR
-#define NRFX_SPI_CONFIG_DEBUG_COLOR 0
+/**
+ * @brief NRFX_SPIM_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPIM_ENABLED
+#define NRFX_SPIM_ENABLED 0
 #endif
 
-// </e>
+/**
+ * @brief NRFX_SPIM_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
+#ifndef NRFX_SPIM_DEFAULT_CONFIG_IRQ_PRIORITY
+#define NRFX_SPIM_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
+#endif
 
-// </e>
+/**
+ * @brief NRFX_SPIM_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPIM_CONFIG_LOG_ENABLED
+#define NRFX_SPIM_CONFIG_LOG_ENABLED 0
+#endif
 
-// <q> NRFX_SYSTICK_ENABLED  - nrfx_systick - ARM(R) SysTick driver
+/**
+ * @brief NRFX_SPIM_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
+#ifndef NRFX_SPIM_CONFIG_LOG_LEVEL
+#define NRFX_SPIM_CONFIG_LOG_LEVEL 3
+#endif
 
+/**
+ * @brief NRFX_SPIM0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPIM0_ENABLED
+#define NRFX_SPIM0_ENABLED 0
+#endif
 
+/**
+ * @brief NRFX_SPIS_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPIS_ENABLED
+#define NRFX_SPIS_ENABLED 0
+#endif
+
+/**
+ * @brief NRFX_SPIS_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
+#ifndef NRFX_SPIS_DEFAULT_CONFIG_IRQ_PRIORITY
+#define NRFX_SPIS_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
+#endif
+
+/**
+ * @brief NRFX_SPIS_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPIS_CONFIG_LOG_ENABLED
+#define NRFX_SPIS_CONFIG_LOG_ENABLED 0
+#endif
+
+/**
+ * @brief NRFX_SPIS_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
+#ifndef NRFX_SPIS_CONFIG_LOG_LEVEL
+#define NRFX_SPIS_CONFIG_LOG_LEVEL 3
+#endif
+
+/**
+ * @brief NRFX_SPIS0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPIS0_ENABLED
+#define NRFX_SPIS0_ENABLED 0
+#endif
+
+/**
+ * @brief NRFX_SYSTICK_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_SYSTICK_ENABLED
 #define NRFX_SYSTICK_ENABLED 0
 #endif
 
-// <e> NRFX_TEMP_ENABLED - nrfx_temp - TEMP peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_TEMP_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_TEMP_ENABLED
 #define NRFX_TEMP_ENABLED 0
 #endif
 
-// <o> NRFX_TEMP_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_TEMP_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_TEMP_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_TEMP_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_TEMP_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// </e>
+/**
+ * @brief NRFX_TEMP_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TEMP_CONFIG_LOG_ENABLED
+#define NRFX_TEMP_CONFIG_LOG_ENABLED 0
+#endif
 
-// <e> NRFX_TIMER_ENABLED - nrfx_timer - TIMER periperal driver
-//==========================================================
+/**
+ * @brief NRFX_TEMP_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
+#ifndef NRFX_TEMP_CONFIG_LOG_LEVEL
+#define NRFX_TEMP_CONFIG_LOG_LEVEL 3
+#endif
+
+/**
+ * @brief NRFX_TIMER_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_TIMER_ENABLED
 #define NRFX_TIMER_ENABLED 0
 #endif
 
-// <q> NRFX_TIMER0_ENABLED  - Enable TIMER0 instance
-
-#ifndef NRFX_TIMER0_ENABLED
-#define NRFX_TIMER0_ENABLED 0
-#endif
-
-// <q> NRFX_TIMER1_ENABLED  - Enable TIMER1 instance
-
-#ifndef NRFX_TIMER1_ENABLED
-#define NRFX_TIMER1_ENABLED 0
-#endif
-
-// <q> NRFX_TIMER2_ENABLED  - Enable TIMER2 instance
-
-#ifndef NRFX_TIMER2_ENABLED
-#define NRFX_TIMER2_ENABLED 0
-#endif
-
-// <o> NRFX_TIMER_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_TIMER_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_TIMER_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_TIMER_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_TIMER_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_TIMER_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_TIMER_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_TIMER_CONFIG_LOG_ENABLED
 #define NRFX_TIMER_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_TIMER_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_TIMER_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_TIMER_CONFIG_LOG_LEVEL
 #define NRFX_TIMER_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_TIMER_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_TIMER_CONFIG_INFO_COLOR
-#define NRFX_TIMER_CONFIG_INFO_COLOR 0
+/**
+ * @brief NRFX_TIMER0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TIMER0_ENABLED
+#define NRFX_TIMER0_ENABLED 0
 #endif
 
-// <o> NRFX_TIMER_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_TIMER_CONFIG_DEBUG_COLOR
-#define NRFX_TIMER_CONFIG_DEBUG_COLOR 0
+/**
+ * @brief NRFX_TIMER1_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TIMER1_ENABLED
+#define NRFX_TIMER1_ENABLED 0
 #endif
 
-// </e>
-
-// </e>
-
-// <e> NRFX_TWIM_ENABLED - nrfx_twim - TWIM peripheral driver
-//==========================================================
-#ifndef NRFX_TWIM_ENABLED
-#define NRFX_TWIM_ENABLED 0
+/**
+ * @brief NRFX_TIMER2_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TIMER2_ENABLED
+#define NRFX_TIMER2_ENABLED 0
 #endif
 
-// <q> NRFX_TWIM0_ENABLED  - Enable TWIM0 instance
-
-#ifndef NRFX_TWIM0_ENABLED
-#define NRFX_TWIM0_ENABLED 0
-#endif
-
-// <o> NRFX_TWIM_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
-#ifndef NRFX_TWIM_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_TWIM_DEFAULT_CONFIG_IRQ_PRIORITY 7
-#endif
-
-// <e> NRFX_TWIM_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
-#ifndef NRFX_TWIM_CONFIG_LOG_ENABLED
-#define NRFX_TWIM_CONFIG_LOG_ENABLED 0
-#endif
-// <o> NRFX_TWIM_CONFIG_LOG_LEVEL  - Default Severity level
-
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
-#ifndef NRFX_TWIM_CONFIG_LOG_LEVEL
-#define NRFX_TWIM_CONFIG_LOG_LEVEL 3
-#endif
-
-// <o> NRFX_TWIM_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_TWIM_CONFIG_INFO_COLOR
-#define NRFX_TWIM_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_TWIM_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_TWIM_CONFIG_DEBUG_COLOR
-#define NRFX_TWIM_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_TWIS_ENABLED - nrfx_twis - TWIS peripheral driver
-//==========================================================
-#ifndef NRFX_TWIS_ENABLED
-#define NRFX_TWIS_ENABLED 0
-#endif
-
-// <q> NRFX_TWIS0_ENABLED  - Enable TWIS0 instance
-
-#ifndef NRFX_TWIS0_ENABLED
-#define NRFX_TWIS0_ENABLED 0
-#endif
-
-// <q> NRFX_TWIS_ASSUME_INIT_AFTER_RESET_ONLY  - Assume that any instance would be initialized only once
-
-// <i> Optimization flag. Registers used by TWIS are shared by other peripherals. Normally, during initialization driver tries to clear all registers to known state before doing the initialization itself. This gives initialization safe procedure, no matter when it would be called. If you activate TWIS only once and do never uninitialize it - set this flag to 1 what gives more optimal code.
-
-#ifndef NRFX_TWIS_ASSUME_INIT_AFTER_RESET_ONLY
-#define NRFX_TWIS_ASSUME_INIT_AFTER_RESET_ONLY 0
-#endif
-
-// <q> NRFX_TWIS_NO_SYNC_MODE  - Remove support for synchronous mode
-
-// <i> Synchronous mode would be used in specific situations. And it uses some additional code and data memory to safely process state machine by polling it in status functions. If this functionality is not required it may be disabled to free some resources.
-
-#ifndef NRFX_TWIS_NO_SYNC_MODE
-#define NRFX_TWIS_NO_SYNC_MODE 0
-#endif
-
-// <o> NRFX_TWIS_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
-#ifndef NRFX_TWIS_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_TWIS_DEFAULT_CONFIG_IRQ_PRIORITY 7
-#endif
-
-// <e> NRFX_TWIS_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
-#ifndef NRFX_TWIS_CONFIG_LOG_ENABLED
-#define NRFX_TWIS_CONFIG_LOG_ENABLED 0
-#endif
-// <o> NRFX_TWIS_CONFIG_LOG_LEVEL  - Default Severity level
-
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
-#ifndef NRFX_TWIS_CONFIG_LOG_LEVEL
-#define NRFX_TWIS_CONFIG_LOG_LEVEL 3
-#endif
-
-// <o> NRFX_TWIS_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_TWIS_CONFIG_INFO_COLOR
-#define NRFX_TWIS_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_TWIS_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_TWIS_CONFIG_DEBUG_COLOR
-#define NRFX_TWIS_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_TWI_ENABLED - nrfx_twi - TWI peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_TWI_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_TWI_ENABLED
 #define NRFX_TWI_ENABLED 0
 #endif
 
-// <q> NRFX_TWI0_ENABLED  - Enable TWI0 instance
-
-#ifndef NRFX_TWI0_ENABLED
-#define NRFX_TWI0_ENABLED 0
-#endif
-
-// <o> NRFX_TWI_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_TWI_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_TWI_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_TWI_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_TWI_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_TWI_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_TWI_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_TWI_CONFIG_LOG_ENABLED
 #define NRFX_TWI_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_TWI_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_TWI_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_TWI_CONFIG_LOG_LEVEL
 #define NRFX_TWI_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_TWI_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_TWI_CONFIG_INFO_COLOR
-#define NRFX_TWI_CONFIG_INFO_COLOR 0
+/**
+ * @brief NRFX_TWI0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWI0_ENABLED
+#define NRFX_TWI0_ENABLED 0
 #endif
 
-// <o> NRFX_TWI_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_TWI_CONFIG_DEBUG_COLOR
-#define NRFX_TWI_CONFIG_DEBUG_COLOR 0
+/**
+ * @brief NRFX_TWIM_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWIM_ENABLED
+#define NRFX_TWIM_ENABLED 0
 #endif
 
-// </e>
-
-// </e>
-
-// <e> NRFX_UARTE_ENABLED - nrfx_uarte - UARTE peripheral driver
-//==========================================================
-#ifndef NRFX_UARTE_ENABLED
-#define NRFX_UARTE_ENABLED 0
+/**
+ * @brief NRFX_TWIM_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
+#ifndef NRFX_TWIM_DEFAULT_CONFIG_IRQ_PRIORITY
+#define NRFX_TWIM_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <q> NRFX_UARTE0_ENABLED - Enable UARTE0 instance
-
-#ifndef NRFX_UARTE0_ENABLED
-#define NRFX_UARTE0_ENABLED 0
+/**
+ * @brief NRFX_TWIM_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWIM_CONFIG_LOG_ENABLED
+#define NRFX_TWIM_CONFIG_LOG_ENABLED 0
 #endif
 
-// <o> NRFX_UARTE_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
-#ifndef NRFX_UARTE_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_UARTE_DEFAULT_CONFIG_IRQ_PRIORITY 7
+/**
+ * @brief NRFX_TWIM_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
+#ifndef NRFX_TWIM_CONFIG_LOG_LEVEL
+#define NRFX_TWIM_CONFIG_LOG_LEVEL 3
 #endif
 
-// <e> NRFX_UARTE_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
-#ifndef NRFX_UARTE_CONFIG_LOG_ENABLED
-#define NRFX_UARTE_CONFIG_LOG_ENABLED 0
-#endif
-// <o> NRFX_UARTE_CONFIG_LOG_LEVEL  - Default Severity level
-
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
-#ifndef NRFX_UARTE_CONFIG_LOG_LEVEL
-#define NRFX_UARTE_CONFIG_LOG_LEVEL 3
+/**
+ * @brief NRFX_TWIM0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWIM0_ENABLED
+#define NRFX_TWIM0_ENABLED 0
 #endif
 
-// <o> NRFX_UARTE_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_UARTE_CONFIG_INFO_COLOR
-#define NRFX_UARTE_CONFIG_INFO_COLOR 0
+/**
+ * @brief NRFX_TWIS_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWIS_ENABLED
+#define NRFX_TWIS_ENABLED 0
 #endif
 
-// <o> NRFX_UARTE_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_UARTE_CONFIG_DEBUG_COLOR
-#define NRFX_UARTE_CONFIG_DEBUG_COLOR 0
+/**
+ * @brief NRFX_TWIS_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
+#ifndef NRFX_TWIS_DEFAULT_CONFIG_IRQ_PRIORITY
+#define NRFX_TWIS_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// </e>
+/**
+ * @brief NRFX_TWIS_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWIS_CONFIG_LOG_ENABLED
+#define NRFX_TWIS_CONFIG_LOG_ENABLED 0
+#endif
 
-// </e>
+/**
+ * @brief NRFX_TWIS_ASSUME_INIT_AFTER_RESET_ONLY - Assume that any instance would be initialized only once.
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWIS_ASSUME_INIT_AFTER_RESET_ONLY
+#define NRFX_TWIS_ASSUME_INIT_AFTER_RESET_ONLY 0
+#endif
 
-// <e> NRFX_UART_ENABLED - nrfx_uart - UART peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_TWIS_NO_SYNC_MODE - Remove support for synchronous mode.
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWIS_NO_SYNC_MODE
+#define NRFX_TWIS_NO_SYNC_MODE 0
+#endif
+
+/**
+ * @brief NRFX_TWIS_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
+#ifndef NRFX_TWIS_CONFIG_LOG_LEVEL
+#define NRFX_TWIS_CONFIG_LOG_LEVEL 3
+#endif
+
+/**
+ * @brief NRFX_TWIS0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWIS0_ENABLED
+#define NRFX_TWIS0_ENABLED 0
+#endif
+
+/**
+ * @brief NRFX_UART_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_UART_ENABLED
 #define NRFX_UART_ENABLED 0
 #endif
 
-// <q> NRFX_UART0_ENABLED - Enable UART0 instance
-
-#ifndef NRFX_UART0_ENABLED
-#define NRFX_UART0_ENABLED 0
-#endif
-
-// <o> NRFX_UART_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_UART_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_UART_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_UART_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_UART_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_UART_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_UART_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_UART_CONFIG_LOG_ENABLED
 #define NRFX_UART_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_UART_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_UART_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_UART_CONFIG_LOG_LEVEL
 #define NRFX_UART_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_UART_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_UART_CONFIG_INFO_COLOR
-#define NRFX_UART_CONFIG_INFO_COLOR 0
+/**
+ * @brief NRFX_UART0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_UART0_ENABLED
+#define NRFX_UART0_ENABLED 0
 #endif
 
-// <o> NRFX_UART_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_UART_CONFIG_DEBUG_COLOR
-#define NRFX_UART_CONFIG_DEBUG_COLOR 0
+/**
+ * @brief NRFX_UARTE_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_UARTE_ENABLED
+#define NRFX_UARTE_ENABLED 0
 #endif
 
-// </e>
+/**
+ * @brief NRFX_UARTE_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
+#ifndef NRFX_UARTE_DEFAULT_CONFIG_IRQ_PRIORITY
+#define NRFX_UARTE_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
+#endif
 
-// </e>
+/**
+ * @brief NRFX_UARTE_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_UARTE_CONFIG_LOG_ENABLED
+#define NRFX_UARTE_CONFIG_LOG_ENABLED 0
+#endif
 
-// <e> NRFX_WDT_ENABLED - nrfx_wdt - WDT peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_UARTE_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
+#ifndef NRFX_UARTE_CONFIG_LOG_LEVEL
+#define NRFX_UARTE_CONFIG_LOG_LEVEL 3
+#endif
+
+/**
+ * @brief NRFX_UARTE0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_UARTE0_ENABLED
+#define NRFX_UARTE0_ENABLED 0
+#endif
+
+/**
+ * @brief NRFX_WDT_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_WDT_ENABLED
 #define NRFX_WDT_ENABLED 0
 #endif
 
-// <q> NRFX_WDT0_ENABLED  - Enable WDT0 instance
-
-#ifndef NRFX_WDT0_ENABLED
-#define NRFX_WDT0_ENABLED 0
+/**
+ * @brief NRFX_WDT_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
+#ifndef NRFX_WDT_DEFAULT_CONFIG_IRQ_PRIORITY
+#define NRFX_WDT_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <o> NRFX_WDT_CONFIG_NO_IRQ  - Remove WDT IRQ handling from WDT driver
-
-// <0=> Include WDT IRQ handling
-// <1=> Remove WDT IRQ handling
-
+/**
+ * @brief NRFX_WDT_CONFIG_NO_IRQ - Remove WDT IRQ handling from WDT driver
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_WDT_CONFIG_NO_IRQ
 #define NRFX_WDT_CONFIG_NO_IRQ 0
 #endif
 
-// <o> NRFX_WDT_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
-#ifndef NRFX_WDT_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_WDT_DEFAULT_CONFIG_IRQ_PRIORITY 7
-#endif
-
-// <e> NRFX_WDT_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_WDT_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_WDT_CONFIG_LOG_ENABLED
 #define NRFX_WDT_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_WDT_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_WDT_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_WDT_CONFIG_LOG_LEVEL
 #define NRFX_WDT_CONFIG_LOG_LEVEL 3
 #endif
-
-// <o> NRFX_WDT_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_WDT_CONFIG_INFO_COLOR
-#define NRFX_WDT_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_WDT_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_WDT_CONFIG_DEBUG_COLOR
-#define NRFX_WDT_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// </h>
 
 #endif // NRFX_CONFIG_NRF52810_H__

--- a/nrfx/templates/nrfx_config_nrf52811.h
+++ b/nrfx/templates/nrfx_config_nrf52811.h
@@ -38,1818 +38,1259 @@
 #error "This file should not be included directly. Include nrfx_config.h instead."
 #endif
 
-// <<< Use Configuration Wizard in Context Menu >>>\n
 
-// <h> nRF_Drivers
+/**
+ * @brief NRFX_DEFAULT_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
+#ifndef NRFX_DEFAULT_IRQ_PRIORITY
+#define NRFX_DEFAULT_IRQ_PRIORITY 7
+#endif
 
-// <e> NRFX_CLOCK_ENABLED - nrfx_clock - CLOCK peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_CLOCK_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_CLOCK_ENABLED
 #define NRFX_CLOCK_ENABLED 0
 #endif
-// <o> NRFX_CLOCK_CONFIG_LF_SRC  - LF Clock Source
 
-// <0=> RC
-// <1=> XTAL
-// <2=> Synth
-// <131073=> External Low Swing
-// <196609=> External Full Swing
-
+/**
+ * @brief NRFX_CLOCK_CONFIG_LF_SRC
+ *
+ * Integer value.
+ * Supported values:
+ * - RC                  = 0
+ * - XTAL                = 1
+ * - Synth               = 2
+ * - External Low Swing  = 131073
+ * - External Full Swing = 196609
+ */
 #ifndef NRFX_CLOCK_CONFIG_LF_SRC
 #define NRFX_CLOCK_CONFIG_LF_SRC 1
 #endif
 
-// <q> NRFX_CLOCK_CONFIG_LF_CAL_ENABLED  - Enables LF Clock Calibration Support
-
+/**
+ * @brief NRFX_CLOCK_CONFIG_LF_CAL_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_CLOCK_CONFIG_LF_CAL_ENABLED
 #define NRFX_CLOCK_CONFIG_LF_CAL_ENABLED 0
 #endif
 
-// <q> NRFX_CLOCK_CONFIG_CT_ENABLED  - Enables Calibration Timer Support
-
+/**
+ * @brief NRFX_CLOCK_CONFIG_CT_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_CLOCK_CONFIG_CT_ENABLED
 #define NRFX_CLOCK_CONFIG_CT_ENABLED 1
 #endif
 
-// <q> NRFX_CLOCK_CONFIG_LFXO_TWO_STAGE_ENABLED - Enables two-stage LFXO start procedure
-
-// <i> If set to a non-zero value, LFRC will be started before LFXO and corresponding
-// <i> event will be generated. It means that CPU will be woken up when LFRC
-// <i> oscillator starts, but user callback will be invoked only after LFXO
-// <i> finally starts.
-
+/**
+ * @brief NRFX_CLOCK_CONFIG_LFXO_TWO_STAGE_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_CLOCK_CONFIG_LFXO_TWO_STAGE_ENABLED
 #define NRFX_CLOCK_CONFIG_LFXO_TWO_STAGE_ENABLED 0
 #endif
 
-// <o> NRFX_CLOCK_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_CLOCK_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_CLOCK_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_CLOCK_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_CLOCK_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_CLOCK_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_CLOCK_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_CLOCK_CONFIG_LOG_ENABLED
 #define NRFX_CLOCK_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_CLOCK_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_CLOCK_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_CLOCK_CONFIG_LOG_LEVEL
 #define NRFX_CLOCK_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_CLOCK_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_CLOCK_CONFIG_INFO_COLOR
-#define NRFX_CLOCK_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_CLOCK_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_CLOCK_CONFIG_DEBUG_COLOR
-#define NRFX_CLOCK_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_COMP_ENABLED - nrfx_comp - COMP peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_COMP_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_COMP_ENABLED
 #define NRFX_COMP_ENABLED 0
 #endif
 
-// <o> NRFX_COMP_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_COMP_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_COMP_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_COMP_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_COMP_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_COMP_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_COMP_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_COMP_CONFIG_LOG_ENABLED
 #define NRFX_COMP_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_COMP_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_COMP_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_COMP_CONFIG_LOG_LEVEL
 #define NRFX_COMP_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_COMP_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_COMP_CONFIG_INFO_COLOR
-#define NRFX_COMP_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_COMP_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_COMP_CONFIG_DEBUG_COLOR
-#define NRFX_COMP_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_EGU_ENABLED - nrfx_egu - EGU peripheral driver.
-//==========================================================
+/**
+ * @brief NRFX_EGU_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_EGU_ENABLED
 #define NRFX_EGU_ENABLED 0
 #endif
 
-// <q> NRFX_EGU0_ENABLED  - Enable EGU0 instance.
+/**
+ * @brief NRFX_EGU_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
+#ifndef NRFX_EGU_DEFAULT_CONFIG_IRQ_PRIORITY
+#define NRFX_EGU_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
+#endif
 
+/**
+ * @brief NRFX_EGU0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_EGU0_ENABLED
 #define NRFX_EGU0_ENABLED 0
 #endif
 
-// <q> NRFX_EGU1_ENABLED  - Enable EGU1 instance.
-
+/**
+ * @brief NRFX_EGU1_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_EGU1_ENABLED
 #define NRFX_EGU1_ENABLED 0
 #endif
 
-// <o> NRFX_EGU_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority.
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
-#ifndef NRFX_EGU_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_EGU_DEFAULT_CONFIG_IRQ_PRIORITY 7
-#endif
-
-// </e>
-
-// <e> NRFX_GPIOTE_ENABLED - nrfx_gpiote - GPIOTE peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_GPIOTE_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_GPIOTE_ENABLED
 #define NRFX_GPIOTE_ENABLED 0
 #endif
 
-// <o> NRFX_GPIOTE_CONFIG_NUM_OF_EVT_HANDLERS - Number of dedicated handlers
+/**
+ * @brief NRFX_GPIOTE_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
+#ifndef NRFX_GPIOTE_DEFAULT_CONFIG_IRQ_PRIORITY
+#define NRFX_GPIOTE_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
+#endif
+
+/**
+ * @brief NRFX_GPIOTE_CONFIG_NUM_OF_EVT_HANDLERS
+ *
+ * Integer value. Minimum: 0 Maximum: 15
+ */
 #ifndef NRFX_GPIOTE_CONFIG_NUM_OF_EVT_HANDLERS
 #define NRFX_GPIOTE_CONFIG_NUM_OF_EVT_HANDLERS 2
 #endif
 
-// <o> NRFX_GPIOTE_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
-#ifndef NRFX_GPIOTE_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_GPIOTE_DEFAULT_CONFIG_IRQ_PRIORITY 7
-#endif
-
-// <e> NRFX_GPIOTE_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_GPIOTE_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_GPIOTE_CONFIG_LOG_ENABLED
 #define NRFX_GPIOTE_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_GPIOTE_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_GPIOTE_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_GPIOTE_CONFIG_LOG_LEVEL
 #define NRFX_GPIOTE_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_GPIOTE_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_GPIOTE_CONFIG_INFO_COLOR
-#define NRFX_GPIOTE_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_GPIOTE_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_GPIOTE_CONFIG_DEBUG_COLOR
-#define NRFX_GPIOTE_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_NVMC_ENABLED - nrfx_nvmc - NVMC peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_NVMC_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_NVMC_ENABLED
 #define NRFX_NVMC_ENABLED 0
 #endif
 
-// </e>
-
-// <e> NRFX_PDM_ENABLED - nrfx_pdm - PDM peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_PDM_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_PDM_ENABLED
 #define NRFX_PDM_ENABLED 0
 #endif
 
-// <o> NRFX_PDM_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_PDM_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_PDM_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_PDM_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_PDM_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_PDM_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_PDM_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_PDM_CONFIG_LOG_ENABLED
 #define NRFX_PDM_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_PDM_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_PDM_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_PDM_CONFIG_LOG_LEVEL
 #define NRFX_PDM_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_PDM_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_PDM_CONFIG_INFO_COLOR
-#define NRFX_PDM_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_PDM_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_PDM_CONFIG_DEBUG_COLOR
-#define NRFX_PDM_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_POWER_ENABLED - nrfx_power - POWER peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_POWER_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_POWER_ENABLED
 #define NRFX_POWER_ENABLED 0
 #endif
-// <o> NRFX_POWER_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
 
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_POWER_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_POWER_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_POWER_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_POWER_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// </e>
-
-// <e> NRFX_PPI_ENABLED - nrfx_ppi - PPI peripheral allocator
-//==========================================================
+/**
+ * @brief NRFX_PPI_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_PPI_ENABLED
 #define NRFX_PPI_ENABLED 0
 #endif
-// <e> NRFX_PPI_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+
+/**
+ * @brief NRFX_PPI_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_PPI_CONFIG_LOG_ENABLED
 #define NRFX_PPI_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_PPI_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_PPI_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_PPI_CONFIG_LOG_LEVEL
 #define NRFX_PPI_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_PPI_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_PPI_CONFIG_INFO_COLOR
-#define NRFX_PPI_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_PPI_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_PPI_CONFIG_DEBUG_COLOR
-#define NRFX_PPI_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_PRS_ENABLED - nrfx_prs - Peripheral Resource Sharing module
-//==========================================================
+/**
+ * @brief NRFX_PRS_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_PRS_ENABLED
 #define NRFX_PRS_ENABLED 0
 #endif
-// <q> NRFX_PRS_BOX_0_ENABLED  - Enables box 0 in the module.
 
-
-#ifndef NRFX_PRS_BOX_0_ENABLED
-#define NRFX_PRS_BOX_0_ENABLED 0
-#endif
-
-// <q> NRFX_PRS_BOX_1_ENABLED  - Enables box 1 in the module.
-
-
-#ifndef NRFX_PRS_BOX_1_ENABLED
-#define NRFX_PRS_BOX_1_ENABLED 0
-#endif
-
-// <q> NRFX_PRS_BOX_2_ENABLED  - Enables box 2 in the module.
-
-
-#ifndef NRFX_PRS_BOX_2_ENABLED
-#define NRFX_PRS_BOX_2_ENABLED 0
-#endif
-
-
-// <e> NRFX_PRS_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_PRS_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_PRS_CONFIG_LOG_ENABLED
 #define NRFX_PRS_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_PRS_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_PRS_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_PRS_CONFIG_LOG_LEVEL
 #define NRFX_PRS_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_PRS_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_PRS_CONFIG_INFO_COLOR
-#define NRFX_PRS_CONFIG_INFO_COLOR 0
+/**
+ * @brief NRFX_PRS_BOX_0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_PRS_BOX_0_ENABLED
+#define NRFX_PRS_BOX_0_ENABLED 0
 #endif
 
-// <o> NRFX_PRS_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_PRS_CONFIG_DEBUG_COLOR
-#define NRFX_PRS_CONFIG_DEBUG_COLOR 0
+/**
+ * @brief NRFX_PRS_BOX_1_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_PRS_BOX_1_ENABLED
+#define NRFX_PRS_BOX_1_ENABLED 0
 #endif
 
-// </e>
+/**
+ * @brief NRFX_PRS_BOX_2_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_PRS_BOX_2_ENABLED
+#define NRFX_PRS_BOX_2_ENABLED 0
+#endif
 
-// </e>
+/**
+ * @brief NRFX_PRS_BOX_4_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_PRS_BOX_4_ENABLED
+#define NRFX_PRS_BOX_4_ENABLED 0
+#endif
 
-// <e> NRFX_PWM_ENABLED - nrfx_pwm - PWM peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_PWM_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_PWM_ENABLED
 #define NRFX_PWM_ENABLED 0
 #endif
 
-// <q> NRFX_PWM0_ENABLED  - Enable PWM0 instance
-
-#ifndef NRFX_PWM0_ENABLED
-#define NRFX_PWM0_ENABLED 0
-#endif
-
-// <o> NRFX_PWM_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_PWM_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_PWM_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_PWM_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_PWM_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_PWM_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_PWM_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_PWM_CONFIG_LOG_ENABLED
 #define NRFX_PWM_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_PWM_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_PWM_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_PWM_CONFIG_LOG_LEVEL
 #define NRFX_PWM_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_PWM_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_PWM_CONFIG_INFO_COLOR
-#define NRFX_PWM_CONFIG_INFO_COLOR 0
+/**
+ * @brief NRFX_PWM0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_PWM0_ENABLED
+#define NRFX_PWM0_ENABLED 0
 #endif
 
-// <o> NRFX_PWM_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_PWM_CONFIG_DEBUG_COLOR
-#define NRFX_PWM_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_QDEC_ENABLED - nrfx_qdec - QDEC peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_QDEC_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_QDEC_ENABLED
 #define NRFX_QDEC_ENABLED 0
 #endif
 
-// <o> NRFX_QDEC_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_QDEC_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_QDEC_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_QDEC_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_QDEC_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_QDEC_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_QDEC_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_QDEC_CONFIG_LOG_ENABLED
 #define NRFX_QDEC_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_QDEC_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_QDEC_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_QDEC_CONFIG_LOG_LEVEL
 #define NRFX_QDEC_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_QDEC_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_QDEC_CONFIG_INFO_COLOR
-#define NRFX_QDEC_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_QDEC_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_QDEC_CONFIG_DEBUG_COLOR
-#define NRFX_QDEC_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_RNG_ENABLED - nrfx_rng - RNG peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_RNG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_RNG_ENABLED
 #define NRFX_RNG_ENABLED 0
 #endif
 
-// <o> NRFX_RNG_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_RNG_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_RNG_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_RNG_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_RNG_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_RNG_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_RNG_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_RNG_CONFIG_LOG_ENABLED
 #define NRFX_RNG_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_RNG_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_RNG_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_RNG_CONFIG_LOG_LEVEL
 #define NRFX_RNG_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_RNG_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_RNG_CONFIG_INFO_COLOR
-#define NRFX_RNG_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_RNG_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_RNG_CONFIG_DEBUG_COLOR
-#define NRFX_RNG_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_RTC_ENABLED - nrfx_rtc - RTC peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_RTC_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_RTC_ENABLED
 #define NRFX_RTC_ENABLED 0
 #endif
-// <q> NRFX_RTC0_ENABLED  - Enable RTC0 instance
 
-#ifndef NRFX_RTC0_ENABLED
-#define NRFX_RTC0_ENABLED 0
-#endif
-
-// <q> NRFX_RTC1_ENABLED  - Enable RTC1 instance
-
-#ifndef NRFX_RTC1_ENABLED
-#define NRFX_RTC1_ENABLED 0
-#endif
-
-// <o> NRFX_RTC_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_RTC_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_RTC_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_RTC_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_RTC_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_RTC_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_RTC_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_RTC_CONFIG_LOG_ENABLED
 #define NRFX_RTC_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_RTC_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_RTC_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_RTC_CONFIG_LOG_LEVEL
 #define NRFX_RTC_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_RTC_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_RTC_CONFIG_INFO_COLOR
-#define NRFX_RTC_CONFIG_INFO_COLOR 0
+/**
+ * @brief NRFX_RTC0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_RTC0_ENABLED
+#define NRFX_RTC0_ENABLED 0
 #endif
 
-// <o> NRFX_RTC_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_RTC_CONFIG_DEBUG_COLOR
-#define NRFX_RTC_CONFIG_DEBUG_COLOR 0
+/**
+ * @brief NRFX_RTC1_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_RTC1_ENABLED
+#define NRFX_RTC1_ENABLED 0
 #endif
 
-// </e>
-
-// </e>
-
-// <e> NRFX_SAADC_ENABLED - nrfx_saadc - SAADC peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_SAADC_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_SAADC_ENABLED
 #define NRFX_SAADC_ENABLED 0
 #endif
 
-// <o> NRFX_SAADC_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_SAADC_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_SAADC_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_SAADC_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_SAADC_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_SAADC_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_SAADC_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_SAADC_CONFIG_LOG_ENABLED
 #define NRFX_SAADC_CONFIG_LOG_ENABLED 0
 #endif
 
-// <o> NRFX_SAADC_CONFIG_LOG_LEVEL  - Default Severity level
-
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_SAADC_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_SAADC_CONFIG_LOG_LEVEL
 #define NRFX_SAADC_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_SAADC_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_SAADC_CONFIG_INFO_COLOR
-#define NRFX_SAADC_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_SAADC_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_SAADC_CONFIG_DEBUG_COLOR
-#define NRFX_SAADC_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_SPIM_ENABLED - nrfx_spim - SPIM peripheral driver
-//==========================================================
-#ifndef NRFX_SPIM_ENABLED
-#define NRFX_SPIM_ENABLED 0
-#endif
-
-// <q> NRFX_SPIM0_ENABLED  - Enable SPIM0 instance
-
-#ifndef NRFX_SPIM0_ENABLED
-#define NRFX_SPIM0_ENABLED 0
-#endif
-
-#ifndef NRFX_SPIM1_ENABLED
-#define NRFX_SPIM1_ENABLED 0
-#endif
-
-// <o> NRFX_SPIM_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
-#ifndef NRFX_SPIM_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_SPIM_DEFAULT_CONFIG_IRQ_PRIORITY 7
-#endif
-
-// <e> NRFX_SPIM_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
-#ifndef NRFX_SPIM_CONFIG_LOG_ENABLED
-#define NRFX_SPIM_CONFIG_LOG_ENABLED 0
-#endif
-// <o> NRFX_SPIM_CONFIG_LOG_LEVEL  - Default Severity level
-
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
-#ifndef NRFX_SPIM_CONFIG_LOG_LEVEL
-#define NRFX_SPIM_CONFIG_LOG_LEVEL 3
-#endif
-
-// <o> NRFX_SPIM_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_SPIM_CONFIG_INFO_COLOR
-#define NRFX_SPIM_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_SPIM_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_SPIM_CONFIG_DEBUG_COLOR
-#define NRFX_SPIM_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_SPIS_ENABLED - nrfx_spis - SPIS peripheral driver
-//==========================================================
-#ifndef NRFX_SPIS_ENABLED
-#define NRFX_SPIS_ENABLED 0
-#endif
-// <q> NRFX_SPIS0_ENABLED  - Enable SPIS0 instance
-
-
-#ifndef NRFX_SPIS0_ENABLED
-#define NRFX_SPIS0_ENABLED 0
-#endif
-
-#ifndef NRFX_SPIS1_ENABLED
-#define NRFX_SPIS1_ENABLED 0
-#endif
-
-// <o> NRFX_SPIS_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
-#ifndef NRFX_SPIS_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_SPIS_DEFAULT_CONFIG_IRQ_PRIORITY 7
-#endif
-
-// <e> NRFX_SPIS_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
-#ifndef NRFX_SPIS_CONFIG_LOG_ENABLED
-#define NRFX_SPIS_CONFIG_LOG_ENABLED 0
-#endif
-// <o> NRFX_SPIS_CONFIG_LOG_LEVEL  - Default Severity level
-
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
-#ifndef NRFX_SPIS_CONFIG_LOG_LEVEL
-#define NRFX_SPIS_CONFIG_LOG_LEVEL 3
-#endif
-
-// <o> NRFX_SPIS_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_SPIS_CONFIG_INFO_COLOR
-#define NRFX_SPIS_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_SPIS_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_SPIS_CONFIG_DEBUG_COLOR
-#define NRFX_SPIS_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_SPI_ENABLED - nrfx_spi - SPI peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_SPI_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_SPI_ENABLED
 #define NRFX_SPI_ENABLED 0
 #endif
-// <q> NRFX_SPI0_ENABLED  - Enable SPI0 instance
 
-
-#ifndef NRFX_SPI0_ENABLED
-#define NRFX_SPI0_ENABLED 0
-#endif
-
-// <q> NRFX_SPI1_ENABLED  - Enable SPI1 instance
-
-
-#ifndef NRFX_SPI1_ENABLED
-#define NRFX_SPI1_ENABLED 0
-#endif
-
-// <o> NRFX_SPI_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_SPI_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_SPI_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_SPI_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_SPI_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_SPI_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_SPI_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_SPI_CONFIG_LOG_ENABLED
 #define NRFX_SPI_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_SPI_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_SPI_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_SPI_CONFIG_LOG_LEVEL
 #define NRFX_SPI_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_SPI_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_SPI_CONFIG_INFO_COLOR
-#define NRFX_SPI_CONFIG_INFO_COLOR 0
+/**
+ * @brief NRFX_SPI1_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPI1_ENABLED
+#define NRFX_SPI1_ENABLED 0
 #endif
 
-// <o> NRFX_SPI_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_SPI_CONFIG_DEBUG_COLOR
-#define NRFX_SPI_CONFIG_DEBUG_COLOR 0
+/**
+ * @brief NRFX_SPI0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPI0_ENABLED
+#define NRFX_SPI0_ENABLED 0
 #endif
 
-// </e>
+/**
+ * @brief NRFX_SPIM_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPIM_ENABLED
+#define NRFX_SPIM_ENABLED 0
+#endif
 
-// </e>
+/**
+ * @brief NRFX_SPIM_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
+#ifndef NRFX_SPIM_DEFAULT_CONFIG_IRQ_PRIORITY
+#define NRFX_SPIM_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
+#endif
 
-// <q> NRFX_SYSTICK_ENABLED  - nrfx_systick - ARM(R) SysTick driver
+/**
+ * @brief NRFX_SPIM_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPIM_CONFIG_LOG_ENABLED
+#define NRFX_SPIM_CONFIG_LOG_ENABLED 0
+#endif
 
+/**
+ * @brief NRFX_SPIM_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
+#ifndef NRFX_SPIM_CONFIG_LOG_LEVEL
+#define NRFX_SPIM_CONFIG_LOG_LEVEL 3
+#endif
 
+/**
+ * @brief NRFX_SPIM1_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPIM1_ENABLED
+#define NRFX_SPIM1_ENABLED 0
+#endif
+
+/**
+ * @brief NRFX_SPIM0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPIM0_ENABLED
+#define NRFX_SPIM0_ENABLED 0
+#endif
+
+/**
+ * @brief NRFX_SPIS_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPIS_ENABLED
+#define NRFX_SPIS_ENABLED 0
+#endif
+
+/**
+ * @brief NRFX_SPIS_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
+#ifndef NRFX_SPIS_DEFAULT_CONFIG_IRQ_PRIORITY
+#define NRFX_SPIS_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
+#endif
+
+/**
+ * @brief NRFX_SPIS_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPIS_CONFIG_LOG_ENABLED
+#define NRFX_SPIS_CONFIG_LOG_ENABLED 0
+#endif
+
+/**
+ * @brief NRFX_SPIS_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
+#ifndef NRFX_SPIS_CONFIG_LOG_LEVEL
+#define NRFX_SPIS_CONFIG_LOG_LEVEL 3
+#endif
+
+/**
+ * @brief NRFX_SPIS1_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPIS1_ENABLED
+#define NRFX_SPIS1_ENABLED 0
+#endif
+
+/**
+ * @brief NRFX_SPIS0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPIS0_ENABLED
+#define NRFX_SPIS0_ENABLED 0
+#endif
+
+/**
+ * @brief NRFX_SYSTICK_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_SYSTICK_ENABLED
 #define NRFX_SYSTICK_ENABLED 0
 #endif
 
-// <e> NRFX_TEMP_ENABLED - nrfx_temp - TEMP peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_TEMP_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_TEMP_ENABLED
 #define NRFX_TEMP_ENABLED 0
 #endif
 
-// <o> NRFX_TEMP_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_TEMP_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_TEMP_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_TEMP_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_TEMP_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// </e>
+/**
+ * @brief NRFX_TEMP_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TEMP_CONFIG_LOG_ENABLED
+#define NRFX_TEMP_CONFIG_LOG_ENABLED 0
+#endif
 
-// <e> NRFX_TIMER_ENABLED - nrfx_timer - TIMER periperal driver
-//==========================================================
+/**
+ * @brief NRFX_TEMP_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
+#ifndef NRFX_TEMP_CONFIG_LOG_LEVEL
+#define NRFX_TEMP_CONFIG_LOG_LEVEL 3
+#endif
+
+/**
+ * @brief NRFX_TIMER_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_TIMER_ENABLED
 #define NRFX_TIMER_ENABLED 0
 #endif
 
-// <q> NRFX_TIMER0_ENABLED  - Enable TIMER0 instance
-
-#ifndef NRFX_TIMER0_ENABLED
-#define NRFX_TIMER0_ENABLED 0
-#endif
-
-// <q> NRFX_TIMER1_ENABLED  - Enable TIMER1 instance
-
-#ifndef NRFX_TIMER1_ENABLED
-#define NRFX_TIMER1_ENABLED 0
-#endif
-
-// <q> NRFX_TIMER2_ENABLED  - Enable TIMER2 instance
-
-#ifndef NRFX_TIMER2_ENABLED
-#define NRFX_TIMER2_ENABLED 0
-#endif
-
-// <o> NRFX_TIMER_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_TIMER_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_TIMER_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_TIMER_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_TIMER_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_TIMER_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_TIMER_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_TIMER_CONFIG_LOG_ENABLED
 #define NRFX_TIMER_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_TIMER_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_TIMER_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_TIMER_CONFIG_LOG_LEVEL
 #define NRFX_TIMER_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_TIMER_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_TIMER_CONFIG_INFO_COLOR
-#define NRFX_TIMER_CONFIG_INFO_COLOR 0
+/**
+ * @brief NRFX_TIMER0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TIMER0_ENABLED
+#define NRFX_TIMER0_ENABLED 0
 #endif
 
-// <o> NRFX_TIMER_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_TIMER_CONFIG_DEBUG_COLOR
-#define NRFX_TIMER_CONFIG_DEBUG_COLOR 0
+/**
+ * @brief NRFX_TIMER1_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TIMER1_ENABLED
+#define NRFX_TIMER1_ENABLED 0
 #endif
 
-// </e>
-
-// </e>
-
-// <e> NRFX_TWIM_ENABLED - nrfx_twim - TWIM peripheral driver
-//==========================================================
-#ifndef NRFX_TWIM_ENABLED
-#define NRFX_TWIM_ENABLED 0
+/**
+ * @brief NRFX_TIMER2_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TIMER2_ENABLED
+#define NRFX_TIMER2_ENABLED 0
 #endif
 
-// <q> NRFX_TWIM0_ENABLED  - Enable TWIM0 instance
-
-#ifndef NRFX_TWIM0_ENABLED
-#define NRFX_TWIM0_ENABLED 0
-#endif
-
-// <o> NRFX_TWIM_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
-#ifndef NRFX_TWIM_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_TWIM_DEFAULT_CONFIG_IRQ_PRIORITY 7
-#endif
-
-// <e> NRFX_TWIM_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
-#ifndef NRFX_TWIM_CONFIG_LOG_ENABLED
-#define NRFX_TWIM_CONFIG_LOG_ENABLED 0
-#endif
-// <o> NRFX_TWIM_CONFIG_LOG_LEVEL  - Default Severity level
-
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
-#ifndef NRFX_TWIM_CONFIG_LOG_LEVEL
-#define NRFX_TWIM_CONFIG_LOG_LEVEL 3
-#endif
-
-// <o> NRFX_TWIM_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_TWIM_CONFIG_INFO_COLOR
-#define NRFX_TWIM_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_TWIM_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_TWIM_CONFIG_DEBUG_COLOR
-#define NRFX_TWIM_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_TWIS_ENABLED - nrfx_twis - TWIS peripheral driver
-//==========================================================
-#ifndef NRFX_TWIS_ENABLED
-#define NRFX_TWIS_ENABLED 0
-#endif
-
-// <q> NRFX_TWIS0_ENABLED  - Enable TWIS0 instance
-
-#ifndef NRFX_TWIS0_ENABLED
-#define NRFX_TWIS0_ENABLED 0
-#endif
-
-// <q> NRFX_TWIS_ASSUME_INIT_AFTER_RESET_ONLY  - Assume that any instance would be initialized only once
-
-// <i> Optimization flag. Registers used by TWIS are shared by other peripherals. Normally, during initialization driver tries to clear all registers to known state before doing the initialization itself. This gives initialization safe procedure, no matter when it would be called. If you activate TWIS only once and do never uninitialize it - set this flag to 1 what gives more optimal code.
-
-#ifndef NRFX_TWIS_ASSUME_INIT_AFTER_RESET_ONLY
-#define NRFX_TWIS_ASSUME_INIT_AFTER_RESET_ONLY 0
-#endif
-
-// <q> NRFX_TWIS_NO_SYNC_MODE  - Remove support for synchronous mode
-
-// <i> Synchronous mode would be used in specific situations. And it uses some additional code and data memory to safely process state machine by polling it in status functions. If this functionality is not required it may be disabled to free some resources.
-
-#ifndef NRFX_TWIS_NO_SYNC_MODE
-#define NRFX_TWIS_NO_SYNC_MODE 0
-#endif
-
-// <o> NRFX_TWIS_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
-#ifndef NRFX_TWIS_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_TWIS_DEFAULT_CONFIG_IRQ_PRIORITY 7
-#endif
-
-// <e> NRFX_TWIS_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
-#ifndef NRFX_TWIS_CONFIG_LOG_ENABLED
-#define NRFX_TWIS_CONFIG_LOG_ENABLED 0
-#endif
-// <o> NRFX_TWIS_CONFIG_LOG_LEVEL  - Default Severity level
-
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
-#ifndef NRFX_TWIS_CONFIG_LOG_LEVEL
-#define NRFX_TWIS_CONFIG_LOG_LEVEL 3
-#endif
-
-// <o> NRFX_TWIS_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_TWIS_CONFIG_INFO_COLOR
-#define NRFX_TWIS_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_TWIS_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_TWIS_CONFIG_DEBUG_COLOR
-#define NRFX_TWIS_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_TWI_ENABLED - nrfx_twi - TWI peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_TWI_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_TWI_ENABLED
 #define NRFX_TWI_ENABLED 0
 #endif
 
-// <q> NRFX_TWI0_ENABLED  - Enable TWI0 instance
-
-#ifndef NRFX_TWI0_ENABLED
-#define NRFX_TWI0_ENABLED 0
-#endif
-
-// <o> NRFX_TWI_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_TWI_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_TWI_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_TWI_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_TWI_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_TWI_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_TWI_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_TWI_CONFIG_LOG_ENABLED
 #define NRFX_TWI_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_TWI_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_TWI_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_TWI_CONFIG_LOG_LEVEL
 #define NRFX_TWI_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_TWI_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_TWI_CONFIG_INFO_COLOR
-#define NRFX_TWI_CONFIG_INFO_COLOR 0
+/**
+ * @brief NRFX_TWI0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWI0_ENABLED
+#define NRFX_TWI0_ENABLED 0
 #endif
 
-// <o> NRFX_TWI_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_TWI_CONFIG_DEBUG_COLOR
-#define NRFX_TWI_CONFIG_DEBUG_COLOR 0
+/**
+ * @brief NRFX_TWIM_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWIM_ENABLED
+#define NRFX_TWIM_ENABLED 0
 #endif
 
-// </e>
-
-// </e>
-
-// <e> NRFX_UARTE_ENABLED - nrfx_uarte - UARTE peripheral driver
-//==========================================================
-#ifndef NRFX_UARTE_ENABLED
-#define NRFX_UARTE_ENABLED 0
+/**
+ * @brief NRFX_TWIM_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
+#ifndef NRFX_TWIM_DEFAULT_CONFIG_IRQ_PRIORITY
+#define NRFX_TWIM_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <q> NRFX_UARTE0_ENABLED - Enable UARTE0 instance
-
-#ifndef NRFX_UARTE0_ENABLED
-#define NRFX_UARTE0_ENABLED 0
+/**
+ * @brief NRFX_TWIM_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWIM_CONFIG_LOG_ENABLED
+#define NRFX_TWIM_CONFIG_LOG_ENABLED 0
 #endif
 
-// <o> NRFX_UARTE_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
-#ifndef NRFX_UARTE_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_UARTE_DEFAULT_CONFIG_IRQ_PRIORITY 7
+/**
+ * @brief NRFX_TWIM_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
+#ifndef NRFX_TWIM_CONFIG_LOG_LEVEL
+#define NRFX_TWIM_CONFIG_LOG_LEVEL 3
 #endif
 
-// <e> NRFX_UARTE_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
-#ifndef NRFX_UARTE_CONFIG_LOG_ENABLED
-#define NRFX_UARTE_CONFIG_LOG_ENABLED 0
-#endif
-// <o> NRFX_UARTE_CONFIG_LOG_LEVEL  - Default Severity level
-
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
-#ifndef NRFX_UARTE_CONFIG_LOG_LEVEL
-#define NRFX_UARTE_CONFIG_LOG_LEVEL 3
+/**
+ * @brief NRFX_TWIM0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWIM0_ENABLED
+#define NRFX_TWIM0_ENABLED 0
 #endif
 
-// <o> NRFX_UARTE_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_UARTE_CONFIG_INFO_COLOR
-#define NRFX_UARTE_CONFIG_INFO_COLOR 0
+/**
+ * @brief NRFX_TWIS_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWIS_ENABLED
+#define NRFX_TWIS_ENABLED 0
 #endif
 
-// <o> NRFX_UARTE_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_UARTE_CONFIG_DEBUG_COLOR
-#define NRFX_UARTE_CONFIG_DEBUG_COLOR 0
+/**
+ * @brief NRFX_TWIS_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
+#ifndef NRFX_TWIS_DEFAULT_CONFIG_IRQ_PRIORITY
+#define NRFX_TWIS_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// </e>
+/**
+ * @brief NRFX_TWIS_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWIS_CONFIG_LOG_ENABLED
+#define NRFX_TWIS_CONFIG_LOG_ENABLED 0
+#endif
 
-// </e>
+/**
+ * @brief NRFX_TWIS_ASSUME_INIT_AFTER_RESET_ONLY - Assume that any instance would be initialized only once.
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWIS_ASSUME_INIT_AFTER_RESET_ONLY
+#define NRFX_TWIS_ASSUME_INIT_AFTER_RESET_ONLY 0
+#endif
 
-// <e> NRFX_UART_ENABLED - nrfx_uart - UART peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_TWIS_NO_SYNC_MODE - Remove support for synchronous mode.
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWIS_NO_SYNC_MODE
+#define NRFX_TWIS_NO_SYNC_MODE 0
+#endif
+
+/**
+ * @brief NRFX_TWIS_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
+#ifndef NRFX_TWIS_CONFIG_LOG_LEVEL
+#define NRFX_TWIS_CONFIG_LOG_LEVEL 3
+#endif
+
+/**
+ * @brief NRFX_TWIS0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWIS0_ENABLED
+#define NRFX_TWIS0_ENABLED 0
+#endif
+
+/**
+ * @brief NRFX_UART_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_UART_ENABLED
 #define NRFX_UART_ENABLED 0
 #endif
 
-// <q> NRFX_UART0_ENABLED - Enable UART0 instance
-
-#ifndef NRFX_UART0_ENABLED
-#define NRFX_UART0_ENABLED 0
-#endif
-
-// <o> NRFX_UART_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_UART_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_UART_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_UART_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_UART_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_UART_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_UART_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_UART_CONFIG_LOG_ENABLED
 #define NRFX_UART_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_UART_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_UART_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_UART_CONFIG_LOG_LEVEL
 #define NRFX_UART_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_UART_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_UART_CONFIG_INFO_COLOR
-#define NRFX_UART_CONFIG_INFO_COLOR 0
+/**
+ * @brief NRFX_UART0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_UART0_ENABLED
+#define NRFX_UART0_ENABLED 0
 #endif
 
-// <o> NRFX_UART_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_UART_CONFIG_DEBUG_COLOR
-#define NRFX_UART_CONFIG_DEBUG_COLOR 0
+/**
+ * @brief NRFX_UARTE_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_UARTE_ENABLED
+#define NRFX_UARTE_ENABLED 0
 #endif
 
-// </e>
+/**
+ * @brief NRFX_UARTE_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
+#ifndef NRFX_UARTE_DEFAULT_CONFIG_IRQ_PRIORITY
+#define NRFX_UARTE_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
+#endif
 
-// </e>
+/**
+ * @brief NRFX_UARTE_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_UARTE_CONFIG_LOG_ENABLED
+#define NRFX_UARTE_CONFIG_LOG_ENABLED 0
+#endif
 
-// <e> NRFX_WDT_ENABLED - nrfx_wdt - WDT peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_UARTE_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
+#ifndef NRFX_UARTE_CONFIG_LOG_LEVEL
+#define NRFX_UARTE_CONFIG_LOG_LEVEL 3
+#endif
+
+/**
+ * @brief NRFX_UARTE0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_UARTE0_ENABLED
+#define NRFX_UARTE0_ENABLED 0
+#endif
+
+/**
+ * @brief NRFX_WDT_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_WDT_ENABLED
 #define NRFX_WDT_ENABLED 0
 #endif
 
-// <q> NRFX_WDT0_ENABLED  - Enable WDT0 instance
-
-#ifndef NRFX_WDT0_ENABLED
-#define NRFX_WDT0_ENABLED 0
+/**
+ * @brief NRFX_WDT_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
+#ifndef NRFX_WDT_DEFAULT_CONFIG_IRQ_PRIORITY
+#define NRFX_WDT_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <o> NRFX_WDT_CONFIG_NO_IRQ  - Remove WDT IRQ handling from WDT driver
-
-// <0=> Include WDT IRQ handling
-// <1=> Remove WDT IRQ handling
-
+/**
+ * @brief NRFX_WDT_CONFIG_NO_IRQ - Remove WDT IRQ handling from WDT driver
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_WDT_CONFIG_NO_IRQ
 #define NRFX_WDT_CONFIG_NO_IRQ 0
 #endif
 
-// <o> NRFX_WDT_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
-#ifndef NRFX_WDT_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_WDT_DEFAULT_CONFIG_IRQ_PRIORITY 7
-#endif
-
-// <e> NRFX_WDT_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_WDT_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_WDT_CONFIG_LOG_ENABLED
 #define NRFX_WDT_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_WDT_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_WDT_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_WDT_CONFIG_LOG_LEVEL
 #define NRFX_WDT_CONFIG_LOG_LEVEL 3
 #endif
-
-// <o> NRFX_WDT_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_WDT_CONFIG_INFO_COLOR
-#define NRFX_WDT_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_WDT_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_WDT_CONFIG_DEBUG_COLOR
-#define NRFX_WDT_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// </h>
 
 #endif // NRFX_CONFIG_NRF52811_H__

--- a/nrfx/templates/nrfx_config_nrf52820.h
+++ b/nrfx/templates/nrfx_config_nrf52820.h
@@ -38,1737 +38,1256 @@
 #error "This file should not be included directly. Include nrfx_config.h instead."
 #endif
 
-// <<< Use Configuration Wizard in Context Menu >>>\n
 
-// <h> nRF_Drivers
+/**
+ * @brief NRFX_DEFAULT_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
+#ifndef NRFX_DEFAULT_IRQ_PRIORITY
+#define NRFX_DEFAULT_IRQ_PRIORITY 7
+#endif
 
-// <e> NRFX_CLOCK_ENABLED - nrfx_clock - CLOCK peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_CLOCK_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_CLOCK_ENABLED
 #define NRFX_CLOCK_ENABLED 0
 #endif
-// <o> NRFX_CLOCK_CONFIG_LF_SRC  - LF Clock Source
 
-// <0=> RC
-// <1=> XTAL
-// <2=> Synth
-// <131073=> External Low Swing
-// <196609=> External Full Swing
-
+/**
+ * @brief NRFX_CLOCK_CONFIG_LF_SRC
+ *
+ * Integer value.
+ * Supported values:
+ * - RC                  = 0
+ * - XTAL                = 1
+ * - Synth               = 2
+ * - External Low Swing  = 131073
+ * - External Full Swing = 196609
+ */
 #ifndef NRFX_CLOCK_CONFIG_LF_SRC
 #define NRFX_CLOCK_CONFIG_LF_SRC 1
 #endif
 
-// <q> NRFX_CLOCK_CONFIG_LF_CAL_ENABLED  - Enables LF Clock Calibration Support
-
+/**
+ * @brief NRFX_CLOCK_CONFIG_LF_CAL_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_CLOCK_CONFIG_LF_CAL_ENABLED
 #define NRFX_CLOCK_CONFIG_LF_CAL_ENABLED 0
 #endif
 
-// <q> NRFX_CLOCK_CONFIG_CT_ENABLED  - Enables Calibration Timer Support
-
+/**
+ * @brief NRFX_CLOCK_CONFIG_CT_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_CLOCK_CONFIG_CT_ENABLED
 #define NRFX_CLOCK_CONFIG_CT_ENABLED 1
 #endif
 
-// <q> NRFX_CLOCK_CONFIG_LFXO_TWO_STAGE_ENABLED - Enables two-stage LFXO start procedure
-
-// <i> If set to a non-zero value, LFRC will be started before LFXO and corresponding
-// <i> event will be generated. It means that CPU will be woken up when LFRC
-// <i> oscillator starts, but user callback will be invoked only after LFXO
-// <i> finally starts.
-
+/**
+ * @brief NRFX_CLOCK_CONFIG_LFXO_TWO_STAGE_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_CLOCK_CONFIG_LFXO_TWO_STAGE_ENABLED
 #define NRFX_CLOCK_CONFIG_LFXO_TWO_STAGE_ENABLED 0
 #endif
 
-// <o> NRFX_CLOCK_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_CLOCK_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_CLOCK_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_CLOCK_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_CLOCK_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_CLOCK_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_CLOCK_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_CLOCK_CONFIG_LOG_ENABLED
 #define NRFX_CLOCK_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_CLOCK_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_CLOCK_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_CLOCK_CONFIG_LOG_LEVEL
 #define NRFX_CLOCK_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_CLOCK_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_CLOCK_CONFIG_INFO_COLOR
-#define NRFX_CLOCK_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_CLOCK_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_CLOCK_CONFIG_DEBUG_COLOR
-#define NRFX_CLOCK_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_COMP_ENABLED - nrfx_comp - COMP peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_COMP_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_COMP_ENABLED
 #define NRFX_COMP_ENABLED 0
 #endif
 
-// <o> NRFX_COMP_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_COMP_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_COMP_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_COMP_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_COMP_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_COMP_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_COMP_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_COMP_CONFIG_LOG_ENABLED
 #define NRFX_COMP_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_COMP_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_COMP_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_COMP_CONFIG_LOG_LEVEL
 #define NRFX_COMP_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_COMP_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_COMP_CONFIG_INFO_COLOR
-#define NRFX_COMP_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_COMP_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_COMP_CONFIG_DEBUG_COLOR
-#define NRFX_COMP_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_EGU_ENABLED - nrfx_egu - EGU peripheral driver.
-//==========================================================
+/**
+ * @brief NRFX_EGU_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_EGU_ENABLED
 #define NRFX_EGU_ENABLED 0
 #endif
 
-// <q> NRFX_EGU0_ENABLED  - Enable EGU0 instance.
+/**
+ * @brief NRFX_EGU_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
+#ifndef NRFX_EGU_DEFAULT_CONFIG_IRQ_PRIORITY
+#define NRFX_EGU_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
+#endif
 
+/**
+ * @brief NRFX_EGU0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_EGU0_ENABLED
 #define NRFX_EGU0_ENABLED 0
 #endif
 
-// <q> NRFX_EGU1_ENABLED  - Enable EGU1 instance.
-
+/**
+ * @brief NRFX_EGU1_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_EGU1_ENABLED
 #define NRFX_EGU1_ENABLED 0
 #endif
 
-// <q> NRFX_EGU2_ENABLED  - Enable EGU2 instance.
-
+/**
+ * @brief NRFX_EGU2_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_EGU2_ENABLED
 #define NRFX_EGU2_ENABLED 0
 #endif
 
-// <q> NRFX_EGU3_ENABLED  - Enable EGU3 instance.
-
+/**
+ * @brief NRFX_EGU3_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_EGU3_ENABLED
 #define NRFX_EGU3_ENABLED 0
 #endif
 
-// <q> NRFX_EGU4_ENABLED  - Enable EGU4 instance.
-
+/**
+ * @brief NRFX_EGU4_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_EGU4_ENABLED
 #define NRFX_EGU4_ENABLED 0
 #endif
 
-// <q> NRFX_EGU5_ENABLED  - Enable EGU5 instance.
-
+/**
+ * @brief NRFX_EGU5_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_EGU5_ENABLED
 #define NRFX_EGU5_ENABLED 0
 #endif
 
-// <o> NRFX_EGU_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority.
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
-#ifndef NRFX_EGU_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_EGU_DEFAULT_CONFIG_IRQ_PRIORITY 7
-#endif
-
-// </e>
-
-// <e> NRFX_GPIOTE_ENABLED - nrfx_gpiote - GPIOTE peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_GPIOTE_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_GPIOTE_ENABLED
 #define NRFX_GPIOTE_ENABLED 0
 #endif
 
-// <o> NRFX_GPIOTE_CONFIG_NUM_OF_EVT_HANDLERS - Number of dedicated handlers
+/**
+ * @brief NRFX_GPIOTE_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
+#ifndef NRFX_GPIOTE_DEFAULT_CONFIG_IRQ_PRIORITY
+#define NRFX_GPIOTE_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
+#endif
+
+/**
+ * @brief NRFX_GPIOTE_CONFIG_NUM_OF_EVT_HANDLERS
+ *
+ * Integer value. Minimum: 0 Maximum: 15
+ */
 #ifndef NRFX_GPIOTE_CONFIG_NUM_OF_EVT_HANDLERS
 #define NRFX_GPIOTE_CONFIG_NUM_OF_EVT_HANDLERS 2
 #endif
 
-// <o> NRFX_GPIOTE_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
-#ifndef NRFX_GPIOTE_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_GPIOTE_DEFAULT_CONFIG_IRQ_PRIORITY 7
-#endif
-
-// <e> NRFX_GPIOTE_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_GPIOTE_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_GPIOTE_CONFIG_LOG_ENABLED
 #define NRFX_GPIOTE_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_GPIOTE_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_GPIOTE_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_GPIOTE_CONFIG_LOG_LEVEL
 #define NRFX_GPIOTE_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_GPIOTE_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_GPIOTE_CONFIG_INFO_COLOR
-#define NRFX_GPIOTE_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_GPIOTE_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_GPIOTE_CONFIG_DEBUG_COLOR
-#define NRFX_GPIOTE_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_NVMC_ENABLED - nrfx_nvmc - NVMC peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_NVMC_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_NVMC_ENABLED
 #define NRFX_NVMC_ENABLED 0
 #endif
 
-// </e>
-
-// <e> NRFX_POWER_ENABLED - nrfx_power - POWER peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_POWER_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_POWER_ENABLED
 #define NRFX_POWER_ENABLED 0
 #endif
-// <o> NRFX_POWER_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
 
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_POWER_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_POWER_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_POWER_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_POWER_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// </e>
-
-// <e> NRFX_PPI_ENABLED - nrfx_ppi - PPI peripheral allocator
-//==========================================================
+/**
+ * @brief NRFX_PPI_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_PPI_ENABLED
 #define NRFX_PPI_ENABLED 0
 #endif
-// <e> NRFX_PPI_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+
+/**
+ * @brief NRFX_PPI_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_PPI_CONFIG_LOG_ENABLED
 #define NRFX_PPI_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_PPI_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_PPI_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_PPI_CONFIG_LOG_LEVEL
 #define NRFX_PPI_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_PPI_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_PPI_CONFIG_INFO_COLOR
-#define NRFX_PPI_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_PPI_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_PPI_CONFIG_DEBUG_COLOR
-#define NRFX_PPI_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_PRS_ENABLED - nrfx_prs - Peripheral Resource Sharing module
-//==========================================================
+/**
+ * @brief NRFX_PRS_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_PRS_ENABLED
 #define NRFX_PRS_ENABLED 0
 #endif
-// <q> NRFX_PRS_BOX_0_ENABLED  - Enables box 0 in the module.
 
-
-#ifndef NRFX_PRS_BOX_0_ENABLED
-#define NRFX_PRS_BOX_0_ENABLED 0
-#endif
-
-// <q> NRFX_PRS_BOX_1_ENABLED  - Enables box 1 in the module.
-
-
-#ifndef NRFX_PRS_BOX_1_ENABLED
-#define NRFX_PRS_BOX_1_ENABLED 0
-#endif
-
-// <q> NRFX_PRS_BOX_2_ENABLED  - Enables box 2 in the module.
-
-
-#ifndef NRFX_PRS_BOX_2_ENABLED
-#define NRFX_PRS_BOX_2_ENABLED 0
-#endif
-
-// <e> NRFX_PRS_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_PRS_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_PRS_CONFIG_LOG_ENABLED
 #define NRFX_PRS_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_PRS_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_PRS_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_PRS_CONFIG_LOG_LEVEL
 #define NRFX_PRS_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_PRS_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_PRS_CONFIG_INFO_COLOR
-#define NRFX_PRS_CONFIG_INFO_COLOR 0
+/**
+ * @brief NRFX_PRS_BOX_0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_PRS_BOX_0_ENABLED
+#define NRFX_PRS_BOX_0_ENABLED 0
 #endif
 
-// <o> NRFX_PRS_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_PRS_CONFIG_DEBUG_COLOR
-#define NRFX_PRS_CONFIG_DEBUG_COLOR 0
+/**
+ * @brief NRFX_PRS_BOX_1_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_PRS_BOX_1_ENABLED
+#define NRFX_PRS_BOX_1_ENABLED 0
 #endif
 
-// </e>
+/**
+ * @brief NRFX_PRS_BOX_2_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_PRS_BOX_2_ENABLED
+#define NRFX_PRS_BOX_2_ENABLED 0
+#endif
 
-// </e>
+/**
+ * @brief NRFX_PRS_BOX_4_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_PRS_BOX_4_ENABLED
+#define NRFX_PRS_BOX_4_ENABLED 0
+#endif
 
-// <e> NRFX_QDEC_ENABLED - nrfx_qdec - QDEC peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_QDEC_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_QDEC_ENABLED
 #define NRFX_QDEC_ENABLED 0
 #endif
 
-// <o> NRFX_QDEC_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_QDEC_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_QDEC_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_QDEC_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_QDEC_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_QDEC_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_QDEC_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_QDEC_CONFIG_LOG_ENABLED
 #define NRFX_QDEC_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_QDEC_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_QDEC_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_QDEC_CONFIG_LOG_LEVEL
 #define NRFX_QDEC_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_QDEC_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_QDEC_CONFIG_INFO_COLOR
-#define NRFX_QDEC_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_QDEC_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_QDEC_CONFIG_DEBUG_COLOR
-#define NRFX_QDEC_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_RNG_ENABLED - nrfx_rng - RNG peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_RNG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_RNG_ENABLED
 #define NRFX_RNG_ENABLED 0
 #endif
 
-// <o> NRFX_RNG_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_RNG_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_RNG_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_RNG_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_RNG_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_RNG_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_RNG_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_RNG_CONFIG_LOG_ENABLED
 #define NRFX_RNG_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_RNG_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_RNG_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_RNG_CONFIG_LOG_LEVEL
 #define NRFX_RNG_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_RNG_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_RNG_CONFIG_INFO_COLOR
-#define NRFX_RNG_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_RNG_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_RNG_CONFIG_DEBUG_COLOR
-#define NRFX_RNG_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_RTC_ENABLED - nrfx_rtc - RTC peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_RTC_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_RTC_ENABLED
 #define NRFX_RTC_ENABLED 0
 #endif
-// <q> NRFX_RTC0_ENABLED  - Enable RTC0 instance
 
-#ifndef NRFX_RTC0_ENABLED
-#define NRFX_RTC0_ENABLED 0
-#endif
-
-// <q> NRFX_RTC1_ENABLED  - Enable RTC1 instance
-
-#ifndef NRFX_RTC1_ENABLED
-#define NRFX_RTC1_ENABLED 0
-#endif
-
-// <o> NRFX_RTC_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_RTC_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_RTC_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_RTC_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_RTC_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_RTC_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_RTC_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_RTC_CONFIG_LOG_ENABLED
 #define NRFX_RTC_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_RTC_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_RTC_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_RTC_CONFIG_LOG_LEVEL
 #define NRFX_RTC_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_RTC_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_RTC_CONFIG_INFO_COLOR
-#define NRFX_RTC_CONFIG_INFO_COLOR 0
+/**
+ * @brief NRFX_RTC0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_RTC0_ENABLED
+#define NRFX_RTC0_ENABLED 0
 #endif
 
-// <o> NRFX_RTC_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_RTC_CONFIG_DEBUG_COLOR
-#define NRFX_RTC_CONFIG_DEBUG_COLOR 0
+/**
+ * @brief NRFX_RTC1_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_RTC1_ENABLED
+#define NRFX_RTC1_ENABLED 0
 #endif
 
-// </e>
-
-// </e>
-
-// <e> NRFX_SPIM_ENABLED - nrfx_spim - SPIM peripheral driver
-//==========================================================
-#ifndef NRFX_SPIM_ENABLED
-#define NRFX_SPIM_ENABLED 0
-#endif
-// <q> NRFX_SPIM0_ENABLED  - Enable SPIM0 instance
-
-
-#ifndef NRFX_SPIM0_ENABLED
-#define NRFX_SPIM0_ENABLED 0
-#endif
-
-// <q> NRFX_SPIM1_ENABLED  - Enable SPIM1 instance
-
-
-#ifndef NRFX_SPIM1_ENABLED
-#define NRFX_SPIM1_ENABLED 0
-#endif
-
-// <o> NRFX_SPIM_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
-#ifndef NRFX_SPIM_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_SPIM_DEFAULT_CONFIG_IRQ_PRIORITY 7
-#endif
-
-// <e> NRFX_SPIM_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
-#ifndef NRFX_SPIM_CONFIG_LOG_ENABLED
-#define NRFX_SPIM_CONFIG_LOG_ENABLED 0
-#endif
-// <o> NRFX_SPIM_CONFIG_LOG_LEVEL  - Default Severity level
-
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
-#ifndef NRFX_SPIM_CONFIG_LOG_LEVEL
-#define NRFX_SPIM_CONFIG_LOG_LEVEL 3
-#endif
-
-// <o> NRFX_SPIM_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_SPIM_CONFIG_INFO_COLOR
-#define NRFX_SPIM_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_SPIM_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_SPIM_CONFIG_DEBUG_COLOR
-#define NRFX_SPIM_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_SPIS_ENABLED - nrfx_spis - SPIS peripheral driver
-//==========================================================
-#ifndef NRFX_SPIS_ENABLED
-#define NRFX_SPIS_ENABLED 0
-#endif
-// <q> NRFX_SPIS0_ENABLED  - Enable SPIS0 instance
-
-
-#ifndef NRFX_SPIS0_ENABLED
-#define NRFX_SPIS0_ENABLED 0
-#endif
-
-// <q> NRFX_SPIS1_ENABLED  - Enable SPIS1 instance
-
-
-#ifndef NRFX_SPIS1_ENABLED
-#define NRFX_SPIS1_ENABLED 0
-#endif
-
-// <o> NRFX_SPIS_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
-#ifndef NRFX_SPIS_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_SPIS_DEFAULT_CONFIG_IRQ_PRIORITY 7
-#endif
-
-// <e> NRFX_SPIS_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
-#ifndef NRFX_SPIS_CONFIG_LOG_ENABLED
-#define NRFX_SPIS_CONFIG_LOG_ENABLED 0
-#endif
-// <o> NRFX_SPIS_CONFIG_LOG_LEVEL  - Default Severity level
-
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
-#ifndef NRFX_SPIS_CONFIG_LOG_LEVEL
-#define NRFX_SPIS_CONFIG_LOG_LEVEL 3
-#endif
-
-// <o> NRFX_SPIS_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_SPIS_CONFIG_INFO_COLOR
-#define NRFX_SPIS_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_SPIS_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_SPIS_CONFIG_DEBUG_COLOR
-#define NRFX_SPIS_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_SPI_ENABLED - nrfx_spi - SPI peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_SPI_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_SPI_ENABLED
 #define NRFX_SPI_ENABLED 0
 #endif
-// <q> NRFX_SPI0_ENABLED  - Enable SPI0 instance
 
-
-#ifndef NRFX_SPI0_ENABLED
-#define NRFX_SPI0_ENABLED 0
-#endif
-
-// <q> NRFX_SPI1_ENABLED  - Enable SPI1 instance
-
-
-#ifndef NRFX_SPI1_ENABLED
-#define NRFX_SPI1_ENABLED 0
-#endif
-
-// <o> NRFX_SPI_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_SPI_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_SPI_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_SPI_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_SPI_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_SPI_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_SPI_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_SPI_CONFIG_LOG_ENABLED
 #define NRFX_SPI_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_SPI_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_SPI_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_SPI_CONFIG_LOG_LEVEL
 #define NRFX_SPI_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_SPI_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_SPI_CONFIG_INFO_COLOR
-#define NRFX_SPI_CONFIG_INFO_COLOR 0
+/**
+ * @brief NRFX_SPI0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPI0_ENABLED
+#define NRFX_SPI0_ENABLED 0
 #endif
 
-// <o> NRFX_SPI_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_SPI_CONFIG_DEBUG_COLOR
-#define NRFX_SPI_CONFIG_DEBUG_COLOR 0
+/**
+ * @brief NRFX_SPI1_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPI1_ENABLED
+#define NRFX_SPI1_ENABLED 0
 #endif
 
-// </e>
+/**
+ * @brief NRFX_SPIM_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPIM_ENABLED
+#define NRFX_SPIM_ENABLED 0
+#endif
 
-// </e>
+/**
+ * @brief NRFX_SPIM_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
+#ifndef NRFX_SPIM_DEFAULT_CONFIG_IRQ_PRIORITY
+#define NRFX_SPIM_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
+#endif
 
-// <q> NRFX_SYSTICK_ENABLED  - nrfx_systick - ARM(R) SysTick driver
+/**
+ * @brief NRFX_SPIM_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPIM_CONFIG_LOG_ENABLED
+#define NRFX_SPIM_CONFIG_LOG_ENABLED 0
+#endif
 
+/**
+ * @brief NRFX_SPIM_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
+#ifndef NRFX_SPIM_CONFIG_LOG_LEVEL
+#define NRFX_SPIM_CONFIG_LOG_LEVEL 3
+#endif
 
+/**
+ * @brief NRFX_SPIM0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPIM0_ENABLED
+#define NRFX_SPIM0_ENABLED 0
+#endif
+
+/**
+ * @brief NRFX_SPIM1_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPIM1_ENABLED
+#define NRFX_SPIM1_ENABLED 0
+#endif
+
+/**
+ * @brief NRFX_SPIS_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPIS_ENABLED
+#define NRFX_SPIS_ENABLED 0
+#endif
+
+/**
+ * @brief NRFX_SPIS_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
+#ifndef NRFX_SPIS_DEFAULT_CONFIG_IRQ_PRIORITY
+#define NRFX_SPIS_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
+#endif
+
+/**
+ * @brief NRFX_SPIS_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPIS_CONFIG_LOG_ENABLED
+#define NRFX_SPIS_CONFIG_LOG_ENABLED 0
+#endif
+
+/**
+ * @brief NRFX_SPIS_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
+#ifndef NRFX_SPIS_CONFIG_LOG_LEVEL
+#define NRFX_SPIS_CONFIG_LOG_LEVEL 3
+#endif
+
+/**
+ * @brief NRFX_SPIS0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPIS0_ENABLED
+#define NRFX_SPIS0_ENABLED 0
+#endif
+
+/**
+ * @brief NRFX_SPIS1_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPIS1_ENABLED
+#define NRFX_SPIS1_ENABLED 0
+#endif
+
+/**
+ * @brief NRFX_SYSTICK_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_SYSTICK_ENABLED
 #define NRFX_SYSTICK_ENABLED 0
 #endif
 
-// <e> NRFX_TEMP_ENABLED - nrfx_temp - TEMP peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_TEMP_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_TEMP_ENABLED
 #define NRFX_TEMP_ENABLED 0
 #endif
 
-// <o> NRFX_TEMP_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_TEMP_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_TEMP_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_TEMP_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_TEMP_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// </e>
+/**
+ * @brief NRFX_TEMP_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TEMP_CONFIG_LOG_ENABLED
+#define NRFX_TEMP_CONFIG_LOG_ENABLED 0
+#endif
 
-// <e> NRFX_TIMER_ENABLED - nrfx_timer - TIMER periperal driver
-//==========================================================
+/**
+ * @brief NRFX_TEMP_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
+#ifndef NRFX_TEMP_CONFIG_LOG_LEVEL
+#define NRFX_TEMP_CONFIG_LOG_LEVEL 3
+#endif
+
+/**
+ * @brief NRFX_TIMER_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_TIMER_ENABLED
 #define NRFX_TIMER_ENABLED 0
 #endif
 
-// <q> NRFX_TIMER0_ENABLED  - Enable TIMER0 instance
-
-#ifndef NRFX_TIMER0_ENABLED
-#define NRFX_TIMER0_ENABLED 0
-#endif
-
-// <q> NRFX_TIMER1_ENABLED  - Enable TIMER1 instance
-
-#ifndef NRFX_TIMER1_ENABLED
-#define NRFX_TIMER1_ENABLED 0
-#endif
-
-// <q> NRFX_TIMER2_ENABLED  - Enable TIMER2 instance
-
-#ifndef NRFX_TIMER2_ENABLED
-#define NRFX_TIMER2_ENABLED 0
-#endif
-
-// <q> NRFX_TIMER3_ENABLED  - Enable TIMER3 instance
-
-#ifndef NRFX_TIMER3_ENABLED
-#define NRFX_TIMER3_ENABLED 0
-#endif
-
-// <o> NRFX_TIMER_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_TIMER_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_TIMER_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_TIMER_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_TIMER_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_TIMER_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_TIMER_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_TIMER_CONFIG_LOG_ENABLED
 #define NRFX_TIMER_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_TIMER_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_TIMER_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_TIMER_CONFIG_LOG_LEVEL
 #define NRFX_TIMER_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_TIMER_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_TIMER_CONFIG_INFO_COLOR
-#define NRFX_TIMER_CONFIG_INFO_COLOR 0
+/**
+ * @brief NRFX_TIMER0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TIMER0_ENABLED
+#define NRFX_TIMER0_ENABLED 0
 #endif
 
-// <o> NRFX_TIMER_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_TIMER_CONFIG_DEBUG_COLOR
-#define NRFX_TIMER_CONFIG_DEBUG_COLOR 0
+/**
+ * @brief NRFX_TIMER1_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TIMER1_ENABLED
+#define NRFX_TIMER1_ENABLED 0
 #endif
 
-// </e>
-
-// </e>
-
-// <e> NRFX_TWIM_ENABLED - nrfx_twim - TWIM peripheral driver
-//==========================================================
-#ifndef NRFX_TWIM_ENABLED
-#define NRFX_TWIM_ENABLED 0
+/**
+ * @brief NRFX_TIMER2_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TIMER2_ENABLED
+#define NRFX_TIMER2_ENABLED 0
 #endif
 
-// <q> NRFX_TWIM0_ENABLED  - Enable TWIM0 instance
-
-#ifndef NRFX_TWIM0_ENABLED
-#define NRFX_TWIM0_ENABLED 0
+/**
+ * @brief NRFX_TIMER3_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TIMER3_ENABLED
+#define NRFX_TIMER3_ENABLED 0
 #endif
 
-// <q> NRFX_TWIM1_ENABLED  - Enable TWIM1 instance
-
-#ifndef NRFX_TWIM1_ENABLED
-#define NRFX_TWIM1_ENABLED 0
-#endif
-
-// <o> NRFX_TWIM_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
-#ifndef NRFX_TWIM_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_TWIM_DEFAULT_CONFIG_IRQ_PRIORITY 7
-#endif
-
-// <e> NRFX_TWIM_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
-#ifndef NRFX_TWIM_CONFIG_LOG_ENABLED
-#define NRFX_TWIM_CONFIG_LOG_ENABLED 0
-#endif
-// <o> NRFX_TWIM_CONFIG_LOG_LEVEL  - Default Severity level
-
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
-#ifndef NRFX_TWIM_CONFIG_LOG_LEVEL
-#define NRFX_TWIM_CONFIG_LOG_LEVEL 3
-#endif
-
-// <o> NRFX_TWIM_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_TWIM_CONFIG_INFO_COLOR
-#define NRFX_TWIM_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_TWIM_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_TWIM_CONFIG_DEBUG_COLOR
-#define NRFX_TWIM_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_TWIS_ENABLED - nrfx_twis - TWIS peripheral driver
-//==========================================================
-#ifndef NRFX_TWIS_ENABLED
-#define NRFX_TWIS_ENABLED 0
-#endif
-
-// <q> NRFX_TWIS0_ENABLED  - Enable TWIS0 instance
-
-#ifndef NRFX_TWIS0_ENABLED
-#define NRFX_TWIS0_ENABLED 0
-#endif
-
-// <q> NRFX_TWIS1_ENABLED  - Enable TWIS1 instance
-
-#ifndef NRFX_TWIS1_ENABLED
-#define NRFX_TWIS1_ENABLED 0
-#endif
-
-// <q> NRFX_TWIS_ASSUME_INIT_AFTER_RESET_ONLY  - Assume that any instance would be initialized only once
-
-// <i> Optimization flag. Registers used by TWIS are shared by other peripherals. Normally, during initialization driver tries to clear all registers to known state before doing the initialization itself. This gives initialization safe procedure, no matter when it would be called. If you activate TWIS only once and do never uninitialize it - set this flag to 1 what gives more optimal code.
-
-#ifndef NRFX_TWIS_ASSUME_INIT_AFTER_RESET_ONLY
-#define NRFX_TWIS_ASSUME_INIT_AFTER_RESET_ONLY 0
-#endif
-
-// <q> NRFX_TWIS_NO_SYNC_MODE  - Remove support for synchronous mode
-
-// <i> Synchronous mode would be used in specific situations. And it uses some additional code and data memory to safely process state machine by polling it in status functions. If this functionality is not required it may be disabled to free some resources.
-
-#ifndef NRFX_TWIS_NO_SYNC_MODE
-#define NRFX_TWIS_NO_SYNC_MODE 0
-#endif
-
-// <o> NRFX_TWIS_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
-#ifndef NRFX_TWIS_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_TWIS_DEFAULT_CONFIG_IRQ_PRIORITY 7
-#endif
-
-// <e> NRFX_TWIS_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
-#ifndef NRFX_TWIS_CONFIG_LOG_ENABLED
-#define NRFX_TWIS_CONFIG_LOG_ENABLED 0
-#endif
-// <o> NRFX_TWIS_CONFIG_LOG_LEVEL  - Default Severity level
-
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
-#ifndef NRFX_TWIS_CONFIG_LOG_LEVEL
-#define NRFX_TWIS_CONFIG_LOG_LEVEL 3
-#endif
-
-// <o> NRFX_TWIS_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_TWIS_CONFIG_INFO_COLOR
-#define NRFX_TWIS_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_TWIS_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_TWIS_CONFIG_DEBUG_COLOR
-#define NRFX_TWIS_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_TWI_ENABLED - nrfx_twi - TWI peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_TWI_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_TWI_ENABLED
 #define NRFX_TWI_ENABLED 0
 #endif
 
-// <q> NRFX_TWI0_ENABLED  - Enable TWI0 instance
-
-#ifndef NRFX_TWI0_ENABLED
-#define NRFX_TWI0_ENABLED 0
-#endif
-
-// <q> NRFX_TWI1_ENABLED  - Enable TWI1 instance
-
-#ifndef NRFX_TWI1_ENABLED
-#define NRFX_TWI1_ENABLED 0
-#endif
-
-// <o> NRFX_TWI_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_TWI_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_TWI_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_TWI_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_TWI_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_TWI_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_TWI_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_TWI_CONFIG_LOG_ENABLED
 #define NRFX_TWI_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_TWI_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_TWI_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_TWI_CONFIG_LOG_LEVEL
 #define NRFX_TWI_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_TWI_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_TWI_CONFIG_INFO_COLOR
-#define NRFX_TWI_CONFIG_INFO_COLOR 0
+/**
+ * @brief NRFX_TWI0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWI0_ENABLED
+#define NRFX_TWI0_ENABLED 0
 #endif
 
-// <o> NRFX_TWI_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_TWI_CONFIG_DEBUG_COLOR
-#define NRFX_TWI_CONFIG_DEBUG_COLOR 0
+/**
+ * @brief NRFX_TWI1_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWI1_ENABLED
+#define NRFX_TWI1_ENABLED 0
 #endif
 
-// </e>
-
-// </e>
-
-// <e> NRFX_UARTE_ENABLED - nrfx_uarte - UARTE peripheral driver
-//==========================================================
-#ifndef NRFX_UARTE_ENABLED
-#define NRFX_UARTE_ENABLED 0
+/**
+ * @brief NRFX_TWIM_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWIM_ENABLED
+#define NRFX_TWIM_ENABLED 0
 #endif
 
-// <q> NRFX_UARTE0_ENABLED - Enable UARTE0 instance
-
-#ifndef NRFX_UARTE0_ENABLED
-#define NRFX_UARTE0_ENABLED 0
+/**
+ * @brief NRFX_TWIM_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
+#ifndef NRFX_TWIM_DEFAULT_CONFIG_IRQ_PRIORITY
+#define NRFX_TWIM_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <o> NRFX_UARTE_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
-#ifndef NRFX_UARTE_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_UARTE_DEFAULT_CONFIG_IRQ_PRIORITY 7
+/**
+ * @brief NRFX_TWIM_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWIM_CONFIG_LOG_ENABLED
+#define NRFX_TWIM_CONFIG_LOG_ENABLED 0
 #endif
 
-// <e> NRFX_UARTE_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
-#ifndef NRFX_UARTE_CONFIG_LOG_ENABLED
-#define NRFX_UARTE_CONFIG_LOG_ENABLED 0
-#endif
-// <o> NRFX_UARTE_CONFIG_LOG_LEVEL  - Default Severity level
-
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
-#ifndef NRFX_UARTE_CONFIG_LOG_LEVEL
-#define NRFX_UARTE_CONFIG_LOG_LEVEL 3
+/**
+ * @brief NRFX_TWIM_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
+#ifndef NRFX_TWIM_CONFIG_LOG_LEVEL
+#define NRFX_TWIM_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_UARTE_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_UARTE_CONFIG_INFO_COLOR
-#define NRFX_UARTE_CONFIG_INFO_COLOR 0
+/**
+ * @brief NRFX_TWIM0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWIM0_ENABLED
+#define NRFX_TWIM0_ENABLED 0
 #endif
 
-// <o> NRFX_UARTE_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_UARTE_CONFIG_DEBUG_COLOR
-#define NRFX_UARTE_CONFIG_DEBUG_COLOR 0
+/**
+ * @brief NRFX_TWIM1_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWIM1_ENABLED
+#define NRFX_TWIM1_ENABLED 0
 #endif
 
-// </e>
+/**
+ * @brief NRFX_TWIS_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWIS_ENABLED
+#define NRFX_TWIS_ENABLED 0
+#endif
 
-// </e>
+/**
+ * @brief NRFX_TWIS_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
+#ifndef NRFX_TWIS_DEFAULT_CONFIG_IRQ_PRIORITY
+#define NRFX_TWIS_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
+#endif
 
-// <e> NRFX_UART_ENABLED - nrfx_uart - UART peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_TWIS_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWIS_CONFIG_LOG_ENABLED
+#define NRFX_TWIS_CONFIG_LOG_ENABLED 0
+#endif
+
+/**
+ * @brief NRFX_TWIS_ASSUME_INIT_AFTER_RESET_ONLY - Assume that any instance would be initialized only once.
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWIS_ASSUME_INIT_AFTER_RESET_ONLY
+#define NRFX_TWIS_ASSUME_INIT_AFTER_RESET_ONLY 0
+#endif
+
+/**
+ * @brief NRFX_TWIS_NO_SYNC_MODE - Remove support for synchronous mode.
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWIS_NO_SYNC_MODE
+#define NRFX_TWIS_NO_SYNC_MODE 0
+#endif
+
+/**
+ * @brief NRFX_TWIS_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
+#ifndef NRFX_TWIS_CONFIG_LOG_LEVEL
+#define NRFX_TWIS_CONFIG_LOG_LEVEL 3
+#endif
+
+/**
+ * @brief NRFX_TWIS0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWIS0_ENABLED
+#define NRFX_TWIS0_ENABLED 0
+#endif
+
+/**
+ * @brief NRFX_TWIS1_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWIS1_ENABLED
+#define NRFX_TWIS1_ENABLED 0
+#endif
+
+/**
+ * @brief NRFX_UART_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_UART_ENABLED
 #define NRFX_UART_ENABLED 0
 #endif
 
-// <q> NRFX_UART0_ENABLED - Enable UART0 instance
-
-#ifndef NRFX_UART0_ENABLED
-#define NRFX_UART0_ENABLED 0
-#endif
-
-// <o> NRFX_UART_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_UART_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_UART_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_UART_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_UART_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_UART_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_UART_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_UART_CONFIG_LOG_ENABLED
 #define NRFX_UART_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_UART_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_UART_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_UART_CONFIG_LOG_LEVEL
 #define NRFX_UART_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_UART_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_UART_CONFIG_INFO_COLOR
-#define NRFX_UART_CONFIG_INFO_COLOR 0
+/**
+ * @brief NRFX_UART0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_UART0_ENABLED
+#define NRFX_UART0_ENABLED 0
 #endif
 
-// <o> NRFX_UART_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_UART_CONFIG_DEBUG_COLOR
-#define NRFX_UART_CONFIG_DEBUG_COLOR 0
+/**
+ * @brief NRFX_UARTE_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_UARTE_ENABLED
+#define NRFX_UARTE_ENABLED 0
 #endif
 
-// </e>
+/**
+ * @brief NRFX_UARTE_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
+#ifndef NRFX_UARTE_DEFAULT_CONFIG_IRQ_PRIORITY
+#define NRFX_UARTE_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
+#endif
 
-// </e>
+/**
+ * @brief NRFX_UARTE_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_UARTE_CONFIG_LOG_ENABLED
+#define NRFX_UARTE_CONFIG_LOG_ENABLED 0
+#endif
 
-// <e> NRFX_USBD_ENABLED - nrfx_usbd - USBD peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_UARTE_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
+#ifndef NRFX_UARTE_CONFIG_LOG_LEVEL
+#define NRFX_UARTE_CONFIG_LOG_LEVEL 3
+#endif
+
+/**
+ * @brief NRFX_UARTE0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_UARTE0_ENABLED
+#define NRFX_UARTE0_ENABLED 0
+#endif
+
+/**
+ * @brief NRFX_USBD_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_USBD_ENABLED
 #define NRFX_USBD_ENABLED 0
 #endif
-// <o> NRFX_USBD_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
 
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_USBD_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_USBD_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_USBD_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_USBD_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <q> USBD_CONFIG_DMASCHEDULER_ISO_BOOST  - Give priority to isochronous transfers
-
-// <i> This option gives priority to isochronous transfers.
-// <i> Enabling it assures that isochronous transfers are always processed,
-// <i> even if multiple other transfers are pending.
-// <i> Isochronous endpoints are prioritized before the usbd_dma_scheduler_algorithm
-// <i> function is called, so the option is independent of the algorithm chosen.
-
+/**
+ * @brief NRFX_USBD_CONFIG_DMASCHEDULER_ISO_BOOST - Give priority to isochronous transfers
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_USBD_CONFIG_DMASCHEDULER_ISO_BOOST
 #define NRFX_USBD_CONFIG_DMASCHEDULER_ISO_BOOST 1
 #endif
 
-// <q> USBD_CONFIG_ISO_IN_ZLP  - Respond to an IN token on ISO IN endpoint with ZLP when no data is ready
-
-
-// <i> If set, ISO IN endpoint will respond to an IN token with ZLP when no data is ready to be sent.
-// <i> Else, there will be no response.
-
+/**
+ * @brief NRFX_USBD_CONFIG_ISO_IN_ZLP - Respond to an IN token on ISO IN endpoint with ZLP when no data is ready.
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_USBD_CONFIG_ISO_IN_ZLP
 #define NRFX_USBD_CONFIG_ISO_IN_ZLP 0
 #endif
 
-// <e> NRFX_USBD_CONFIG_LOG_ENABLED - Enable logging in the module
-//==========================================================
+/**
+ * @brief NRFX_USBD_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_USBD_CONFIG_LOG_ENABLED
 #define NRFX_USBD_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_USBD_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_USBD_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_USBD_CONFIG_LOG_LEVEL
 #define NRFX_USBD_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_USBD_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_USBD_CONFIG_INFO_COLOR
-#define NRFX_USBD_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_USBD_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_USBD_CONFIG_DEBUG_COLOR
-#define NRFX_USBD_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_WDT_ENABLED - nrfx_wdt - WDT peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_WDT_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_WDT_ENABLED
 #define NRFX_WDT_ENABLED 0
 #endif
 
-// <q> NRFX_WDT0_ENABLED  - Enable WDT0 instance
-
-#ifndef NRFX_WDT0_ENABLED
-#define NRFX_WDT0_ENABLED 0
+/**
+ * @brief NRFX_WDT_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
+#ifndef NRFX_WDT_DEFAULT_CONFIG_IRQ_PRIORITY
+#define NRFX_WDT_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <o> NRFX_WDT_CONFIG_NO_IRQ  - Remove WDT IRQ handling from WDT driver
-
-// <0=> Include WDT IRQ handling
-// <1=> Remove WDT IRQ handling
-
+/**
+ * @brief NRFX_WDT_CONFIG_NO_IRQ - Remove WDT IRQ handling from WDT driver
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_WDT_CONFIG_NO_IRQ
 #define NRFX_WDT_CONFIG_NO_IRQ 0
 #endif
 
-// <o> NRFX_WDT_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
-#ifndef NRFX_WDT_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_WDT_DEFAULT_CONFIG_IRQ_PRIORITY 7
-#endif
-
-// <e> NRFX_WDT_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_WDT_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_WDT_CONFIG_LOG_ENABLED
 #define NRFX_WDT_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_WDT_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_WDT_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_WDT_CONFIG_LOG_LEVEL
 #define NRFX_WDT_CONFIG_LOG_LEVEL 3
 #endif
-
-// <o> NRFX_WDT_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_WDT_CONFIG_INFO_COLOR
-#define NRFX_WDT_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_WDT_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_WDT_CONFIG_DEBUG_COLOR
-#define NRFX_WDT_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// </h>
 
 #endif // NRFX_CONFIG_NRF52820_H__

--- a/nrfx/templates/nrfx_config_nrf52832.h
+++ b/nrfx/templates/nrfx_config_nrf52832.h
@@ -38,2231 +38,1590 @@
 #error "This file should not be included directly. Include nrfx_config.h instead."
 #endif
 
-// <<< Use Configuration Wizard in Context Menu >>>\n
 
-// <h> nRF_Drivers
+/**
+ * @brief NRFX_DEFAULT_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
+#ifndef NRFX_DEFAULT_IRQ_PRIORITY
+#define NRFX_DEFAULT_IRQ_PRIORITY 7
+#endif
 
-// <e> NRFX_CLOCK_ENABLED - nrfx_clock - CLOCK peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_CLOCK_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_CLOCK_ENABLED
 #define NRFX_CLOCK_ENABLED 0
 #endif
-// <o> NRFX_CLOCK_CONFIG_LF_SRC  - LF Clock Source
 
-// <0=> RC
-// <1=> XTAL
-// <2=> Synth
-// <131073=> External Low Swing
-// <196609=> External Full Swing
-
+/**
+ * @brief NRFX_CLOCK_CONFIG_LF_SRC
+ *
+ * Integer value.
+ * Supported values:
+ * - RC                  = 0
+ * - XTAL                = 1
+ * - Synth               = 2
+ * - External Low Swing  = 131073
+ * - External Full Swing = 196609
+ */
 #ifndef NRFX_CLOCK_CONFIG_LF_SRC
 #define NRFX_CLOCK_CONFIG_LF_SRC 1
 #endif
 
-// <q> NRFX_CLOCK_CONFIG_LF_CAL_ENABLED  - Enables LF Clock Calibration Support
-
+/**
+ * @brief NRFX_CLOCK_CONFIG_LF_CAL_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_CLOCK_CONFIG_LF_CAL_ENABLED
 #define NRFX_CLOCK_CONFIG_LF_CAL_ENABLED 0
 #endif
 
-// <q> NRFX_CLOCK_CONFIG_CT_ENABLED  - Enables Calibration Timer Support
-
+/**
+ * @brief NRFX_CLOCK_CONFIG_CT_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_CLOCK_CONFIG_CT_ENABLED
 #define NRFX_CLOCK_CONFIG_CT_ENABLED 1
 #endif
 
-// <q> NRFX_CLOCK_CONFIG_LFXO_TWO_STAGE_ENABLED - Enables two-stage LFXO start procedure
-
-// <i> If set to a non-zero value, LFRC will be started before LFXO and corresponding
-// <i> event will be generated. It means that CPU will be woken up when LFRC
-// <i> oscillator starts, but user callback will be invoked only after LFXO
-// <i> finally starts.
-
+/**
+ * @brief NRFX_CLOCK_CONFIG_LFXO_TWO_STAGE_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_CLOCK_CONFIG_LFXO_TWO_STAGE_ENABLED
 #define NRFX_CLOCK_CONFIG_LFXO_TWO_STAGE_ENABLED 0
 #endif
 
-// <o> NRFX_CLOCK_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_CLOCK_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_CLOCK_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_CLOCK_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_CLOCK_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_CLOCK_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_CLOCK_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_CLOCK_CONFIG_LOG_ENABLED
 #define NRFX_CLOCK_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_CLOCK_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_CLOCK_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_CLOCK_CONFIG_LOG_LEVEL
 #define NRFX_CLOCK_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_CLOCK_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_CLOCK_CONFIG_INFO_COLOR
-#define NRFX_CLOCK_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_CLOCK_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_CLOCK_CONFIG_DEBUG_COLOR
-#define NRFX_CLOCK_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_COMP_ENABLED - nrfx_comp - COMP peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_COMP_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_COMP_ENABLED
 #define NRFX_COMP_ENABLED 0
 #endif
 
-// <o> NRFX_COMP_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_COMP_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_COMP_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_COMP_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_COMP_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_COMP_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_COMP_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_COMP_CONFIG_LOG_ENABLED
 #define NRFX_COMP_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_COMP_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_COMP_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_COMP_CONFIG_LOG_LEVEL
 #define NRFX_COMP_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_COMP_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_COMP_CONFIG_INFO_COLOR
-#define NRFX_COMP_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_COMP_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_COMP_CONFIG_DEBUG_COLOR
-#define NRFX_COMP_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_EGU_ENABLED - nrfx_egu - EGU peripheral driver.
-//==========================================================
+/**
+ * @brief NRFX_EGU_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_EGU_ENABLED
 #define NRFX_EGU_ENABLED 0
 #endif
 
-// <q> NRFX_EGU0_ENABLED  - Enable EGU0 instance.
+/**
+ * @brief NRFX_EGU_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
+#ifndef NRFX_EGU_DEFAULT_CONFIG_IRQ_PRIORITY
+#define NRFX_EGU_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
+#endif
 
+/**
+ * @brief NRFX_EGU0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_EGU0_ENABLED
 #define NRFX_EGU0_ENABLED 0
 #endif
 
-// <q> NRFX_EGU1_ENABLED  - Enable EGU1 instance.
-
+/**
+ * @brief NRFX_EGU1_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_EGU1_ENABLED
 #define NRFX_EGU1_ENABLED 0
 #endif
 
-// <q> NRFX_EGU2_ENABLED  - Enable EGU2 instance.
-
+/**
+ * @brief NRFX_EGU2_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_EGU2_ENABLED
 #define NRFX_EGU2_ENABLED 0
 #endif
 
-// <q> NRFX_EGU3_ENABLED  - Enable EGU3 instance.
-
+/**
+ * @brief NRFX_EGU3_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_EGU3_ENABLED
 #define NRFX_EGU3_ENABLED 0
 #endif
 
-// <q> NRFX_EGU4_ENABLED  - Enable EGU4 instance.
-
+/**
+ * @brief NRFX_EGU4_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_EGU4_ENABLED
 #define NRFX_EGU4_ENABLED 0
 #endif
 
-// <q> NRFX_EGU5_ENABLED  - Enable EGU5 instance.
-
+/**
+ * @brief NRFX_EGU5_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_EGU5_ENABLED
 #define NRFX_EGU5_ENABLED 0
 #endif
 
-// <o> NRFX_EGU_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority.
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
-#ifndef NRFX_EGU_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_EGU_DEFAULT_CONFIG_IRQ_PRIORITY 7
-#endif
-
-// </e>
-
-// <e> NRFX_GPIOTE_ENABLED - nrfx_gpiote - GPIOTE peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_GPIOTE_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_GPIOTE_ENABLED
 #define NRFX_GPIOTE_ENABLED 0
 #endif
 
-// <o> NRFX_GPIOTE_CONFIG_NUM_OF_EVT_HANDLERS - Number of dedicated handlers
+/**
+ * @brief NRFX_GPIOTE_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
+#ifndef NRFX_GPIOTE_DEFAULT_CONFIG_IRQ_PRIORITY
+#define NRFX_GPIOTE_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
+#endif
+
+/**
+ * @brief NRFX_GPIOTE_CONFIG_NUM_OF_EVT_HANDLERS
+ *
+ * Integer value. Minimum: 0 Maximum: 15
+ */
 #ifndef NRFX_GPIOTE_CONFIG_NUM_OF_EVT_HANDLERS
 #define NRFX_GPIOTE_CONFIG_NUM_OF_EVT_HANDLERS 2
 #endif
 
-// <o> NRFX_GPIOTE_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
-#ifndef NRFX_GPIOTE_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_GPIOTE_DEFAULT_CONFIG_IRQ_PRIORITY 7
-#endif
-
-// <e> NRFX_GPIOTE_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_GPIOTE_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_GPIOTE_CONFIG_LOG_ENABLED
 #define NRFX_GPIOTE_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_GPIOTE_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_GPIOTE_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_GPIOTE_CONFIG_LOG_LEVEL
 #define NRFX_GPIOTE_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_GPIOTE_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_GPIOTE_CONFIG_INFO_COLOR
-#define NRFX_GPIOTE_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_GPIOTE_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_GPIOTE_CONFIG_DEBUG_COLOR
-#define NRFX_GPIOTE_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_I2S_ENABLED - nrfx_i2s - I2S peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_I2S_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_I2S_ENABLED
 #define NRFX_I2S_ENABLED 0
 #endif
 
-// <o> NRFX_I2S_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_I2S_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_I2S_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_I2S_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_I2S_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_I2S_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_I2S_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_I2S_CONFIG_LOG_ENABLED
 #define NRFX_I2S_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_I2S_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_I2S_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_I2S_CONFIG_LOG_LEVEL
 #define NRFX_I2S_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_I2S_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_I2S_CONFIG_INFO_COLOR
-#define NRFX_I2S_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_I2S_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_I2S_CONFIG_DEBUG_COLOR
-#define NRFX_I2S_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_LPCOMP_ENABLED - nrfx_lpcomp - LPCOMP peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_LPCOMP_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_LPCOMP_ENABLED
 #define NRFX_LPCOMP_ENABLED 0
 #endif
 
-// <o> NRFX_LPCOMP_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_LPCOMP_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_LPCOMP_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_LPCOMP_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_LPCOMP_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_LPCOMP_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_LPCOMP_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_LPCOMP_CONFIG_LOG_ENABLED
 #define NRFX_LPCOMP_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_LPCOMP_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_LPCOMP_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_LPCOMP_CONFIG_LOG_LEVEL
 #define NRFX_LPCOMP_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_LPCOMP_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_LPCOMP_CONFIG_INFO_COLOR
-#define NRFX_LPCOMP_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_LPCOMP_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_LPCOMP_CONFIG_DEBUG_COLOR
-#define NRFX_LPCOMP_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_NFCT_ENABLED - nrfx_nfct - NFCT peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_NFCT_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_NFCT_ENABLED
 #define NRFX_NFCT_ENABLED 0
 #endif
-// <o> NRFX_NFCT_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
 
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_NFCT_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_NFCT_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_NFCT_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_NFCT_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <o> NRFX_NFCT_CONFIG_TIMER_INSTANCE_ID - Timer instance used for workarounds in the driver.
-
-// <0=> 0
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-
+/**
+ * @brief NRFX_NFCT_CONFIG_TIMER_INSTANCE_ID - Timer instance used for workarounds in the driver.
+ *
+ * Integer value. Minimum: 0 Maximum: 5
+ */
 #ifndef NRFX_NFCT_CONFIG_TIMER_INSTANCE_ID
 #define NRFX_NFCT_CONFIG_TIMER_INSTANCE_ID 4
 #endif
 
-// <e> NRFX_NFCT_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_NFCT_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_NFCT_CONFIG_LOG_ENABLED
 #define NRFX_NFCT_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_NFCT_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_NFCT_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_NFCT_CONFIG_LOG_LEVEL
 #define NRFX_NFCT_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_NFCT_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_NFCT_CONFIG_INFO_COLOR
-#define NRFX_NFCT_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_NFCT_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_NFCT_CONFIG_DEBUG_COLOR
-#define NRFX_NFCT_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_NVMC_ENABLED - nrfx_nvmc - NVMC peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_NVMC_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_NVMC_ENABLED
 #define NRFX_NVMC_ENABLED 0
 #endif
 
-// </e>
-
-// <e> NRFX_PDM_ENABLED - nrfx_pdm - PDM peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_PDM_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_PDM_ENABLED
 #define NRFX_PDM_ENABLED 0
 #endif
 
-// <o> NRFX_PDM_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_PDM_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_PDM_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_PDM_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_PDM_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_PDM_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_PDM_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_PDM_CONFIG_LOG_ENABLED
 #define NRFX_PDM_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_PDM_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_PDM_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_PDM_CONFIG_LOG_LEVEL
 #define NRFX_PDM_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_PDM_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_PDM_CONFIG_INFO_COLOR
-#define NRFX_PDM_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_PDM_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_PDM_CONFIG_DEBUG_COLOR
-#define NRFX_PDM_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_POWER_ENABLED - nrfx_power - POWER peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_POWER_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_POWER_ENABLED
 #define NRFX_POWER_ENABLED 0
 #endif
-// <o> NRFX_POWER_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
 
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_POWER_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_POWER_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_POWER_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_POWER_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// </e>
-
-// <e> NRFX_PPI_ENABLED - nrfx_ppi - PPI peripheral allocator
-//==========================================================
+/**
+ * @brief NRFX_PPI_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_PPI_ENABLED
 #define NRFX_PPI_ENABLED 0
 #endif
-// <e> NRFX_PPI_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+
+/**
+ * @brief NRFX_PPI_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_PPI_CONFIG_LOG_ENABLED
 #define NRFX_PPI_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_PPI_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_PPI_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_PPI_CONFIG_LOG_LEVEL
 #define NRFX_PPI_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_PPI_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_PPI_CONFIG_INFO_COLOR
-#define NRFX_PPI_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_PPI_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_PPI_CONFIG_DEBUG_COLOR
-#define NRFX_PPI_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_PRS_ENABLED - nrfx_prs - Peripheral Resource Sharing module
-//==========================================================
+/**
+ * @brief NRFX_PRS_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_PRS_ENABLED
 #define NRFX_PRS_ENABLED 0
 #endif
-// <q> NRFX_PRS_BOX_0_ENABLED  - Enables box 0 in the module.
 
-
-#ifndef NRFX_PRS_BOX_0_ENABLED
-#define NRFX_PRS_BOX_0_ENABLED 0
-#endif
-
-// <q> NRFX_PRS_BOX_1_ENABLED  - Enables box 1 in the module.
-
-
-#ifndef NRFX_PRS_BOX_1_ENABLED
-#define NRFX_PRS_BOX_1_ENABLED 0
-#endif
-
-// <q> NRFX_PRS_BOX_2_ENABLED  - Enables box 2 in the module.
-
-
-#ifndef NRFX_PRS_BOX_2_ENABLED
-#define NRFX_PRS_BOX_2_ENABLED 0
-#endif
-
-// <q> NRFX_PRS_BOX_3_ENABLED  - Enables box 3 in the module.
-
-
-#ifndef NRFX_PRS_BOX_3_ENABLED
-#define NRFX_PRS_BOX_3_ENABLED 0
-#endif
-
-// <q> NRFX_PRS_BOX_4_ENABLED  - Enables box 4 in the module.
-
-
-#ifndef NRFX_PRS_BOX_4_ENABLED
-#define NRFX_PRS_BOX_4_ENABLED 0
-#endif
-
-// <e> NRFX_PRS_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_PRS_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_PRS_CONFIG_LOG_ENABLED
 #define NRFX_PRS_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_PRS_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_PRS_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_PRS_CONFIG_LOG_LEVEL
 #define NRFX_PRS_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_PRS_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_PRS_CONFIG_INFO_COLOR
-#define NRFX_PRS_CONFIG_INFO_COLOR 0
+/**
+ * @brief NRFX_PRS_BOX_0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_PRS_BOX_0_ENABLED
+#define NRFX_PRS_BOX_0_ENABLED 0
 #endif
 
-// <o> NRFX_PRS_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_PRS_CONFIG_DEBUG_COLOR
-#define NRFX_PRS_CONFIG_DEBUG_COLOR 0
+/**
+ * @brief NRFX_PRS_BOX_1_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_PRS_BOX_1_ENABLED
+#define NRFX_PRS_BOX_1_ENABLED 0
 #endif
 
-// </e>
+/**
+ * @brief NRFX_PRS_BOX_2_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_PRS_BOX_2_ENABLED
+#define NRFX_PRS_BOX_2_ENABLED 0
+#endif
 
-// </e>
+/**
+ * @brief NRFX_PRS_BOX_3_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_PRS_BOX_3_ENABLED
+#define NRFX_PRS_BOX_3_ENABLED 0
+#endif
 
-// <e> NRFX_PWM_ENABLED - nrfx_pwm - PWM peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_PRS_BOX_4_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_PRS_BOX_4_ENABLED
+#define NRFX_PRS_BOX_4_ENABLED 0
+#endif
+
+/**
+ * @brief NRFX_PWM_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_PWM_ENABLED
 #define NRFX_PWM_ENABLED 0
 #endif
 
-// <q> NRFX_PWM0_ENABLED  - Enable PWM0 instance
-
-#ifndef NRFX_PWM0_ENABLED
-#define NRFX_PWM0_ENABLED 0
-#endif
-
-// <q> NRFX_PWM1_ENABLED  - Enable PWM1 instance
-
-#ifndef NRFX_PWM1_ENABLED
-#define NRFX_PWM1_ENABLED 0
-#endif
-
-// <q> NRFX_PWM2_ENABLED  - Enable PWM2 instance
-
-#ifndef NRFX_PWM2_ENABLED
-#define NRFX_PWM2_ENABLED 0
-#endif
-
-// <o> NRFX_PWM_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_PWM_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_PWM_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_PWM_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_PWM_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_PWM_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_PWM_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_PWM_CONFIG_LOG_ENABLED
 #define NRFX_PWM_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_PWM_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
-#ifndef NRFX_PWM_CONFIG_LOG_LEVEL
-#define NRFX_PWM_CONFIG_LOG_LEVEL 3
-#endif
-
-// <o> NRFX_PWM_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_PWM_CONFIG_INFO_COLOR
-#define NRFX_PWM_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_PWM_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_PWM_CONFIG_DEBUG_COLOR
-#define NRFX_PWM_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// <e> NRFX_PWM_NRF52_ANOMALY_109_WORKAROUND_ENABLED - Enables nRF52 Anomaly 109 workaround for PWM.
-
-// <i> The workaround uses interrupts to wake up the CPU and ensure
-// <i> it is active when PWM is about to start a DMA transfer. For
-// <i> initial transfer, done when a playback is started via PPI,
-// <i> a specific EGU instance is used to generate the interrupt.
-// <i> During the playback, the PWM interrupt triggered on SEQEND
-// <i> event of a preceding sequence is used to protect the transfer
-// <i> done for the next sequence to be played.
-//==========================================================
+/**
+ * @brief NRFX_PWM_NRF52_ANOMALY_109_WORKAROUND_ENABLED - Enables nRF52 Anomaly 109 workaround for PWM.
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_PWM_NRF52_ANOMALY_109_WORKAROUND_ENABLED
 #define NRFX_PWM_NRF52_ANOMALY_109_WORKAROUND_ENABLED 0
 #endif
-// <o> NRFX_PWM_NRF52_ANOMALY_109_EGU_INSTANCE  - EGU instance used by the nRF52 Anomaly 109 workaround for PWM.
 
-// <0=> EGU0
-// <1=> EGU1
-// <2=> EGU2
-// <3=> EGU3
-// <4=> EGU4
-// <5=> EGU5
-
+/**
+ * @brief NRFX_PWM_NRF52_ANOMALY_109_EGU_INSTANCE - EGU instance used by the nRF52 Anomaly 109 workaround for PWM.
+ *
+ * Integer value.
+ * Supported values:
+ * - EGU0 = 0
+ * - EGU1 = 1
+ * - EGU2 = 2
+ * - EGU3 = 3
+ * - EGU4 = 4
+ * - EGU5 = 5
+ */
 #ifndef NRFX_PWM_NRF52_ANOMALY_109_EGU_INSTANCE
 #define NRFX_PWM_NRF52_ANOMALY_109_EGU_INSTANCE 5
 #endif
 
-// </e>
+/**
+ * @brief NRFX_PWM_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
+#ifndef NRFX_PWM_CONFIG_LOG_LEVEL
+#define NRFX_PWM_CONFIG_LOG_LEVEL 3
+#endif
 
-// </e>
+/**
+ * @brief NRFX_PWM0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_PWM0_ENABLED
+#define NRFX_PWM0_ENABLED 0
+#endif
 
-// <e> NRFX_QDEC_ENABLED - nrfx_qdec - QDEC peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_PWM1_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_PWM1_ENABLED
+#define NRFX_PWM1_ENABLED 0
+#endif
+
+/**
+ * @brief NRFX_PWM2_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_PWM2_ENABLED
+#define NRFX_PWM2_ENABLED 0
+#endif
+
+/**
+ * @brief NRFX_QDEC_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_QDEC_ENABLED
 #define NRFX_QDEC_ENABLED 0
 #endif
 
-// <o> NRFX_QDEC_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_QDEC_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_QDEC_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_QDEC_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_QDEC_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_QDEC_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_QDEC_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_QDEC_CONFIG_LOG_ENABLED
 #define NRFX_QDEC_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_QDEC_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_QDEC_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_QDEC_CONFIG_LOG_LEVEL
 #define NRFX_QDEC_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_QDEC_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_QDEC_CONFIG_INFO_COLOR
-#define NRFX_QDEC_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_QDEC_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_QDEC_CONFIG_DEBUG_COLOR
-#define NRFX_QDEC_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_RNG_ENABLED - nrfx_rng - RNG peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_RNG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_RNG_ENABLED
 #define NRFX_RNG_ENABLED 0
 #endif
 
-// <o> NRFX_RNG_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_RNG_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_RNG_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_RNG_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_RNG_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_RNG_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_RNG_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_RNG_CONFIG_LOG_ENABLED
 #define NRFX_RNG_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_RNG_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_RNG_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_RNG_CONFIG_LOG_LEVEL
 #define NRFX_RNG_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_RNG_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_RNG_CONFIG_INFO_COLOR
-#define NRFX_RNG_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_RNG_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_RNG_CONFIG_DEBUG_COLOR
-#define NRFX_RNG_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_RTC_ENABLED - nrfx_rtc - RTC peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_RTC_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_RTC_ENABLED
 #define NRFX_RTC_ENABLED 0
 #endif
-// <q> NRFX_RTC0_ENABLED  - Enable RTC0 instance
 
-#ifndef NRFX_RTC0_ENABLED
-#define NRFX_RTC0_ENABLED 0
-#endif
-
-// <q> NRFX_RTC1_ENABLED  - Enable RTC1 instance
-
-#ifndef NRFX_RTC1_ENABLED
-#define NRFX_RTC1_ENABLED 0
-#endif
-
-// <q> NRFX_RTC2_ENABLED  - Enable RTC2 instance
-
-#ifndef NRFX_RTC2_ENABLED
-#define NRFX_RTC2_ENABLED 0
-#endif
-
-// <o> NRFX_RTC_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_RTC_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_RTC_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_RTC_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_RTC_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_RTC_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_RTC_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_RTC_CONFIG_LOG_ENABLED
 #define NRFX_RTC_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_RTC_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_RTC_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_RTC_CONFIG_LOG_LEVEL
 #define NRFX_RTC_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_RTC_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_RTC_CONFIG_INFO_COLOR
-#define NRFX_RTC_CONFIG_INFO_COLOR 0
+/**
+ * @brief NRFX_RTC0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_RTC0_ENABLED
+#define NRFX_RTC0_ENABLED 0
 #endif
 
-// <o> NRFX_RTC_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_RTC_CONFIG_DEBUG_COLOR
-#define NRFX_RTC_CONFIG_DEBUG_COLOR 0
+/**
+ * @brief NRFX_RTC1_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_RTC1_ENABLED
+#define NRFX_RTC1_ENABLED 0
 #endif
 
-// </e>
+/**
+ * @brief NRFX_RTC2_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_RTC2_ENABLED
+#define NRFX_RTC2_ENABLED 0
+#endif
 
-// </e>
-
-// <e> NRFX_SAADC_ENABLED - nrfx_saadc - SAADC peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_SAADC_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_SAADC_ENABLED
 #define NRFX_SAADC_ENABLED 0
 #endif
 
-// <o> NRFX_SAADC_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_SAADC_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_SAADC_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_SAADC_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_SAADC_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_SAADC_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_SAADC_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_SAADC_CONFIG_LOG_ENABLED
 #define NRFX_SAADC_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_SAADC_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_SAADC_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_SAADC_CONFIG_LOG_LEVEL
 #define NRFX_SAADC_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_SAADC_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_SAADC_CONFIG_INFO_COLOR
-#define NRFX_SAADC_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_SAADC_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_SAADC_CONFIG_DEBUG_COLOR
-#define NRFX_SAADC_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_SPIM_ENABLED - nrfx_spim - SPIM peripheral driver
-//==========================================================
-#ifndef NRFX_SPIM_ENABLED
-#define NRFX_SPIM_ENABLED 0
-#endif
-// <q> NRFX_SPIM0_ENABLED  - Enable SPIM0 instance
-
-
-#ifndef NRFX_SPIM0_ENABLED
-#define NRFX_SPIM0_ENABLED 0
-#endif
-
-// <q> NRFX_SPIM1_ENABLED  - Enable SPIM1 instance
-
-
-#ifndef NRFX_SPIM1_ENABLED
-#define NRFX_SPIM1_ENABLED 0
-#endif
-
-// <q> NRFX_SPIM2_ENABLED  - Enable SPIM2 instance
-
-
-#ifndef NRFX_SPIM2_ENABLED
-#define NRFX_SPIM2_ENABLED 0
-#endif
-
-// <o> NRFX_SPIM_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
-#ifndef NRFX_SPIM_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_SPIM_DEFAULT_CONFIG_IRQ_PRIORITY 7
-#endif
-
-// <e> NRFX_SPIM_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
-#ifndef NRFX_SPIM_CONFIG_LOG_ENABLED
-#define NRFX_SPIM_CONFIG_LOG_ENABLED 0
-#endif
-// <o> NRFX_SPIM_CONFIG_LOG_LEVEL  - Default Severity level
-
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
-#ifndef NRFX_SPIM_CONFIG_LOG_LEVEL
-#define NRFX_SPIM_CONFIG_LOG_LEVEL 3
-#endif
-
-// <o> NRFX_SPIM_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_SPIM_CONFIG_INFO_COLOR
-#define NRFX_SPIM_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_SPIM_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_SPIM_CONFIG_DEBUG_COLOR
-#define NRFX_SPIM_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// <q> NRFX_SPIM_NRF52_ANOMALY_109_WORKAROUND_ENABLED  - Enables nRF52 anomaly 109 workaround for SPIM.
-
-
-// <i> The workaround uses interrupts to wake up the CPU by catching
-// <i> a start event of zero-length transmission to start the clock. This
-// <i> ensures that the DMA transfer will be executed without issues and
-// <i> that the proper transfer will be started. See more in the Errata
-// <i> document or Anomaly 109 Addendum located at
-// <i> https://infocenter.nordicsemi.com/
-
-#ifndef NRFX_SPIM_NRF52_ANOMALY_109_WORKAROUND_ENABLED
-#define NRFX_SPIM_NRF52_ANOMALY_109_WORKAROUND_ENABLED 0
-#endif
-
-// </e>
-
-// <e> NRFX_SPIS_ENABLED - nrfx_spis - SPIS peripheral driver
-//==========================================================
-#ifndef NRFX_SPIS_ENABLED
-#define NRFX_SPIS_ENABLED 0
-#endif
-// <q> NRFX_SPIS0_ENABLED  - Enable SPIS0 instance
-
-
-#ifndef NRFX_SPIS0_ENABLED
-#define NRFX_SPIS0_ENABLED 0
-#endif
-
-// <q> NRFX_SPIS1_ENABLED  - Enable SPIS1 instance
-
-
-#ifndef NRFX_SPIS1_ENABLED
-#define NRFX_SPIS1_ENABLED 0
-#endif
-
-// <q> NRFX_SPIS2_ENABLED  - Enable SPIS2 instance
-
-
-#ifndef NRFX_SPIS2_ENABLED
-#define NRFX_SPIS2_ENABLED 0
-#endif
-
-// <o> NRFX_SPIS_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
-#ifndef NRFX_SPIS_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_SPIS_DEFAULT_CONFIG_IRQ_PRIORITY 7
-#endif
-
-// <e> NRFX_SPIS_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
-#ifndef NRFX_SPIS_CONFIG_LOG_ENABLED
-#define NRFX_SPIS_CONFIG_LOG_ENABLED 0
-#endif
-// <o> NRFX_SPIS_CONFIG_LOG_LEVEL  - Default Severity level
-
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
-#ifndef NRFX_SPIS_CONFIG_LOG_LEVEL
-#define NRFX_SPIS_CONFIG_LOG_LEVEL 3
-#endif
-
-// <o> NRFX_SPIS_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_SPIS_CONFIG_INFO_COLOR
-#define NRFX_SPIS_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_SPIS_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_SPIS_CONFIG_DEBUG_COLOR
-#define NRFX_SPIS_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// <q> NRFX_SPIS_NRF52_ANOMALY_109_WORKAROUND_ENABLED  - Enables nRF52 Anomaly 109 workaround for SPIS.
-
-
-// <i> The workaround uses a GPIOTE channel to generate interrupts
-// <i> on falling edges detected on the CSN line. This will make
-// <i> the CPU active for the moment when SPIS starts DMA transfers,
-// <i> and this way the transfers will be protected.
-// <i> This workaround uses GPIOTE driver, so this driver must be
-// <i> enabled as well.
-
-#ifndef NRFX_SPIS_NRF52_ANOMALY_109_WORKAROUND_ENABLED
-#define NRFX_SPIS_NRF52_ANOMALY_109_WORKAROUND_ENABLED 0
-#endif
-
-// </e>
-
-// <e> NRFX_SPI_ENABLED - nrfx_spi - SPI peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_SPI_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_SPI_ENABLED
 #define NRFX_SPI_ENABLED 0
 #endif
-// <q> NRFX_SPI0_ENABLED  - Enable SPI0 instance
 
-
-#ifndef NRFX_SPI0_ENABLED
-#define NRFX_SPI0_ENABLED 0
-#endif
-
-// <q> NRFX_SPI1_ENABLED  - Enable SPI1 instance
-
-
-#ifndef NRFX_SPI1_ENABLED
-#define NRFX_SPI1_ENABLED 0
-#endif
-
-// <q> NRFX_SPI2_ENABLED  - Enable SPI2 instance
-
-
-#ifndef NRFX_SPI2_ENABLED
-#define NRFX_SPI2_ENABLED 0
-#endif
-
-// <o> NRFX_SPI_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_SPI_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_SPI_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_SPI_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_SPI_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_SPI_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_SPI_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_SPI_CONFIG_LOG_ENABLED
 #define NRFX_SPI_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_SPI_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_SPI_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_SPI_CONFIG_LOG_LEVEL
 #define NRFX_SPI_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_SPI_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_SPI_CONFIG_INFO_COLOR
-#define NRFX_SPI_CONFIG_INFO_COLOR 0
+/**
+ * @brief NRFX_SPI0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPI0_ENABLED
+#define NRFX_SPI0_ENABLED 0
 #endif
 
-// <o> NRFX_SPI_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_SPI_CONFIG_DEBUG_COLOR
-#define NRFX_SPI_CONFIG_DEBUG_COLOR 0
+/**
+ * @brief NRFX_SPI1_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPI1_ENABLED
+#define NRFX_SPI1_ENABLED 0
 #endif
 
-// </e>
+/**
+ * @brief NRFX_SPI2_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPI2_ENABLED
+#define NRFX_SPI2_ENABLED 0
+#endif
 
-// </e>
+/**
+ * @brief NRFX_SPIM_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPIM_ENABLED
+#define NRFX_SPIM_ENABLED 0
+#endif
 
-// <q> NRFX_SYSTICK_ENABLED  - nrfx_systick - ARM(R) SysTick driver
+/**
+ * @brief NRFX_SPIM_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
+#ifndef NRFX_SPIM_DEFAULT_CONFIG_IRQ_PRIORITY
+#define NRFX_SPIM_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
+#endif
 
+/**
+ * @brief NRFX_SPIM_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPIM_CONFIG_LOG_ENABLED
+#define NRFX_SPIM_CONFIG_LOG_ENABLED 0
+#endif
 
+/**
+ * @brief NRFX_SPIM_NRF52_ANOMALY_109_WORKAROUND_ENABLED - Enables nRF52 Anomaly 109 workaround for SPIM.
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPIM_NRF52_ANOMALY_109_WORKAROUND_ENABLED
+#define NRFX_SPIM_NRF52_ANOMALY_109_WORKAROUND_ENABLED 0
+#endif
+
+/**
+ * @brief NRFX_SPIM_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
+#ifndef NRFX_SPIM_CONFIG_LOG_LEVEL
+#define NRFX_SPIM_CONFIG_LOG_LEVEL 3
+#endif
+
+/**
+ * @brief NRFX_SPIM0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPIM0_ENABLED
+#define NRFX_SPIM0_ENABLED 0
+#endif
+
+/**
+ * @brief NRFX_SPIM1_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPIM1_ENABLED
+#define NRFX_SPIM1_ENABLED 0
+#endif
+
+/**
+ * @brief NRFX_SPIM2_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPIM2_ENABLED
+#define NRFX_SPIM2_ENABLED 0
+#endif
+
+/**
+ * @brief NRFX_SPIS_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPIS_ENABLED
+#define NRFX_SPIS_ENABLED 0
+#endif
+
+/**
+ * @brief NRFX_SPIS_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
+#ifndef NRFX_SPIS_DEFAULT_CONFIG_IRQ_PRIORITY
+#define NRFX_SPIS_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
+#endif
+
+/**
+ * @brief NRFX_SPIS_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPIS_CONFIG_LOG_ENABLED
+#define NRFX_SPIS_CONFIG_LOG_ENABLED 0
+#endif
+
+/**
+ * @brief NRFX_SPIS_NRF52_ANOMALY_109_WORKAROUND_ENABLED - Enables nRF52 Anomaly 109 workaround for SPIS.
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPIS_NRF52_ANOMALY_109_WORKAROUND_ENABLED
+#define NRFX_SPIS_NRF52_ANOMALY_109_WORKAROUND_ENABLED 0
+#endif
+
+/**
+ * @brief NRFX_SPIS_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
+#ifndef NRFX_SPIS_CONFIG_LOG_LEVEL
+#define NRFX_SPIS_CONFIG_LOG_LEVEL 3
+#endif
+
+/**
+ * @brief NRFX_SPIS0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPIS0_ENABLED
+#define NRFX_SPIS0_ENABLED 0
+#endif
+
+/**
+ * @brief NRFX_SPIS1_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPIS1_ENABLED
+#define NRFX_SPIS1_ENABLED 0
+#endif
+
+/**
+ * @brief NRFX_SPIS2_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPIS2_ENABLED
+#define NRFX_SPIS2_ENABLED 0
+#endif
+
+/**
+ * @brief NRFX_SYSTICK_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_SYSTICK_ENABLED
 #define NRFX_SYSTICK_ENABLED 0
 #endif
 
-// <e> NRFX_TEMP_ENABLED - nrfx_temp - TEMP peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_TEMP_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_TEMP_ENABLED
 #define NRFX_TEMP_ENABLED 0
 #endif
 
-// <o> NRFX_TEMP_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_TEMP_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_TEMP_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_TEMP_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_TEMP_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// </e>
+/**
+ * @brief NRFX_TEMP_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TEMP_CONFIG_LOG_ENABLED
+#define NRFX_TEMP_CONFIG_LOG_ENABLED 0
+#endif
 
-// <e> NRFX_TIMER_ENABLED - nrfx_timer - TIMER periperal driver
-//==========================================================
+/**
+ * @brief NRFX_TEMP_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
+#ifndef NRFX_TEMP_CONFIG_LOG_LEVEL
+#define NRFX_TEMP_CONFIG_LOG_LEVEL 3
+#endif
+
+/**
+ * @brief NRFX_TIMER_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_TIMER_ENABLED
 #define NRFX_TIMER_ENABLED 0
 #endif
 
-// <q> NRFX_TIMER0_ENABLED  - Enable TIMER0 instance
-
-#ifndef NRFX_TIMER0_ENABLED
-#define NRFX_TIMER0_ENABLED 0
-#endif
-
-// <q> NRFX_TIMER1_ENABLED  - Enable TIMER1 instance
-
-#ifndef NRFX_TIMER1_ENABLED
-#define NRFX_TIMER1_ENABLED 0
-#endif
-
-// <q> NRFX_TIMER2_ENABLED  - Enable TIMER2 instance
-
-#ifndef NRFX_TIMER2_ENABLED
-#define NRFX_TIMER2_ENABLED 0
-#endif
-
-// <q> NRFX_TIMER3_ENABLED  - Enable TIMER3 instance
-
-#ifndef NRFX_TIMER3_ENABLED
-#define NRFX_TIMER3_ENABLED 0
-#endif
-
-// <q> NRFX_TIMER4_ENABLED  - Enable TIMER4 instance
-
-#ifndef NRFX_TIMER4_ENABLED
-#define NRFX_TIMER4_ENABLED 0
-#endif
-
-// <o> NRFX_TIMER_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_TIMER_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_TIMER_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_TIMER_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_TIMER_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_TIMER_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_TIMER_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_TIMER_CONFIG_LOG_ENABLED
 #define NRFX_TIMER_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_TIMER_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_TIMER_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_TIMER_CONFIG_LOG_LEVEL
 #define NRFX_TIMER_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_TIMER_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_TIMER_CONFIG_INFO_COLOR
-#define NRFX_TIMER_CONFIG_INFO_COLOR 0
+/**
+ * @brief NRFX_TIMER0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TIMER0_ENABLED
+#define NRFX_TIMER0_ENABLED 0
 #endif
 
-// <o> NRFX_TIMER_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_TIMER_CONFIG_DEBUG_COLOR
-#define NRFX_TIMER_CONFIG_DEBUG_COLOR 0
+/**
+ * @brief NRFX_TIMER1_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TIMER1_ENABLED
+#define NRFX_TIMER1_ENABLED 0
 #endif
 
-// </e>
-
-// </e>
-
-// <e> NRFX_TWIM_ENABLED - nrfx_twim - TWIM peripheral driver
-//==========================================================
-#ifndef NRFX_TWIM_ENABLED
-#define NRFX_TWIM_ENABLED 0
+/**
+ * @brief NRFX_TIMER2_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TIMER2_ENABLED
+#define NRFX_TIMER2_ENABLED 0
 #endif
 
-// <q> NRFX_TWIM0_ENABLED  - Enable TWIM0 instance
-
-#ifndef NRFX_TWIM0_ENABLED
-#define NRFX_TWIM0_ENABLED 0
+/**
+ * @brief NRFX_TIMER3_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TIMER3_ENABLED
+#define NRFX_TIMER3_ENABLED 0
 #endif
 
-// <q> NRFX_TWIM1_ENABLED  - Enable TWIM1 instance
-
-#ifndef NRFX_TWIM1_ENABLED
-#define NRFX_TWIM1_ENABLED 0
+/**
+ * @brief NRFX_TIMER4_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TIMER4_ENABLED
+#define NRFX_TIMER4_ENABLED 0
 #endif
 
-// <o> NRFX_TWIM_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
-#ifndef NRFX_TWIM_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_TWIM_DEFAULT_CONFIG_IRQ_PRIORITY 7
-#endif
-
-// <e> NRFX_TWIM_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
-#ifndef NRFX_TWIM_CONFIG_LOG_ENABLED
-#define NRFX_TWIM_CONFIG_LOG_ENABLED 0
-#endif
-// <o> NRFX_TWIM_CONFIG_LOG_LEVEL  - Default Severity level
-
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
-#ifndef NRFX_TWIM_CONFIG_LOG_LEVEL
-#define NRFX_TWIM_CONFIG_LOG_LEVEL 3
-#endif
-
-// <o> NRFX_TWIM_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_TWIM_CONFIG_INFO_COLOR
-#define NRFX_TWIM_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_TWIM_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_TWIM_CONFIG_DEBUG_COLOR
-#define NRFX_TWIM_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// <q> NRFX_TWIM_NRF52_ANOMALY_109_WORKAROUND_ENABLED  - Enables nRF52 anomaly 109 workaround for TWIM.
-
-
-// <i> The workaround uses interrupts to wake up the CPU by catching
-// <i> the start event of zero-frequency transmission, clear the
-// <i> peripheral, set desired frequency, start the peripheral, and
-// <i> the proper transmission. See more in the Errata document or
-// <i> Anomaly 109 Addendum located at https://infocenter.nordicsemi.com/
-
-#ifndef NRFX_TWIM_NRF52_ANOMALY_109_WORKAROUND_ENABLED
-#define NRFX_TWIM_NRF52_ANOMALY_109_WORKAROUND_ENABLED 0
-#endif
-
-// </e>
-
-// <e> NRFX_TWIS_ENABLED - nrfx_twis - TWIS peripheral driver
-//==========================================================
-#ifndef NRFX_TWIS_ENABLED
-#define NRFX_TWIS_ENABLED 0
-#endif
-
-// <q> NRFX_TWIS0_ENABLED  - Enable TWIS0 instance
-
-#ifndef NRFX_TWIS0_ENABLED
-#define NRFX_TWIS0_ENABLED 0
-#endif
-
-// <q> NRFX_TWIS1_ENABLED  - Enable TWIS1 instance
-
-#ifndef NRFX_TWIS1_ENABLED
-#define NRFX_TWIS1_ENABLED 0
-#endif
-
-// <q> NRFX_TWIS_ASSUME_INIT_AFTER_RESET_ONLY  - Assume that any instance would be initialized only once
-
-// <i> Optimization flag. Registers used by TWIS are shared by other peripherals. Normally, during initialization driver tries to clear all registers to known state before doing the initialization itself. This gives initialization safe procedure, no matter when it would be called. If you activate TWIS only once and do never uninitialize it - set this flag to 1 what gives more optimal code.
-
-#ifndef NRFX_TWIS_ASSUME_INIT_AFTER_RESET_ONLY
-#define NRFX_TWIS_ASSUME_INIT_AFTER_RESET_ONLY 0
-#endif
-
-// <q> NRFX_TWIS_NO_SYNC_MODE  - Remove support for synchronous mode
-
-// <i> Synchronous mode would be used in specific situations. And it uses some additional code and data memory to safely process state machine by polling it in status functions. If this functionality is not required it may be disabled to free some resources.
-
-#ifndef NRFX_TWIS_NO_SYNC_MODE
-#define NRFX_TWIS_NO_SYNC_MODE 0
-#endif
-
-// <o> NRFX_TWIS_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
-#ifndef NRFX_TWIS_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_TWIS_DEFAULT_CONFIG_IRQ_PRIORITY 7
-#endif
-
-// <e> NRFX_TWIS_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
-#ifndef NRFX_TWIS_CONFIG_LOG_ENABLED
-#define NRFX_TWIS_CONFIG_LOG_ENABLED 0
-#endif
-// <o> NRFX_TWIS_CONFIG_LOG_LEVEL  - Default Severity level
-
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
-#ifndef NRFX_TWIS_CONFIG_LOG_LEVEL
-#define NRFX_TWIS_CONFIG_LOG_LEVEL 3
-#endif
-
-// <o> NRFX_TWIS_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_TWIS_CONFIG_INFO_COLOR
-#define NRFX_TWIS_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_TWIS_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_TWIS_CONFIG_DEBUG_COLOR
-#define NRFX_TWIS_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_TWI_ENABLED - nrfx_twi - TWI peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_TWI_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_TWI_ENABLED
 #define NRFX_TWI_ENABLED 0
 #endif
 
-// <q> NRFX_TWI0_ENABLED  - Enable TWI0 instance
-
-#ifndef NRFX_TWI0_ENABLED
-#define NRFX_TWI0_ENABLED 0
-#endif
-
-// <q> NRFX_TWI1_ENABLED  - Enable TWI1 instance
-
-#ifndef NRFX_TWI1_ENABLED
-#define NRFX_TWI1_ENABLED 0
-#endif
-
-// <o> NRFX_TWI_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_TWI_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_TWI_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_TWI_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_TWI_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_TWI_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_TWI_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_TWI_CONFIG_LOG_ENABLED
 #define NRFX_TWI_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_TWI_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_TWI_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_TWI_CONFIG_LOG_LEVEL
 #define NRFX_TWI_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_TWI_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_TWI_CONFIG_INFO_COLOR
-#define NRFX_TWI_CONFIG_INFO_COLOR 0
+/**
+ * @brief NRFX_TWI0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWI0_ENABLED
+#define NRFX_TWI0_ENABLED 0
 #endif
 
-// <o> NRFX_TWI_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_TWI_CONFIG_DEBUG_COLOR
-#define NRFX_TWI_CONFIG_DEBUG_COLOR 0
+/**
+ * @brief NRFX_TWI1_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWI1_ENABLED
+#define NRFX_TWI1_ENABLED 0
 #endif
 
-// </e>
-
-// </e>
-
-// <e> NRFX_UARTE_ENABLED - nrfx_uarte - UARTE peripheral driver
-//==========================================================
-#ifndef NRFX_UARTE_ENABLED
-#define NRFX_UARTE_ENABLED 0
+/**
+ * @brief NRFX_TWIM_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWIM_ENABLED
+#define NRFX_TWIM_ENABLED 0
 #endif
 
-// <q> NRFX_UARTE0_ENABLED - Enable UARTE0 instance
-
-#ifndef NRFX_UARTE0_ENABLED
-#define NRFX_UARTE0_ENABLED 0
+/**
+ * @brief NRFX_TWIM_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
+#ifndef NRFX_TWIM_DEFAULT_CONFIG_IRQ_PRIORITY
+#define NRFX_TWIM_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <o> NRFX_UARTE_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
-#ifndef NRFX_UARTE_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_UARTE_DEFAULT_CONFIG_IRQ_PRIORITY 7
+/**
+ * @brief NRFX_TWIM_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWIM_CONFIG_LOG_ENABLED
+#define NRFX_TWIM_CONFIG_LOG_ENABLED 0
 #endif
 
-// <e> NRFX_UARTE_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
-#ifndef NRFX_UARTE_CONFIG_LOG_ENABLED
-#define NRFX_UARTE_CONFIG_LOG_ENABLED 0
-#endif
-// <o> NRFX_UARTE_CONFIG_LOG_LEVEL  - Default Severity level
-
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
-#ifndef NRFX_UARTE_CONFIG_LOG_LEVEL
-#define NRFX_UARTE_CONFIG_LOG_LEVEL 3
+/**
+ * @brief NRFX_TWIM_NRF52_ANOMALY_109_WORKAROUND_ENABLED - Enables nRF52 Anomaly 109 workaround for TWIM.
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWIM_NRF52_ANOMALY_109_WORKAROUND_ENABLED
+#define NRFX_TWIM_NRF52_ANOMALY_109_WORKAROUND_ENABLED 0
 #endif
 
-// <o> NRFX_UARTE_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_UARTE_CONFIG_INFO_COLOR
-#define NRFX_UARTE_CONFIG_INFO_COLOR 0
+/**
+ * @brief NRFX_TWIM_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
+#ifndef NRFX_TWIM_CONFIG_LOG_LEVEL
+#define NRFX_TWIM_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_UARTE_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_UARTE_CONFIG_DEBUG_COLOR
-#define NRFX_UARTE_CONFIG_DEBUG_COLOR 0
+/**
+ * @brief NRFX_TWIM0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWIM0_ENABLED
+#define NRFX_TWIM0_ENABLED 0
 #endif
 
-// </e>
+/**
+ * @brief NRFX_TWIM1_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWIM1_ENABLED
+#define NRFX_TWIM1_ENABLED 0
+#endif
 
-// </e>
+/**
+ * @brief NRFX_TWIS_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWIS_ENABLED
+#define NRFX_TWIS_ENABLED 0
+#endif
 
-// <e> NRFX_UART_ENABLED - nrfx_uart - UART peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_TWIS_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
+#ifndef NRFX_TWIS_DEFAULT_CONFIG_IRQ_PRIORITY
+#define NRFX_TWIS_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
+#endif
+
+/**
+ * @brief NRFX_TWIS_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWIS_CONFIG_LOG_ENABLED
+#define NRFX_TWIS_CONFIG_LOG_ENABLED 0
+#endif
+
+/**
+ * @brief NRFX_TWIS_ASSUME_INIT_AFTER_RESET_ONLY - Assume that any instance would be initialized only once.
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWIS_ASSUME_INIT_AFTER_RESET_ONLY
+#define NRFX_TWIS_ASSUME_INIT_AFTER_RESET_ONLY 0
+#endif
+
+/**
+ * @brief NRFX_TWIS_NO_SYNC_MODE - Remove support for synchronous mode.
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWIS_NO_SYNC_MODE
+#define NRFX_TWIS_NO_SYNC_MODE 0
+#endif
+
+/**
+ * @brief NRFX_TWIS_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
+#ifndef NRFX_TWIS_CONFIG_LOG_LEVEL
+#define NRFX_TWIS_CONFIG_LOG_LEVEL 3
+#endif
+
+/**
+ * @brief NRFX_TWIS0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWIS0_ENABLED
+#define NRFX_TWIS0_ENABLED 0
+#endif
+
+/**
+ * @brief NRFX_TWIS1_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWIS1_ENABLED
+#define NRFX_TWIS1_ENABLED 0
+#endif
+
+/**
+ * @brief NRFX_UART_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_UART_ENABLED
 #define NRFX_UART_ENABLED 0
 #endif
 
-// <q> NRFX_UART0_ENABLED - Enable UART0 instance
-
-#ifndef NRFX_UART0_ENABLED
-#define NRFX_UART0_ENABLED 0
-#endif
-
-// <o> NRFX_UART_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_UART_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_UART_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_UART_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_UART_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_UART_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_UART_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_UART_CONFIG_LOG_ENABLED
 #define NRFX_UART_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_UART_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_UART_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_UART_CONFIG_LOG_LEVEL
 #define NRFX_UART_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_UART_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_UART_CONFIG_INFO_COLOR
-#define NRFX_UART_CONFIG_INFO_COLOR 0
+/**
+ * @brief NRFX_UART0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_UART0_ENABLED
+#define NRFX_UART0_ENABLED 0
 #endif
 
-// <o> NRFX_UART_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_UART_CONFIG_DEBUG_COLOR
-#define NRFX_UART_CONFIG_DEBUG_COLOR 0
+/**
+ * @brief NRFX_UARTE_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_UARTE_ENABLED
+#define NRFX_UARTE_ENABLED 0
 #endif
 
-// </e>
+/**
+ * @brief NRFX_UARTE_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
+#ifndef NRFX_UARTE_DEFAULT_CONFIG_IRQ_PRIORITY
+#define NRFX_UARTE_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
+#endif
 
-// </e>
+/**
+ * @brief NRFX_UARTE_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_UARTE_CONFIG_LOG_ENABLED
+#define NRFX_UARTE_CONFIG_LOG_ENABLED 0
+#endif
 
-// <e> NRFX_WDT_ENABLED - nrfx_wdt - WDT peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_UARTE_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
+#ifndef NRFX_UARTE_CONFIG_LOG_LEVEL
+#define NRFX_UARTE_CONFIG_LOG_LEVEL 3
+#endif
+
+/**
+ * @brief NRFX_UARTE0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_UARTE0_ENABLED
+#define NRFX_UARTE0_ENABLED 0
+#endif
+
+/**
+ * @brief NRFX_WDT_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_WDT_ENABLED
 #define NRFX_WDT_ENABLED 0
 #endif
 
-// <q> NRFX_WDT0_ENABLED  - Enable WDT0 instance
-
-#ifndef NRFX_WDT0_ENABLED
-#define NRFX_WDT0_ENABLED 0
+/**
+ * @brief NRFX_WDT_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
+#ifndef NRFX_WDT_DEFAULT_CONFIG_IRQ_PRIORITY
+#define NRFX_WDT_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <o> NRFX_WDT_CONFIG_NO_IRQ  - Remove WDT IRQ handling from WDT driver
-
-// <0=> Include WDT IRQ handling
-// <1=> Remove WDT IRQ handling
-
+/**
+ * @brief NRFX_WDT_CONFIG_NO_IRQ - Remove WDT IRQ handling from WDT driver
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_WDT_CONFIG_NO_IRQ
 #define NRFX_WDT_CONFIG_NO_IRQ 0
 #endif
 
-// <o> NRFX_WDT_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
-#ifndef NRFX_WDT_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_WDT_DEFAULT_CONFIG_IRQ_PRIORITY 7
-#endif
-
-// <e> NRFX_WDT_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_WDT_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_WDT_CONFIG_LOG_ENABLED
 #define NRFX_WDT_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_WDT_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_WDT_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_WDT_CONFIG_LOG_LEVEL
 #define NRFX_WDT_CONFIG_LOG_LEVEL 3
 #endif
-
-// <o> NRFX_WDT_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_WDT_CONFIG_INFO_COLOR
-#define NRFX_WDT_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_WDT_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_WDT_CONFIG_DEBUG_COLOR
-#define NRFX_WDT_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// </h>
 
 #endif // NRFX_CONFIG_NRF52832_H__

--- a/nrfx/templates/nrfx_config_nrf52833.h
+++ b/nrfx/templates/nrfx_config_nrf52833.h
@@ -38,2283 +38,1625 @@
 #error "This file should not be included directly. Include nrfx_config.h instead."
 #endif
 
-// <<< Use Configuration Wizard in Context Menu >>>\n
 
-// <h> nRF_Drivers
+/**
+ * @brief NRFX_DEFAULT_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
+#ifndef NRFX_DEFAULT_IRQ_PRIORITY
+#define NRFX_DEFAULT_IRQ_PRIORITY 7
+#endif
 
-// <e> NRFX_CLOCK_ENABLED - nrfx_clock - CLOCK peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_CLOCK_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_CLOCK_ENABLED
 #define NRFX_CLOCK_ENABLED 0
 #endif
-// <o> NRFX_CLOCK_CONFIG_LF_SRC  - LF Clock Source
 
-// <0=> RC
-// <1=> XTAL
-// <2=> Synth
-// <131073=> External Low Swing
-// <196609=> External Full Swing
-
+/**
+ * @brief NRFX_CLOCK_CONFIG_LF_SRC
+ *
+ * Integer value.
+ * Supported values:
+ * - RC                  = 0
+ * - XTAL                = 1
+ * - Synth               = 2
+ * - External Low Swing  = 131073
+ * - External Full Swing = 196609
+ */
 #ifndef NRFX_CLOCK_CONFIG_LF_SRC
 #define NRFX_CLOCK_CONFIG_LF_SRC 1
 #endif
 
-// <q> NRFX_CLOCK_CONFIG_LF_CAL_ENABLED  - Enables LF Clock Calibration Support
-
+/**
+ * @brief NRFX_CLOCK_CONFIG_LF_CAL_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_CLOCK_CONFIG_LF_CAL_ENABLED
 #define NRFX_CLOCK_CONFIG_LF_CAL_ENABLED 0
 #endif
 
-// <q> NRFX_CLOCK_CONFIG_CT_ENABLED  - Enables Calibration Timer Support
-
+/**
+ * @brief NRFX_CLOCK_CONFIG_CT_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_CLOCK_CONFIG_CT_ENABLED
 #define NRFX_CLOCK_CONFIG_CT_ENABLED 1
 #endif
 
-// <q> NRFX_CLOCK_CONFIG_LFXO_TWO_STAGE_ENABLED - Enables two-stage LFXO start procedure
-
-// <i> If set to a non-zero value, LFRC will be started before LFXO and corresponding
-// <i> event will be generated. It means that CPU will be woken up when LFRC
-// <i> oscillator starts, but user callback will be invoked only after LFXO
-// <i> finally starts.
-
+/**
+ * @brief NRFX_CLOCK_CONFIG_LFXO_TWO_STAGE_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_CLOCK_CONFIG_LFXO_TWO_STAGE_ENABLED
 #define NRFX_CLOCK_CONFIG_LFXO_TWO_STAGE_ENABLED 0
 #endif
 
-// <o> NRFX_CLOCK_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_CLOCK_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_CLOCK_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_CLOCK_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_CLOCK_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_CLOCK_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_CLOCK_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_CLOCK_CONFIG_LOG_ENABLED
 #define NRFX_CLOCK_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_CLOCK_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_CLOCK_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_CLOCK_CONFIG_LOG_LEVEL
 #define NRFX_CLOCK_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_CLOCK_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_CLOCK_CONFIG_INFO_COLOR
-#define NRFX_CLOCK_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_CLOCK_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_CLOCK_CONFIG_DEBUG_COLOR
-#define NRFX_CLOCK_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_COMP_ENABLED - nrfx_comp - COMP peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_COMP_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_COMP_ENABLED
 #define NRFX_COMP_ENABLED 0
 #endif
 
-// <o> NRFX_COMP_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_COMP_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_COMP_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_COMP_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_COMP_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_COMP_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_COMP_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_COMP_CONFIG_LOG_ENABLED
 #define NRFX_COMP_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_COMP_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_COMP_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_COMP_CONFIG_LOG_LEVEL
 #define NRFX_COMP_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_COMP_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_COMP_CONFIG_INFO_COLOR
-#define NRFX_COMP_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_COMP_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_COMP_CONFIG_DEBUG_COLOR
-#define NRFX_COMP_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_EGU_ENABLED - nrfx_egu - EGU peripheral driver.
-//==========================================================
+/**
+ * @brief NRFX_EGU_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_EGU_ENABLED
 #define NRFX_EGU_ENABLED 0
 #endif
 
-// <q> NRFX_EGU0_ENABLED  - Enable EGU0 instance.
+/**
+ * @brief NRFX_EGU_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
+#ifndef NRFX_EGU_DEFAULT_CONFIG_IRQ_PRIORITY
+#define NRFX_EGU_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
+#endif
 
+/**
+ * @brief NRFX_EGU0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_EGU0_ENABLED
 #define NRFX_EGU0_ENABLED 0
 #endif
 
-// <q> NRFX_EGU1_ENABLED  - Enable EGU1 instance.
-
+/**
+ * @brief NRFX_EGU1_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_EGU1_ENABLED
 #define NRFX_EGU1_ENABLED 0
 #endif
 
-// <q> NRFX_EGU2_ENABLED  - Enable EGU2 instance.
-
+/**
+ * @brief NRFX_EGU2_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_EGU2_ENABLED
 #define NRFX_EGU2_ENABLED 0
 #endif
 
-// <q> NRFX_EGU3_ENABLED  - Enable EGU3 instance.
-
+/**
+ * @brief NRFX_EGU3_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_EGU3_ENABLED
 #define NRFX_EGU3_ENABLED 0
 #endif
 
-// <q> NRFX_EGU4_ENABLED  - Enable EGU4 instance.
-
+/**
+ * @brief NRFX_EGU4_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_EGU4_ENABLED
 #define NRFX_EGU4_ENABLED 0
 #endif
 
-// <q> NRFX_EGU5_ENABLED  - Enable EGU5 instance.
-
+/**
+ * @brief NRFX_EGU5_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_EGU5_ENABLED
 #define NRFX_EGU5_ENABLED 0
 #endif
 
-// <o> NRFX_EGU_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority.
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
-#ifndef NRFX_EGU_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_EGU_DEFAULT_CONFIG_IRQ_PRIORITY 7
-#endif
-
-// </e>
-
-// <e> NRFX_GPIOTE_ENABLED - nrfx_gpiote - GPIOTE peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_GPIOTE_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_GPIOTE_ENABLED
 #define NRFX_GPIOTE_ENABLED 0
 #endif
 
-// <o> NRFX_GPIOTE_CONFIG_NUM_OF_EVT_HANDLERS - Number of dedicated handlers
+/**
+ * @brief NRFX_GPIOTE_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
+#ifndef NRFX_GPIOTE_DEFAULT_CONFIG_IRQ_PRIORITY
+#define NRFX_GPIOTE_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
+#endif
+
+/**
+ * @brief NRFX_GPIOTE_CONFIG_NUM_OF_EVT_HANDLERS
+ *
+ * Integer value. Minimum: 0 Maximum: 15
+ */
 #ifndef NRFX_GPIOTE_CONFIG_NUM_OF_EVT_HANDLERS
 #define NRFX_GPIOTE_CONFIG_NUM_OF_EVT_HANDLERS 2
 #endif
 
-// <o> NRFX_GPIOTE_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
-#ifndef NRFX_GPIOTE_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_GPIOTE_DEFAULT_CONFIG_IRQ_PRIORITY 7
-#endif
-
-// <e> NRFX_GPIOTE_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_GPIOTE_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_GPIOTE_CONFIG_LOG_ENABLED
 #define NRFX_GPIOTE_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_GPIOTE_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_GPIOTE_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_GPIOTE_CONFIG_LOG_LEVEL
 #define NRFX_GPIOTE_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_GPIOTE_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_GPIOTE_CONFIG_INFO_COLOR
-#define NRFX_GPIOTE_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_GPIOTE_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_GPIOTE_CONFIG_DEBUG_COLOR
-#define NRFX_GPIOTE_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_I2S_ENABLED - nrfx_i2s - I2S peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_I2S_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_I2S_ENABLED
 #define NRFX_I2S_ENABLED 0
 #endif
 
-// <o> NRFX_I2S_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_I2S_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_I2S_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_I2S_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_I2S_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_I2S_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_I2S_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_I2S_CONFIG_LOG_ENABLED
 #define NRFX_I2S_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_I2S_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_I2S_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_I2S_CONFIG_LOG_LEVEL
 #define NRFX_I2S_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_I2S_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_I2S_CONFIG_INFO_COLOR
-#define NRFX_I2S_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_I2S_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_I2S_CONFIG_DEBUG_COLOR
-#define NRFX_I2S_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_LPCOMP_ENABLED - nrfx_lpcomp - LPCOMP peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_LPCOMP_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_LPCOMP_ENABLED
 #define NRFX_LPCOMP_ENABLED 0
 #endif
 
-// <o> NRFX_LPCOMP_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_LPCOMP_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_LPCOMP_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_LPCOMP_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_LPCOMP_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_LPCOMP_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_LPCOMP_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_LPCOMP_CONFIG_LOG_ENABLED
 #define NRFX_LPCOMP_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_LPCOMP_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_LPCOMP_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_LPCOMP_CONFIG_LOG_LEVEL
 #define NRFX_LPCOMP_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_LPCOMP_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_LPCOMP_CONFIG_INFO_COLOR
-#define NRFX_LPCOMP_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_LPCOMP_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_LPCOMP_CONFIG_DEBUG_COLOR
-#define NRFX_LPCOMP_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_NFCT_ENABLED - nrfx_nfct - NFCT peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_NFCT_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_NFCT_ENABLED
 #define NRFX_NFCT_ENABLED 0
 #endif
-// <o> NRFX_NFCT_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
 
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_NFCT_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_NFCT_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_NFCT_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_NFCT_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <o> NRFX_NFCT_CONFIG_TIMER_INSTANCE_ID - Timer instance used for workarounds in the driver.
-
-// <0=> 0
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-
+/**
+ * @brief NRFX_NFCT_CONFIG_TIMER_INSTANCE_ID - Timer instance used for workarounds in the driver.
+ *
+ * Integer value. Minimum: 0 Maximum: 5
+ */
 #ifndef NRFX_NFCT_CONFIG_TIMER_INSTANCE_ID
 #define NRFX_NFCT_CONFIG_TIMER_INSTANCE_ID 4
 #endif
 
-// <e> NRFX_NFCT_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_NFCT_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_NFCT_CONFIG_LOG_ENABLED
 #define NRFX_NFCT_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_NFCT_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_NFCT_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_NFCT_CONFIG_LOG_LEVEL
 #define NRFX_NFCT_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_NFCT_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_NFCT_CONFIG_INFO_COLOR
-#define NRFX_NFCT_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_NFCT_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_NFCT_CONFIG_DEBUG_COLOR
-#define NRFX_NFCT_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_NVMC_ENABLED - nrfx_nvmc - NVMC peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_NVMC_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_NVMC_ENABLED
 #define NRFX_NVMC_ENABLED 0
 #endif
 
-// </e>
-
-// <e> NRFX_PDM_ENABLED - nrfx_pdm - PDM peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_PDM_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_PDM_ENABLED
 #define NRFX_PDM_ENABLED 0
 #endif
 
-// <o> NRFX_PDM_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_PDM_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_PDM_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_PDM_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_PDM_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_PDM_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_PDM_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_PDM_CONFIG_LOG_ENABLED
 #define NRFX_PDM_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_PDM_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_PDM_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_PDM_CONFIG_LOG_LEVEL
 #define NRFX_PDM_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_PDM_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_PDM_CONFIG_INFO_COLOR
-#define NRFX_PDM_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_PDM_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_PDM_CONFIG_DEBUG_COLOR
-#define NRFX_PDM_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_POWER_ENABLED - nrfx_power - POWER peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_POWER_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_POWER_ENABLED
 #define NRFX_POWER_ENABLED 0
 #endif
-// <o> NRFX_POWER_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
 
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_POWER_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_POWER_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_POWER_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_POWER_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// </e>
-
-// <e> NRFX_PPI_ENABLED - nrfx_ppi - PPI peripheral allocator
-//==========================================================
+/**
+ * @brief NRFX_PPI_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_PPI_ENABLED
 #define NRFX_PPI_ENABLED 0
 #endif
-// <e> NRFX_PPI_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+
+/**
+ * @brief NRFX_PPI_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_PPI_CONFIG_LOG_ENABLED
 #define NRFX_PPI_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_PPI_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_PPI_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_PPI_CONFIG_LOG_LEVEL
 #define NRFX_PPI_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_PPI_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_PPI_CONFIG_INFO_COLOR
-#define NRFX_PPI_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_PPI_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_PPI_CONFIG_DEBUG_COLOR
-#define NRFX_PPI_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_PRS_ENABLED - nrfx_prs - Peripheral Resource Sharing module
-//==========================================================
+/**
+ * @brief NRFX_PRS_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_PRS_ENABLED
 #define NRFX_PRS_ENABLED 0
 #endif
-// <q> NRFX_PRS_BOX_0_ENABLED  - Enables box 0 in the module.
 
-
-#ifndef NRFX_PRS_BOX_0_ENABLED
-#define NRFX_PRS_BOX_0_ENABLED 0
-#endif
-
-// <q> NRFX_PRS_BOX_1_ENABLED  - Enables box 1 in the module.
-
-
-#ifndef NRFX_PRS_BOX_1_ENABLED
-#define NRFX_PRS_BOX_1_ENABLED 0
-#endif
-
-// <q> NRFX_PRS_BOX_2_ENABLED  - Enables box 2 in the module.
-
-
-#ifndef NRFX_PRS_BOX_2_ENABLED
-#define NRFX_PRS_BOX_2_ENABLED 0
-#endif
-
-// <q> NRFX_PRS_BOX_3_ENABLED  - Enables box 3 in the module.
-
-
-#ifndef NRFX_PRS_BOX_3_ENABLED
-#define NRFX_PRS_BOX_3_ENABLED 0
-#endif
-
-// <q> NRFX_PRS_BOX_4_ENABLED  - Enables box 4 in the module.
-
-
-#ifndef NRFX_PRS_BOX_4_ENABLED
-#define NRFX_PRS_BOX_4_ENABLED 0
-#endif
-
-// <e> NRFX_PRS_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_PRS_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_PRS_CONFIG_LOG_ENABLED
 #define NRFX_PRS_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_PRS_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_PRS_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_PRS_CONFIG_LOG_LEVEL
 #define NRFX_PRS_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_PRS_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_PRS_CONFIG_INFO_COLOR
-#define NRFX_PRS_CONFIG_INFO_COLOR 0
+/**
+ * @brief NRFX_PRS_BOX_0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_PRS_BOX_0_ENABLED
+#define NRFX_PRS_BOX_0_ENABLED 0
 #endif
 
-// <o> NRFX_PRS_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_PRS_CONFIG_DEBUG_COLOR
-#define NRFX_PRS_CONFIG_DEBUG_COLOR 0
+/**
+ * @brief NRFX_PRS_BOX_1_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_PRS_BOX_1_ENABLED
+#define NRFX_PRS_BOX_1_ENABLED 0
 #endif
 
-// </e>
+/**
+ * @brief NRFX_PRS_BOX_2_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_PRS_BOX_2_ENABLED
+#define NRFX_PRS_BOX_2_ENABLED 0
+#endif
 
-// </e>
+/**
+ * @brief NRFX_PRS_BOX_3_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_PRS_BOX_3_ENABLED
+#define NRFX_PRS_BOX_3_ENABLED 0
+#endif
 
-// <e> NRFX_PWM_ENABLED - nrfx_pwm - PWM peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_PRS_BOX_4_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_PRS_BOX_4_ENABLED
+#define NRFX_PRS_BOX_4_ENABLED 0
+#endif
+
+/**
+ * @brief NRFX_PWM_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_PWM_ENABLED
 #define NRFX_PWM_ENABLED 0
 #endif
 
-// <q> NRFX_PWM0_ENABLED  - Enable PWM0 instance
-
-#ifndef NRFX_PWM0_ENABLED
-#define NRFX_PWM0_ENABLED 0
-#endif
-
-// <q> NRFX_PWM1_ENABLED  - Enable PWM1 instance
-
-#ifndef NRFX_PWM1_ENABLED
-#define NRFX_PWM1_ENABLED 0
-#endif
-
-// <q> NRFX_PWM2_ENABLED  - Enable PWM2 instance
-
-#ifndef NRFX_PWM2_ENABLED
-#define NRFX_PWM2_ENABLED 0
-#endif
-
-// <q> NRFX_PWM3_ENABLED  - Enable PWM3 instance
-
-#ifndef NRFX_PWM3_ENABLED
-#define NRFX_PWM3_ENABLED 0
-#endif
-
-// <o> NRFX_PWM_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_PWM_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_PWM_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_PWM_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_PWM_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_PWM_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_PWM_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_PWM_CONFIG_LOG_ENABLED
 #define NRFX_PWM_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_PWM_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_PWM_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_PWM_CONFIG_LOG_LEVEL
 #define NRFX_PWM_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_PWM_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_PWM_CONFIG_INFO_COLOR
-#define NRFX_PWM_CONFIG_INFO_COLOR 0
+/**
+ * @brief NRFX_PWM0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_PWM0_ENABLED
+#define NRFX_PWM0_ENABLED 0
 #endif
 
-// <o> NRFX_PWM_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_PWM_CONFIG_DEBUG_COLOR
-#define NRFX_PWM_CONFIG_DEBUG_COLOR 0
+/**
+ * @brief NRFX_PWM1_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_PWM1_ENABLED
+#define NRFX_PWM1_ENABLED 0
 #endif
 
-// </e>
+/**
+ * @brief NRFX_PWM2_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_PWM2_ENABLED
+#define NRFX_PWM2_ENABLED 0
+#endif
 
-// </e>
+/**
+ * @brief NRFX_PWM3_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_PWM3_ENABLED
+#define NRFX_PWM3_ENABLED 0
+#endif
 
-// <e> NRFX_QDEC_ENABLED - nrfx_qdec - QDEC peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_QDEC_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_QDEC_ENABLED
 #define NRFX_QDEC_ENABLED 0
 #endif
 
-// <o> NRFX_QDEC_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_QDEC_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_QDEC_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_QDEC_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_QDEC_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_QDEC_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_QDEC_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_QDEC_CONFIG_LOG_ENABLED
 #define NRFX_QDEC_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_QDEC_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_QDEC_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_QDEC_CONFIG_LOG_LEVEL
 #define NRFX_QDEC_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_QDEC_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_QDEC_CONFIG_INFO_COLOR
-#define NRFX_QDEC_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_QDEC_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_QDEC_CONFIG_DEBUG_COLOR
-#define NRFX_QDEC_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_RNG_ENABLED - nrfx_rng - RNG peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_RNG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_RNG_ENABLED
 #define NRFX_RNG_ENABLED 0
 #endif
 
-// <o> NRFX_RNG_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_RNG_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_RNG_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_RNG_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_RNG_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_RNG_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_RNG_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_RNG_CONFIG_LOG_ENABLED
 #define NRFX_RNG_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_RNG_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_RNG_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_RNG_CONFIG_LOG_LEVEL
 #define NRFX_RNG_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_RNG_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_RNG_CONFIG_INFO_COLOR
-#define NRFX_RNG_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_RNG_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_RNG_CONFIG_DEBUG_COLOR
-#define NRFX_RNG_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_RTC_ENABLED - nrfx_rtc - RTC peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_RTC_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_RTC_ENABLED
 #define NRFX_RTC_ENABLED 0
 #endif
-// <q> NRFX_RTC0_ENABLED  - Enable RTC0 instance
 
-#ifndef NRFX_RTC0_ENABLED
-#define NRFX_RTC0_ENABLED 0
-#endif
-
-// <q> NRFX_RTC1_ENABLED  - Enable RTC1 instance
-
-#ifndef NRFX_RTC1_ENABLED
-#define NRFX_RTC1_ENABLED 0
-#endif
-
-// <q> NRFX_RTC2_ENABLED  - Enable RTC2 instance
-
-#ifndef NRFX_RTC2_ENABLED
-#define NRFX_RTC2_ENABLED 0
-#endif
-
-// <o> NRFX_RTC_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_RTC_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_RTC_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_RTC_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_RTC_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_RTC_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_RTC_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_RTC_CONFIG_LOG_ENABLED
 #define NRFX_RTC_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_RTC_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_RTC_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_RTC_CONFIG_LOG_LEVEL
 #define NRFX_RTC_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_RTC_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_RTC_CONFIG_INFO_COLOR
-#define NRFX_RTC_CONFIG_INFO_COLOR 0
+/**
+ * @brief NRFX_RTC0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_RTC0_ENABLED
+#define NRFX_RTC0_ENABLED 0
 #endif
 
-// <o> NRFX_RTC_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_RTC_CONFIG_DEBUG_COLOR
-#define NRFX_RTC_CONFIG_DEBUG_COLOR 0
+/**
+ * @brief NRFX_RTC1_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_RTC1_ENABLED
+#define NRFX_RTC1_ENABLED 0
 #endif
 
-// </e>
+/**
+ * @brief NRFX_RTC2_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_RTC2_ENABLED
+#define NRFX_RTC2_ENABLED 0
+#endif
 
-// </e>
-
-// <e> NRFX_SAADC_ENABLED - nrfx_saadc - SAADC peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_SAADC_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_SAADC_ENABLED
 #define NRFX_SAADC_ENABLED 0
 #endif
 
-// <o> NRFX_SAADC_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_SAADC_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_SAADC_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_SAADC_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_SAADC_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_SAADC_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_SAADC_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_SAADC_CONFIG_LOG_ENABLED
 #define NRFX_SAADC_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_SAADC_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_SAADC_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_SAADC_CONFIG_LOG_LEVEL
 #define NRFX_SAADC_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_SAADC_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_SAADC_CONFIG_INFO_COLOR
-#define NRFX_SAADC_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_SAADC_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_SAADC_CONFIG_DEBUG_COLOR
-#define NRFX_SAADC_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_SPIM_ENABLED - nrfx_spim - SPIM peripheral driver
-//==========================================================
-#ifndef NRFX_SPIM_ENABLED
-#define NRFX_SPIM_ENABLED 0
-#endif
-// <q> NRFX_SPIM0_ENABLED  - Enable SPIM0 instance
-
-
-#ifndef NRFX_SPIM0_ENABLED
-#define NRFX_SPIM0_ENABLED 0
-#endif
-
-// <q> NRFX_SPIM1_ENABLED  - Enable SPIM1 instance
-
-
-#ifndef NRFX_SPIM1_ENABLED
-#define NRFX_SPIM1_ENABLED 0
-#endif
-
-// <q> NRFX_SPIM2_ENABLED  - Enable SPIM2 instance
-
-
-#ifndef NRFX_SPIM2_ENABLED
-#define NRFX_SPIM2_ENABLED 0
-#endif
-
-// <q> NRFX_SPIM3_ENABLED  - Enable SPIM3 instance
-
-
-#ifndef NRFX_SPIM3_ENABLED
-#define NRFX_SPIM3_ENABLED 0
-#endif
-
-// <q> NRFX_SPIM_EXTENDED_ENABLED  - Enable extended SPIM features
-
-
-#ifndef NRFX_SPIM_EXTENDED_ENABLED
-#define NRFX_SPIM_EXTENDED_ENABLED 0
-#endif
-
-// <o> NRFX_SPIM_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
-#ifndef NRFX_SPIM_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_SPIM_DEFAULT_CONFIG_IRQ_PRIORITY 7
-#endif
-
-// <e> NRFX_SPIM_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
-#ifndef NRFX_SPIM_CONFIG_LOG_ENABLED
-#define NRFX_SPIM_CONFIG_LOG_ENABLED 0
-#endif
-// <o> NRFX_SPIM_CONFIG_LOG_LEVEL  - Default Severity level
-
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
-#ifndef NRFX_SPIM_CONFIG_LOG_LEVEL
-#define NRFX_SPIM_CONFIG_LOG_LEVEL 3
-#endif
-
-// <o> NRFX_SPIM_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_SPIM_CONFIG_INFO_COLOR
-#define NRFX_SPIM_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_SPIM_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_SPIM_CONFIG_DEBUG_COLOR
-#define NRFX_SPIM_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_SPIS_ENABLED - nrfx_spis - SPIS peripheral driver
-//==========================================================
-#ifndef NRFX_SPIS_ENABLED
-#define NRFX_SPIS_ENABLED 0
-#endif
-// <q> NRFX_SPIS0_ENABLED  - Enable SPIS0 instance
-
-
-#ifndef NRFX_SPIS0_ENABLED
-#define NRFX_SPIS0_ENABLED 0
-#endif
-
-// <q> NRFX_SPIS1_ENABLED  - Enable SPIS1 instance
-
-
-#ifndef NRFX_SPIS1_ENABLED
-#define NRFX_SPIS1_ENABLED 0
-#endif
-
-// <q> NRFX_SPIS2_ENABLED  - Enable SPIS2 instance
-
-
-#ifndef NRFX_SPIS2_ENABLED
-#define NRFX_SPIS2_ENABLED 0
-#endif
-
-// <o> NRFX_SPIS_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
-#ifndef NRFX_SPIS_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_SPIS_DEFAULT_CONFIG_IRQ_PRIORITY 7
-#endif
-
-// <e> NRFX_SPIS_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
-#ifndef NRFX_SPIS_CONFIG_LOG_ENABLED
-#define NRFX_SPIS_CONFIG_LOG_ENABLED 0
-#endif
-// <o> NRFX_SPIS_CONFIG_LOG_LEVEL  - Default Severity level
-
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
-#ifndef NRFX_SPIS_CONFIG_LOG_LEVEL
-#define NRFX_SPIS_CONFIG_LOG_LEVEL 3
-#endif
-
-// <o> NRFX_SPIS_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_SPIS_CONFIG_INFO_COLOR
-#define NRFX_SPIS_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_SPIS_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_SPIS_CONFIG_DEBUG_COLOR
-#define NRFX_SPIS_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_SPI_ENABLED - nrfx_spi - SPI peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_SPI_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_SPI_ENABLED
 #define NRFX_SPI_ENABLED 0
 #endif
-// <q> NRFX_SPI0_ENABLED  - Enable SPI0 instance
 
-
-#ifndef NRFX_SPI0_ENABLED
-#define NRFX_SPI0_ENABLED 0
-#endif
-
-// <q> NRFX_SPI1_ENABLED  - Enable SPI1 instance
-
-
-#ifndef NRFX_SPI1_ENABLED
-#define NRFX_SPI1_ENABLED 0
-#endif
-
-// <q> NRFX_SPI2_ENABLED  - Enable SPI2 instance
-
-
-#ifndef NRFX_SPI2_ENABLED
-#define NRFX_SPI2_ENABLED 0
-#endif
-
-// <o> NRFX_SPI_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_SPI_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_SPI_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_SPI_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_SPI_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_SPI_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_SPI_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_SPI_CONFIG_LOG_ENABLED
 #define NRFX_SPI_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_SPI_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_SPI_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_SPI_CONFIG_LOG_LEVEL
 #define NRFX_SPI_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_SPI_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_SPI_CONFIG_INFO_COLOR
-#define NRFX_SPI_CONFIG_INFO_COLOR 0
+/**
+ * @brief NRFX_SPI0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPI0_ENABLED
+#define NRFX_SPI0_ENABLED 0
 #endif
 
-// <o> NRFX_SPI_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_SPI_CONFIG_DEBUG_COLOR
-#define NRFX_SPI_CONFIG_DEBUG_COLOR 0
+/**
+ * @brief NRFX_SPI1_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPI1_ENABLED
+#define NRFX_SPI1_ENABLED 0
 #endif
 
-// </e>
+/**
+ * @brief NRFX_SPI2_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPI2_ENABLED
+#define NRFX_SPI2_ENABLED 0
+#endif
 
-// </e>
+/**
+ * @brief NRFX_SPIM_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPIM_ENABLED
+#define NRFX_SPIM_ENABLED 0
+#endif
 
-// <q> NRFX_SYSTICK_ENABLED  - nrfx_systick - ARM(R) SysTick driver
+/**
+ * @brief NRFX_SPIM_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
+#ifndef NRFX_SPIM_DEFAULT_CONFIG_IRQ_PRIORITY
+#define NRFX_SPIM_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
+#endif
 
+/**
+ * @brief NRFX_SPIM_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPIM_CONFIG_LOG_ENABLED
+#define NRFX_SPIM_CONFIG_LOG_ENABLED 0
+#endif
 
+/**
+ * @brief NRFX_SPIM_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
+#ifndef NRFX_SPIM_CONFIG_LOG_LEVEL
+#define NRFX_SPIM_CONFIG_LOG_LEVEL 3
+#endif
+
+/**
+ * @brief NRFX_SPIM0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPIM0_ENABLED
+#define NRFX_SPIM0_ENABLED 0
+#endif
+
+/**
+ * @brief NRFX_SPIM1_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPIM1_ENABLED
+#define NRFX_SPIM1_ENABLED 0
+#endif
+
+/**
+ * @brief NRFX_SPIM2_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPIM2_ENABLED
+#define NRFX_SPIM2_ENABLED 0
+#endif
+
+/**
+ * @brief NRFX_SPIM3_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPIM3_ENABLED
+#define NRFX_SPIM3_ENABLED 0
+#endif
+
+/**
+ * @brief NRFX_SPIS_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPIS_ENABLED
+#define NRFX_SPIS_ENABLED 0
+#endif
+
+/**
+ * @brief NRFX_SPIS_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
+#ifndef NRFX_SPIS_DEFAULT_CONFIG_IRQ_PRIORITY
+#define NRFX_SPIS_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
+#endif
+
+/**
+ * @brief NRFX_SPIS_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPIS_CONFIG_LOG_ENABLED
+#define NRFX_SPIS_CONFIG_LOG_ENABLED 0
+#endif
+
+/**
+ * @brief NRFX_SPIS_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
+#ifndef NRFX_SPIS_CONFIG_LOG_LEVEL
+#define NRFX_SPIS_CONFIG_LOG_LEVEL 3
+#endif
+
+/**
+ * @brief NRFX_SPIS0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPIS0_ENABLED
+#define NRFX_SPIS0_ENABLED 0
+#endif
+
+/**
+ * @brief NRFX_SPIS1_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPIS1_ENABLED
+#define NRFX_SPIS1_ENABLED 0
+#endif
+
+/**
+ * @brief NRFX_SPIS2_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPIS2_ENABLED
+#define NRFX_SPIS2_ENABLED 0
+#endif
+
+/**
+ * @brief NRFX_SYSTICK_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_SYSTICK_ENABLED
 #define NRFX_SYSTICK_ENABLED 0
 #endif
 
-// <e> NRFX_TEMP_ENABLED - nrfx_temp - TEMP peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_TEMP_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_TEMP_ENABLED
 #define NRFX_TEMP_ENABLED 0
 #endif
 
-// <o> NRFX_TEMP_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_TEMP_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_TEMP_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_TEMP_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_TEMP_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// </e>
+/**
+ * @brief NRFX_TEMP_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TEMP_CONFIG_LOG_ENABLED
+#define NRFX_TEMP_CONFIG_LOG_ENABLED 0
+#endif
 
-// <e> NRFX_TIMER_ENABLED - nrfx_timer - TIMER periperal driver
-//==========================================================
+/**
+ * @brief NRFX_TEMP_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
+#ifndef NRFX_TEMP_CONFIG_LOG_LEVEL
+#define NRFX_TEMP_CONFIG_LOG_LEVEL 3
+#endif
+
+/**
+ * @brief NRFX_TIMER_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_TIMER_ENABLED
 #define NRFX_TIMER_ENABLED 0
 #endif
 
-// <q> NRFX_TIMER0_ENABLED  - Enable TIMER0 instance
-
-#ifndef NRFX_TIMER0_ENABLED
-#define NRFX_TIMER0_ENABLED 0
-#endif
-
-// <q> NRFX_TIMER1_ENABLED  - Enable TIMER1 instance
-
-#ifndef NRFX_TIMER1_ENABLED
-#define NRFX_TIMER1_ENABLED 0
-#endif
-
-// <q> NRFX_TIMER2_ENABLED  - Enable TIMER2 instance
-
-#ifndef NRFX_TIMER2_ENABLED
-#define NRFX_TIMER2_ENABLED 0
-#endif
-
-// <q> NRFX_TIMER3_ENABLED  - Enable TIMER3 instance
-
-#ifndef NRFX_TIMER3_ENABLED
-#define NRFX_TIMER3_ENABLED 0
-#endif
-
-// <q> NRFX_TIMER4_ENABLED  - Enable TIMER4 instance
-
-#ifndef NRFX_TIMER4_ENABLED
-#define NRFX_TIMER4_ENABLED 0
-#endif
-
-// <o> NRFX_TIMER_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_TIMER_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_TIMER_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_TIMER_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_TIMER_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_TIMER_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_TIMER_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_TIMER_CONFIG_LOG_ENABLED
 #define NRFX_TIMER_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_TIMER_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_TIMER_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_TIMER_CONFIG_LOG_LEVEL
 #define NRFX_TIMER_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_TIMER_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_TIMER_CONFIG_INFO_COLOR
-#define NRFX_TIMER_CONFIG_INFO_COLOR 0
+/**
+ * @brief NRFX_TIMER0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TIMER0_ENABLED
+#define NRFX_TIMER0_ENABLED 0
 #endif
 
-// <o> NRFX_TIMER_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_TIMER_CONFIG_DEBUG_COLOR
-#define NRFX_TIMER_CONFIG_DEBUG_COLOR 0
+/**
+ * @brief NRFX_TIMER1_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TIMER1_ENABLED
+#define NRFX_TIMER1_ENABLED 0
 #endif
 
-// </e>
-
-// </e>
-
-// <e> NRFX_TWIM_ENABLED - nrfx_twim - TWIM peripheral driver
-//==========================================================
-#ifndef NRFX_TWIM_ENABLED
-#define NRFX_TWIM_ENABLED 0
+/**
+ * @brief NRFX_TIMER2_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TIMER2_ENABLED
+#define NRFX_TIMER2_ENABLED 0
 #endif
 
-// <q> NRFX_TWIM0_ENABLED  - Enable TWIM0 instance
-
-#ifndef NRFX_TWIM0_ENABLED
-#define NRFX_TWIM0_ENABLED 0
+/**
+ * @brief NRFX_TIMER3_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TIMER3_ENABLED
+#define NRFX_TIMER3_ENABLED 0
 #endif
 
-// <q> NRFX_TWIM1_ENABLED  - Enable TWIM1 instance
-
-#ifndef NRFX_TWIM1_ENABLED
-#define NRFX_TWIM1_ENABLED 0
+/**
+ * @brief NRFX_TIMER4_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TIMER4_ENABLED
+#define NRFX_TIMER4_ENABLED 0
 #endif
 
-// <o> NRFX_TWIM_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
-#ifndef NRFX_TWIM_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_TWIM_DEFAULT_CONFIG_IRQ_PRIORITY 7
-#endif
-
-// <e> NRFX_TWIM_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
-#ifndef NRFX_TWIM_CONFIG_LOG_ENABLED
-#define NRFX_TWIM_CONFIG_LOG_ENABLED 0
-#endif
-// <o> NRFX_TWIM_CONFIG_LOG_LEVEL  - Default Severity level
-
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
-#ifndef NRFX_TWIM_CONFIG_LOG_LEVEL
-#define NRFX_TWIM_CONFIG_LOG_LEVEL 3
-#endif
-
-// <o> NRFX_TWIM_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_TWIM_CONFIG_INFO_COLOR
-#define NRFX_TWIM_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_TWIM_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_TWIM_CONFIG_DEBUG_COLOR
-#define NRFX_TWIM_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_TWIS_ENABLED - nrfx_twis - TWIS peripheral driver
-//==========================================================
-#ifndef NRFX_TWIS_ENABLED
-#define NRFX_TWIS_ENABLED 0
-#endif
-
-// <q> NRFX_TWIS0_ENABLED  - Enable TWIS0 instance
-
-#ifndef NRFX_TWIS0_ENABLED
-#define NRFX_TWIS0_ENABLED 0
-#endif
-
-// <q> NRFX_TWIS1_ENABLED  - Enable TWIS1 instance
-
-#ifndef NRFX_TWIS1_ENABLED
-#define NRFX_TWIS1_ENABLED 0
-#endif
-
-// <q> NRFX_TWIS_ASSUME_INIT_AFTER_RESET_ONLY  - Assume that any instance would be initialized only once
-
-// <i> Optimization flag. Registers used by TWIS are shared by other peripherals. Normally, during initialization driver tries to clear all registers to known state before doing the initialization itself. This gives initialization safe procedure, no matter when it would be called. If you activate TWIS only once and do never uninitialize it - set this flag to 1 what gives more optimal code.
-
-#ifndef NRFX_TWIS_ASSUME_INIT_AFTER_RESET_ONLY
-#define NRFX_TWIS_ASSUME_INIT_AFTER_RESET_ONLY 0
-#endif
-
-// <q> NRFX_TWIS_NO_SYNC_MODE  - Remove support for synchronous mode
-
-// <i> Synchronous mode would be used in specific situations. And it uses some additional code and data memory to safely process state machine by polling it in status functions. If this functionality is not required it may be disabled to free some resources.
-
-#ifndef NRFX_TWIS_NO_SYNC_MODE
-#define NRFX_TWIS_NO_SYNC_MODE 0
-#endif
-
-// <o> NRFX_TWIS_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
-#ifndef NRFX_TWIS_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_TWIS_DEFAULT_CONFIG_IRQ_PRIORITY 7
-#endif
-
-// <e> NRFX_TWIS_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
-#ifndef NRFX_TWIS_CONFIG_LOG_ENABLED
-#define NRFX_TWIS_CONFIG_LOG_ENABLED 0
-#endif
-// <o> NRFX_TWIS_CONFIG_LOG_LEVEL  - Default Severity level
-
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
-#ifndef NRFX_TWIS_CONFIG_LOG_LEVEL
-#define NRFX_TWIS_CONFIG_LOG_LEVEL 3
-#endif
-
-// <o> NRFX_TWIS_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_TWIS_CONFIG_INFO_COLOR
-#define NRFX_TWIS_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_TWIS_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_TWIS_CONFIG_DEBUG_COLOR
-#define NRFX_TWIS_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_TWI_ENABLED - nrfx_twi - TWI peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_TWI_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_TWI_ENABLED
 #define NRFX_TWI_ENABLED 0
 #endif
 
-// <q> NRFX_TWI0_ENABLED  - Enable TWI0 instance
-
-#ifndef NRFX_TWI0_ENABLED
-#define NRFX_TWI0_ENABLED 0
-#endif
-
-// <q> NRFX_TWI1_ENABLED  - Enable TWI1 instance
-
-#ifndef NRFX_TWI1_ENABLED
-#define NRFX_TWI1_ENABLED 0
-#endif
-
-// <o> NRFX_TWI_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_TWI_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_TWI_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_TWI_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_TWI_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_TWI_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_TWI_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_TWI_CONFIG_LOG_ENABLED
 #define NRFX_TWI_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_TWI_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_TWI_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_TWI_CONFIG_LOG_LEVEL
 #define NRFX_TWI_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_TWI_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_TWI_CONFIG_INFO_COLOR
-#define NRFX_TWI_CONFIG_INFO_COLOR 0
+/**
+ * @brief NRFX_TWI0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWI0_ENABLED
+#define NRFX_TWI0_ENABLED 0
 #endif
 
-// <o> NRFX_TWI_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_TWI_CONFIG_DEBUG_COLOR
-#define NRFX_TWI_CONFIG_DEBUG_COLOR 0
+/**
+ * @brief NRFX_TWI1_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWI1_ENABLED
+#define NRFX_TWI1_ENABLED 0
 #endif
 
-// </e>
-
-// </e>
-
-// <e> NRFX_UARTE_ENABLED - nrfx_uarte - UARTE peripheral driver
-//==========================================================
-#ifndef NRFX_UARTE_ENABLED
-#define NRFX_UARTE_ENABLED 0
+/**
+ * @brief NRFX_TWIM_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWIM_ENABLED
+#define NRFX_TWIM_ENABLED 0
 #endif
 
-// <q> NRFX_UARTE0_ENABLED - Enable UARTE0 instance
-
-#ifndef NRFX_UARTE0_ENABLED
-#define NRFX_UARTE0_ENABLED 0
+/**
+ * @brief NRFX_TWIM_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
+#ifndef NRFX_TWIM_DEFAULT_CONFIG_IRQ_PRIORITY
+#define NRFX_TWIM_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <q> NRFX_UARTE1_ENABLED - Enable UARTE1 instance
-
-#ifndef NRFX_UARTE1_ENABLED
-#define NRFX_UARTE1_ENABLED 0
+/**
+ * @brief NRFX_TWIM_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWIM_CONFIG_LOG_ENABLED
+#define NRFX_TWIM_CONFIG_LOG_ENABLED 0
 #endif
 
-// <o> NRFX_UARTE_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
-#ifndef NRFX_UARTE_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_UARTE_DEFAULT_CONFIG_IRQ_PRIORITY 7
+/**
+ * @brief NRFX_TWIM_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
+#ifndef NRFX_TWIM_CONFIG_LOG_LEVEL
+#define NRFX_TWIM_CONFIG_LOG_LEVEL 3
 #endif
 
-// <e> NRFX_UARTE_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
-#ifndef NRFX_UARTE_CONFIG_LOG_ENABLED
-#define NRFX_UARTE_CONFIG_LOG_ENABLED 0
-#endif
-// <o> NRFX_UARTE_CONFIG_LOG_LEVEL  - Default Severity level
-
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
-#ifndef NRFX_UARTE_CONFIG_LOG_LEVEL
-#define NRFX_UARTE_CONFIG_LOG_LEVEL 3
+/**
+ * @brief NRFX_TWIM0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWIM0_ENABLED
+#define NRFX_TWIM0_ENABLED 0
 #endif
 
-// <o> NRFX_UARTE_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_UARTE_CONFIG_INFO_COLOR
-#define NRFX_UARTE_CONFIG_INFO_COLOR 0
+/**
+ * @brief NRFX_TWIM1_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWIM1_ENABLED
+#define NRFX_TWIM1_ENABLED 0
 #endif
 
-// <o> NRFX_UARTE_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_UARTE_CONFIG_DEBUG_COLOR
-#define NRFX_UARTE_CONFIG_DEBUG_COLOR 0
+/**
+ * @brief NRFX_TWIS_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWIS_ENABLED
+#define NRFX_TWIS_ENABLED 0
 #endif
 
-// </e>
+/**
+ * @brief NRFX_TWIS_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
+#ifndef NRFX_TWIS_DEFAULT_CONFIG_IRQ_PRIORITY
+#define NRFX_TWIS_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
+#endif
 
-// </e>
+/**
+ * @brief NRFX_TWIS_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWIS_CONFIG_LOG_ENABLED
+#define NRFX_TWIS_CONFIG_LOG_ENABLED 0
+#endif
 
-// <e> NRFX_UART_ENABLED - nrfx_uart - UART peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_TWIS_ASSUME_INIT_AFTER_RESET_ONLY - Assume that any instance would be initialized only once.
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWIS_ASSUME_INIT_AFTER_RESET_ONLY
+#define NRFX_TWIS_ASSUME_INIT_AFTER_RESET_ONLY 0
+#endif
+
+/**
+ * @brief NRFX_TWIS_NO_SYNC_MODE - Remove support for synchronous mode.
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWIS_NO_SYNC_MODE
+#define NRFX_TWIS_NO_SYNC_MODE 0
+#endif
+
+/**
+ * @brief NRFX_TWIS_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
+#ifndef NRFX_TWIS_CONFIG_LOG_LEVEL
+#define NRFX_TWIS_CONFIG_LOG_LEVEL 3
+#endif
+
+/**
+ * @brief NRFX_TWIS0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWIS0_ENABLED
+#define NRFX_TWIS0_ENABLED 0
+#endif
+
+/**
+ * @brief NRFX_TWIS1_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWIS1_ENABLED
+#define NRFX_TWIS1_ENABLED 0
+#endif
+
+/**
+ * @brief NRFX_UART_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_UART_ENABLED
 #define NRFX_UART_ENABLED 0
 #endif
 
-// <q> NRFX_UART0_ENABLED - Enable UART0 instance
-
-#ifndef NRFX_UART0_ENABLED
-#define NRFX_UART0_ENABLED 0
-#endif
-
-// <o> NRFX_UART_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_UART_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_UART_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_UART_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_UART_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_UART_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_UART_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_UART_CONFIG_LOG_ENABLED
 #define NRFX_UART_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_UART_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_UART_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_UART_CONFIG_LOG_LEVEL
 #define NRFX_UART_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_UART_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_UART_CONFIG_INFO_COLOR
-#define NRFX_UART_CONFIG_INFO_COLOR 0
+/**
+ * @brief NRFX_UART0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_UART0_ENABLED
+#define NRFX_UART0_ENABLED 0
 #endif
 
-// <o> NRFX_UART_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_UART_CONFIG_DEBUG_COLOR
-#define NRFX_UART_CONFIG_DEBUG_COLOR 0
+/**
+ * @brief NRFX_UARTE_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_UARTE_ENABLED
+#define NRFX_UARTE_ENABLED 0
 #endif
 
-// </e>
+/**
+ * @brief NRFX_UARTE_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
+#ifndef NRFX_UARTE_DEFAULT_CONFIG_IRQ_PRIORITY
+#define NRFX_UARTE_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
+#endif
 
-// </e>
+/**
+ * @brief NRFX_UARTE_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_UARTE_CONFIG_LOG_ENABLED
+#define NRFX_UARTE_CONFIG_LOG_ENABLED 0
+#endif
 
-// <e> NRFX_USBD_ENABLED - nrfx_usbd - USBD peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_UARTE_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
+#ifndef NRFX_UARTE_CONFIG_LOG_LEVEL
+#define NRFX_UARTE_CONFIG_LOG_LEVEL 3
+#endif
+
+/**
+ * @brief NRFX_UARTE0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_UARTE0_ENABLED
+#define NRFX_UARTE0_ENABLED 0
+#endif
+
+/**
+ * @brief NRFX_UARTE1_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_UARTE1_ENABLED
+#define NRFX_UARTE1_ENABLED 0
+#endif
+
+/**
+ * @brief NRFX_USBD_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_USBD_ENABLED
 #define NRFX_USBD_ENABLED 0
 #endif
-// <o> NRFX_USBD_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
 
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_USBD_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_USBD_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_USBD_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_USBD_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <q> USBD_CONFIG_DMASCHEDULER_ISO_BOOST  - Give priority to isochronous transfers
-
-// <i> This option gives priority to isochronous transfers.
-// <i> Enabling it assures that isochronous transfers are always processed,
-// <i> even if multiple other transfers are pending.
-// <i> Isochronous endpoints are prioritized before the usbd_dma_scheduler_algorithm
-// <i> function is called, so the option is independent of the algorithm chosen.
-
+/**
+ * @brief NRFX_USBD_CONFIG_DMASCHEDULER_ISO_BOOST - Give priority to isochronous transfers
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_USBD_CONFIG_DMASCHEDULER_ISO_BOOST
 #define NRFX_USBD_CONFIG_DMASCHEDULER_ISO_BOOST 1
 #endif
 
-// <q> USBD_CONFIG_ISO_IN_ZLP  - Respond to an IN token on ISO IN endpoint with ZLP when no data is ready
-
-
-// <i> If set, ISO IN endpoint will respond to an IN token with ZLP when no data is ready to be sent.
-// <i> Else, there will be no response.
-
+/**
+ * @brief NRFX_USBD_CONFIG_ISO_IN_ZLP - Respond to an IN token on ISO IN endpoint with ZLP when no data is ready.
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_USBD_CONFIG_ISO_IN_ZLP
 #define NRFX_USBD_CONFIG_ISO_IN_ZLP 0
 #endif
 
-// <e> NRFX_USBD_CONFIG_LOG_ENABLED - Enable logging in the module
-//==========================================================
+/**
+ * @brief NRFX_USBD_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_USBD_CONFIG_LOG_ENABLED
 #define NRFX_USBD_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_USBD_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_USBD_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_USBD_CONFIG_LOG_LEVEL
 #define NRFX_USBD_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_USBD_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_USBD_CONFIG_INFO_COLOR
-#define NRFX_USBD_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_USBD_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_USBD_CONFIG_DEBUG_COLOR
-#define NRFX_USBD_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_WDT_ENABLED - nrfx_wdt - WDT peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_WDT_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_WDT_ENABLED
 #define NRFX_WDT_ENABLED 0
 #endif
 
-// <q> NRFX_WDT0_ENABLED  - Enable WDT0 instance
-
-#ifndef NRFX_WDT0_ENABLED
-#define NRFX_WDT0_ENABLED 0
+/**
+ * @brief NRFX_WDT_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
+#ifndef NRFX_WDT_DEFAULT_CONFIG_IRQ_PRIORITY
+#define NRFX_WDT_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <o> NRFX_WDT_CONFIG_NO_IRQ  - Remove WDT IRQ handling from WDT driver
-
-// <0=> Include WDT IRQ handling
-// <1=> Remove WDT IRQ handling
-
+/**
+ * @brief NRFX_WDT_CONFIG_NO_IRQ - Remove WDT IRQ handling from WDT driver
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_WDT_CONFIG_NO_IRQ
 #define NRFX_WDT_CONFIG_NO_IRQ 0
 #endif
 
-// <o> NRFX_WDT_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
-#ifndef NRFX_WDT_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_WDT_DEFAULT_CONFIG_IRQ_PRIORITY 7
-#endif
-
-// <e> NRFX_WDT_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_WDT_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_WDT_CONFIG_LOG_ENABLED
 #define NRFX_WDT_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_WDT_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_WDT_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_WDT_CONFIG_LOG_LEVEL
 #define NRFX_WDT_CONFIG_LOG_LEVEL 3
 #endif
-
-// <o> NRFX_WDT_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_WDT_CONFIG_INFO_COLOR
-#define NRFX_WDT_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_WDT_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_WDT_CONFIG_DEBUG_COLOR
-#define NRFX_WDT_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// </h>
 
 #endif // NRFX_CONFIG_NRF52833_H__

--- a/nrfx/templates/nrfx_config_nrf52840.h
+++ b/nrfx/templates/nrfx_config_nrf52840.h
@@ -38,2316 +38,1652 @@
 #error "This file should not be included directly. Include nrfx_config.h instead."
 #endif
 
-// <<< Use Configuration Wizard in Context Menu >>>\n
 
-// <h> nRF_Drivers
+/**
+ * @brief NRFX_DEFAULT_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
+#ifndef NRFX_DEFAULT_IRQ_PRIORITY
+#define NRFX_DEFAULT_IRQ_PRIORITY 7
+#endif
 
-// <e> NRFX_CLOCK_ENABLED - nrfx_clock - CLOCK peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_CLOCK_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_CLOCK_ENABLED
 #define NRFX_CLOCK_ENABLED 0
 #endif
-// <o> NRFX_CLOCK_CONFIG_LF_SRC  - LF Clock Source
 
-// <0=> RC
-// <1=> XTAL
-// <2=> Synth
-// <131073=> External Low Swing
-// <196609=> External Full Swing
-
+/**
+ * @brief NRFX_CLOCK_CONFIG_LF_SRC
+ *
+ * Integer value.
+ * Supported values:
+ * - RC                  = 0
+ * - XTAL                = 1
+ * - Synth               = 2
+ * - External Low Swing  = 131073
+ * - External Full Swing = 196609
+ */
 #ifndef NRFX_CLOCK_CONFIG_LF_SRC
 #define NRFX_CLOCK_CONFIG_LF_SRC 1
 #endif
 
-// <q> NRFX_CLOCK_CONFIG_LF_CAL_ENABLED  - Enables LF Clock Calibration Support
-
+/**
+ * @brief NRFX_CLOCK_CONFIG_LF_CAL_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_CLOCK_CONFIG_LF_CAL_ENABLED
 #define NRFX_CLOCK_CONFIG_LF_CAL_ENABLED 0
 #endif
 
-// <q> NRFX_CLOCK_CONFIG_CT_ENABLED  - Enables Calibration Timer Support
-
+/**
+ * @brief NRFX_CLOCK_CONFIG_CT_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_CLOCK_CONFIG_CT_ENABLED
 #define NRFX_CLOCK_CONFIG_CT_ENABLED 1
 #endif
 
-// <q> NRFX_CLOCK_CONFIG_LFXO_TWO_STAGE_ENABLED - Enables two-stage LFXO start procedure
-
-// <i> If set to a non-zero value, LFRC will be started before LFXO and corresponding
-// <i> event will be generated. It means that CPU will be woken up when LFRC
-// <i> oscillator starts, but user callback will be invoked only after LFXO
-// <i> finally starts.
-
+/**
+ * @brief NRFX_CLOCK_CONFIG_LFXO_TWO_STAGE_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_CLOCK_CONFIG_LFXO_TWO_STAGE_ENABLED
 #define NRFX_CLOCK_CONFIG_LFXO_TWO_STAGE_ENABLED 0
 #endif
 
-// <o> NRFX_CLOCK_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_CLOCK_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_CLOCK_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_CLOCK_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_CLOCK_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_CLOCK_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_CLOCK_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_CLOCK_CONFIG_LOG_ENABLED
 #define NRFX_CLOCK_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_CLOCK_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_CLOCK_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_CLOCK_CONFIG_LOG_LEVEL
 #define NRFX_CLOCK_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_CLOCK_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_CLOCK_CONFIG_INFO_COLOR
-#define NRFX_CLOCK_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_CLOCK_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_CLOCK_CONFIG_DEBUG_COLOR
-#define NRFX_CLOCK_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_COMP_ENABLED - nrfx_comp - COMP peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_COMP_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_COMP_ENABLED
 #define NRFX_COMP_ENABLED 0
 #endif
 
-// <o> NRFX_COMP_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_COMP_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_COMP_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_COMP_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_COMP_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_COMP_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_COMP_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_COMP_CONFIG_LOG_ENABLED
 #define NRFX_COMP_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_COMP_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_COMP_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_COMP_CONFIG_LOG_LEVEL
 #define NRFX_COMP_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_COMP_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_COMP_CONFIG_INFO_COLOR
-#define NRFX_COMP_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_COMP_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_COMP_CONFIG_DEBUG_COLOR
-#define NRFX_COMP_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_EGU_ENABLED - nrfx_egu - EGU peripheral driver.
-//==========================================================
+/**
+ * @brief NRFX_EGU_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_EGU_ENABLED
 #define NRFX_EGU_ENABLED 0
 #endif
 
-// <q> NRFX_EGU0_ENABLED  - Enable EGU0 instance.
+/**
+ * @brief NRFX_EGU_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
+#ifndef NRFX_EGU_DEFAULT_CONFIG_IRQ_PRIORITY
+#define NRFX_EGU_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
+#endif
 
+/**
+ * @brief NRFX_EGU0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_EGU0_ENABLED
 #define NRFX_EGU0_ENABLED 0
 #endif
 
-// <q> NRFX_EGU1_ENABLED  - Enable EGU1 instance.
-
+/**
+ * @brief NRFX_EGU1_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_EGU1_ENABLED
 #define NRFX_EGU1_ENABLED 0
 #endif
 
-// <q> NRFX_EGU2_ENABLED  - Enable EGU2 instance.
-
+/**
+ * @brief NRFX_EGU2_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_EGU2_ENABLED
 #define NRFX_EGU2_ENABLED 0
 #endif
 
-// <q> NRFX_EGU3_ENABLED  - Enable EGU3 instance.
-
+/**
+ * @brief NRFX_EGU3_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_EGU3_ENABLED
 #define NRFX_EGU3_ENABLED 0
 #endif
 
-// <q> NRFX_EGU4_ENABLED  - Enable EGU4 instance.
-
+/**
+ * @brief NRFX_EGU4_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_EGU4_ENABLED
 #define NRFX_EGU4_ENABLED 0
 #endif
 
-// <q> NRFX_EGU5_ENABLED  - Enable EGU5 instance.
-
+/**
+ * @brief NRFX_EGU5_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_EGU5_ENABLED
 #define NRFX_EGU5_ENABLED 0
 #endif
 
-// <o> NRFX_EGU_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority.
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
-#ifndef NRFX_EGU_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_EGU_DEFAULT_CONFIG_IRQ_PRIORITY 7
-#endif
-
-// </e>
-
-// <e> NRFX_GPIOTE_ENABLED - nrfx_gpiote - GPIOTE peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_GPIOTE_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_GPIOTE_ENABLED
 #define NRFX_GPIOTE_ENABLED 0
 #endif
 
-// <o> NRFX_GPIOTE_CONFIG_NUM_OF_EVT_HANDLERS - Number of dedicated handlers
+/**
+ * @brief NRFX_GPIOTE_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
+#ifndef NRFX_GPIOTE_DEFAULT_CONFIG_IRQ_PRIORITY
+#define NRFX_GPIOTE_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
+#endif
+
+/**
+ * @brief NRFX_GPIOTE_CONFIG_NUM_OF_EVT_HANDLERS
+ *
+ * Integer value. Minimum: 0 Maximum: 15
+ */
 #ifndef NRFX_GPIOTE_CONFIG_NUM_OF_EVT_HANDLERS
 #define NRFX_GPIOTE_CONFIG_NUM_OF_EVT_HANDLERS 2
 #endif
 
-// <o> NRFX_GPIOTE_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
-#ifndef NRFX_GPIOTE_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_GPIOTE_DEFAULT_CONFIG_IRQ_PRIORITY 7
-#endif
-
-// <e> NRFX_GPIOTE_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_GPIOTE_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_GPIOTE_CONFIG_LOG_ENABLED
 #define NRFX_GPIOTE_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_GPIOTE_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_GPIOTE_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_GPIOTE_CONFIG_LOG_LEVEL
 #define NRFX_GPIOTE_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_GPIOTE_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_GPIOTE_CONFIG_INFO_COLOR
-#define NRFX_GPIOTE_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_GPIOTE_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_GPIOTE_CONFIG_DEBUG_COLOR
-#define NRFX_GPIOTE_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_I2S_ENABLED - nrfx_i2s - I2S peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_I2S_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_I2S_ENABLED
 #define NRFX_I2S_ENABLED 0
 #endif
 
-// <o> NRFX_I2S_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_I2S_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_I2S_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_I2S_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_I2S_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_I2S_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_I2S_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_I2S_CONFIG_LOG_ENABLED
 #define NRFX_I2S_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_I2S_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_I2S_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_I2S_CONFIG_LOG_LEVEL
 #define NRFX_I2S_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_I2S_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_I2S_CONFIG_INFO_COLOR
-#define NRFX_I2S_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_I2S_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_I2S_CONFIG_DEBUG_COLOR
-#define NRFX_I2S_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_LPCOMP_ENABLED - nrfx_lpcomp - LPCOMP peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_LPCOMP_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_LPCOMP_ENABLED
 #define NRFX_LPCOMP_ENABLED 0
 #endif
 
-// <o> NRFX_LPCOMP_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_LPCOMP_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_LPCOMP_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_LPCOMP_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_LPCOMP_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_LPCOMP_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_LPCOMP_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_LPCOMP_CONFIG_LOG_ENABLED
 #define NRFX_LPCOMP_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_LPCOMP_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_LPCOMP_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_LPCOMP_CONFIG_LOG_LEVEL
 #define NRFX_LPCOMP_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_LPCOMP_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_LPCOMP_CONFIG_INFO_COLOR
-#define NRFX_LPCOMP_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_LPCOMP_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_LPCOMP_CONFIG_DEBUG_COLOR
-#define NRFX_LPCOMP_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_NFCT_ENABLED - nrfx_nfct - NFCT peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_NFCT_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_NFCT_ENABLED
 #define NRFX_NFCT_ENABLED 0
 #endif
-// <o> NRFX_NFCT_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
 
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_NFCT_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_NFCT_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_NFCT_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_NFCT_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <o> NRFX_NFCT_CONFIG_TIMER_INSTANCE_ID - Timer instance used for workarounds in the driver.
-
-// <0=> 0
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-
+/**
+ * @brief NRFX_NFCT_CONFIG_TIMER_INSTANCE_ID - Timer instance used for workarounds in the driver.
+ *
+ * Integer value. Minimum: 0 Maximum: 5
+ */
 #ifndef NRFX_NFCT_CONFIG_TIMER_INSTANCE_ID
 #define NRFX_NFCT_CONFIG_TIMER_INSTANCE_ID 4
 #endif
 
-// <e> NRFX_NFCT_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_NFCT_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_NFCT_CONFIG_LOG_ENABLED
 #define NRFX_NFCT_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_NFCT_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_NFCT_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_NFCT_CONFIG_LOG_LEVEL
 #define NRFX_NFCT_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_NFCT_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_NFCT_CONFIG_INFO_COLOR
-#define NRFX_NFCT_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_NFCT_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_NFCT_CONFIG_DEBUG_COLOR
-#define NRFX_NFCT_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_NVMC_ENABLED - nrfx_nvmc - NVMC peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_NVMC_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_NVMC_ENABLED
 #define NRFX_NVMC_ENABLED 0
 #endif
 
-// </e>
-
-// <e> NRFX_PDM_ENABLED - nrfx_pdm - PDM peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_PDM_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_PDM_ENABLED
 #define NRFX_PDM_ENABLED 0
 #endif
 
-// <o> NRFX_PDM_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_PDM_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_PDM_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_PDM_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_PDM_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_PDM_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_PDM_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_PDM_CONFIG_LOG_ENABLED
 #define NRFX_PDM_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_PDM_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_PDM_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_PDM_CONFIG_LOG_LEVEL
 #define NRFX_PDM_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_PDM_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_PDM_CONFIG_INFO_COLOR
-#define NRFX_PDM_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_PDM_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_PDM_CONFIG_DEBUG_COLOR
-#define NRFX_PDM_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_POWER_ENABLED - nrfx_power - POWER peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_POWER_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_POWER_ENABLED
 #define NRFX_POWER_ENABLED 0
 #endif
-// <o> NRFX_POWER_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
 
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_POWER_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_POWER_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_POWER_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_POWER_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// </e>
-
-// <e> NRFX_PPI_ENABLED - nrfx_ppi - PPI peripheral allocator
-//==========================================================
+/**
+ * @brief NRFX_PPI_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_PPI_ENABLED
 #define NRFX_PPI_ENABLED 0
 #endif
-// <e> NRFX_PPI_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+
+/**
+ * @brief NRFX_PPI_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_PPI_CONFIG_LOG_ENABLED
 #define NRFX_PPI_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_PPI_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_PPI_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_PPI_CONFIG_LOG_LEVEL
 #define NRFX_PPI_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_PPI_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_PPI_CONFIG_INFO_COLOR
-#define NRFX_PPI_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_PPI_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_PPI_CONFIG_DEBUG_COLOR
-#define NRFX_PPI_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_PRS_ENABLED - nrfx_prs - Peripheral Resource Sharing module
-//==========================================================
+/**
+ * @brief NRFX_PRS_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_PRS_ENABLED
 #define NRFX_PRS_ENABLED 0
 #endif
-// <q> NRFX_PRS_BOX_0_ENABLED  - Enables box 0 in the module.
 
-
-#ifndef NRFX_PRS_BOX_0_ENABLED
-#define NRFX_PRS_BOX_0_ENABLED 0
-#endif
-
-// <q> NRFX_PRS_BOX_1_ENABLED  - Enables box 1 in the module.
-
-
-#ifndef NRFX_PRS_BOX_1_ENABLED
-#define NRFX_PRS_BOX_1_ENABLED 0
-#endif
-
-// <q> NRFX_PRS_BOX_2_ENABLED  - Enables box 2 in the module.
-
-
-#ifndef NRFX_PRS_BOX_2_ENABLED
-#define NRFX_PRS_BOX_2_ENABLED 0
-#endif
-
-// <q> NRFX_PRS_BOX_3_ENABLED  - Enables box 3 in the module.
-
-
-#ifndef NRFX_PRS_BOX_3_ENABLED
-#define NRFX_PRS_BOX_3_ENABLED 0
-#endif
-
-// <q> NRFX_PRS_BOX_4_ENABLED  - Enables box 4 in the module.
-
-
-#ifndef NRFX_PRS_BOX_4_ENABLED
-#define NRFX_PRS_BOX_4_ENABLED 0
-#endif
-
-// <e> NRFX_PRS_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_PRS_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_PRS_CONFIG_LOG_ENABLED
 #define NRFX_PRS_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_PRS_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_PRS_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_PRS_CONFIG_LOG_LEVEL
 #define NRFX_PRS_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_PRS_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_PRS_CONFIG_INFO_COLOR
-#define NRFX_PRS_CONFIG_INFO_COLOR 0
+/**
+ * @brief NRFX_PRS_BOX_0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_PRS_BOX_0_ENABLED
+#define NRFX_PRS_BOX_0_ENABLED 0
 #endif
 
-// <o> NRFX_PRS_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_PRS_CONFIG_DEBUG_COLOR
-#define NRFX_PRS_CONFIG_DEBUG_COLOR 0
+/**
+ * @brief NRFX_PRS_BOX_1_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_PRS_BOX_1_ENABLED
+#define NRFX_PRS_BOX_1_ENABLED 0
 #endif
 
-// </e>
+/**
+ * @brief NRFX_PRS_BOX_2_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_PRS_BOX_2_ENABLED
+#define NRFX_PRS_BOX_2_ENABLED 0
+#endif
 
-// </e>
+/**
+ * @brief NRFX_PRS_BOX_3_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_PRS_BOX_3_ENABLED
+#define NRFX_PRS_BOX_3_ENABLED 0
+#endif
 
-// <e> NRFX_PWM_ENABLED - nrfx_pwm - PWM peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_PRS_BOX_4_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_PRS_BOX_4_ENABLED
+#define NRFX_PRS_BOX_4_ENABLED 0
+#endif
+
+/**
+ * @brief NRFX_PWM_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_PWM_ENABLED
 #define NRFX_PWM_ENABLED 0
 #endif
 
-// <q> NRFX_PWM0_ENABLED  - Enable PWM0 instance
-
-#ifndef NRFX_PWM0_ENABLED
-#define NRFX_PWM0_ENABLED 0
-#endif
-
-// <q> NRFX_PWM1_ENABLED  - Enable PWM1 instance
-
-#ifndef NRFX_PWM1_ENABLED
-#define NRFX_PWM1_ENABLED 0
-#endif
-
-// <q> NRFX_PWM2_ENABLED  - Enable PWM2 instance
-
-#ifndef NRFX_PWM2_ENABLED
-#define NRFX_PWM2_ENABLED 0
-#endif
-
-// <q> NRFX_PWM3_ENABLED  - Enable PWM3 instance
-
-#ifndef NRFX_PWM3_ENABLED
-#define NRFX_PWM3_ENABLED 0
-#endif
-
-// <o> NRFX_PWM_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_PWM_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_PWM_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_PWM_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_PWM_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_PWM_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_PWM_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_PWM_CONFIG_LOG_ENABLED
 #define NRFX_PWM_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_PWM_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_PWM_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_PWM_CONFIG_LOG_LEVEL
 #define NRFX_PWM_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_PWM_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_PWM_CONFIG_INFO_COLOR
-#define NRFX_PWM_CONFIG_INFO_COLOR 0
+/**
+ * @brief NRFX_PWM0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_PWM0_ENABLED
+#define NRFX_PWM0_ENABLED 0
 #endif
 
-// <o> NRFX_PWM_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_PWM_CONFIG_DEBUG_COLOR
-#define NRFX_PWM_CONFIG_DEBUG_COLOR 0
+/**
+ * @brief NRFX_PWM1_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_PWM1_ENABLED
+#define NRFX_PWM1_ENABLED 0
 #endif
 
-// </e>
+/**
+ * @brief NRFX_PWM2_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_PWM2_ENABLED
+#define NRFX_PWM2_ENABLED 0
+#endif
 
-// </e>
+/**
+ * @brief NRFX_PWM3_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_PWM3_ENABLED
+#define NRFX_PWM3_ENABLED 0
+#endif
 
-// <e> NRFX_QDEC_ENABLED - nrfx_qdec - QDEC peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_QDEC_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_QDEC_ENABLED
 #define NRFX_QDEC_ENABLED 0
 #endif
 
-// <o> NRFX_QDEC_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_QDEC_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_QDEC_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_QDEC_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_QDEC_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_QDEC_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_QDEC_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_QDEC_CONFIG_LOG_ENABLED
 #define NRFX_QDEC_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_QDEC_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_QDEC_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_QDEC_CONFIG_LOG_LEVEL
 #define NRFX_QDEC_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_QDEC_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_QDEC_CONFIG_INFO_COLOR
-#define NRFX_QDEC_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_QDEC_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_QDEC_CONFIG_DEBUG_COLOR
-#define NRFX_QDEC_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_QSPI_ENABLED - nrfx_qspi - QSPI peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_QSPI_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_QSPI_ENABLED
 #define NRFX_QSPI_ENABLED 0
 #endif
 
-// <o> NRFX_QSPI_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_QSPI_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_QSPI_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_QSPI_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_QSPI_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// </e>
-
-// <e> NRFX_RNG_ENABLED - nrfx_rng - RNG peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_RNG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_RNG_ENABLED
 #define NRFX_RNG_ENABLED 0
 #endif
 
-// <o> NRFX_RNG_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_RNG_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_RNG_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_RNG_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_RNG_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_RNG_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_RNG_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_RNG_CONFIG_LOG_ENABLED
 #define NRFX_RNG_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_RNG_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_RNG_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_RNG_CONFIG_LOG_LEVEL
 #define NRFX_RNG_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_RNG_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_RNG_CONFIG_INFO_COLOR
-#define NRFX_RNG_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_RNG_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_RNG_CONFIG_DEBUG_COLOR
-#define NRFX_RNG_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_RTC_ENABLED - nrfx_rtc - RTC peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_RTC_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_RTC_ENABLED
 #define NRFX_RTC_ENABLED 0
 #endif
-// <q> NRFX_RTC0_ENABLED  - Enable RTC0 instance
 
-#ifndef NRFX_RTC0_ENABLED
-#define NRFX_RTC0_ENABLED 0
-#endif
-
-// <q> NRFX_RTC1_ENABLED  - Enable RTC1 instance
-
-#ifndef NRFX_RTC1_ENABLED
-#define NRFX_RTC1_ENABLED 0
-#endif
-
-// <q> NRFX_RTC2_ENABLED  - Enable RTC2 instance
-
-#ifndef NRFX_RTC2_ENABLED
-#define NRFX_RTC2_ENABLED 0
-#endif
-
-// <o> NRFX_RTC_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_RTC_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_RTC_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_RTC_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_RTC_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_RTC_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_RTC_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_RTC_CONFIG_LOG_ENABLED
 #define NRFX_RTC_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_RTC_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_RTC_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_RTC_CONFIG_LOG_LEVEL
 #define NRFX_RTC_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_RTC_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_RTC_CONFIG_INFO_COLOR
-#define NRFX_RTC_CONFIG_INFO_COLOR 0
+/**
+ * @brief NRFX_RTC0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_RTC0_ENABLED
+#define NRFX_RTC0_ENABLED 0
 #endif
 
-// <o> NRFX_RTC_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_RTC_CONFIG_DEBUG_COLOR
-#define NRFX_RTC_CONFIG_DEBUG_COLOR 0
+/**
+ * @brief NRFX_RTC1_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_RTC1_ENABLED
+#define NRFX_RTC1_ENABLED 0
 #endif
 
-// </e>
+/**
+ * @brief NRFX_RTC2_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_RTC2_ENABLED
+#define NRFX_RTC2_ENABLED 0
+#endif
 
-// </e>
-
-// <e> NRFX_SAADC_ENABLED - nrfx_saadc - SAADC peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_SAADC_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_SAADC_ENABLED
 #define NRFX_SAADC_ENABLED 0
 #endif
 
-// <o> NRFX_SAADC_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_SAADC_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_SAADC_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_SAADC_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_SAADC_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_SAADC_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_SAADC_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_SAADC_CONFIG_LOG_ENABLED
 #define NRFX_SAADC_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_SAADC_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_SAADC_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_SAADC_CONFIG_LOG_LEVEL
 #define NRFX_SAADC_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_SAADC_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_SAADC_CONFIG_INFO_COLOR
-#define NRFX_SAADC_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_SAADC_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_SAADC_CONFIG_DEBUG_COLOR
-#define NRFX_SAADC_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_SPIM_ENABLED - nrfx_spim - SPIM peripheral driver
-//==========================================================
-#ifndef NRFX_SPIM_ENABLED
-#define NRFX_SPIM_ENABLED 0
-#endif
-// <q> NRFX_SPIM0_ENABLED  - Enable SPIM0 instance
-
-
-#ifndef NRFX_SPIM0_ENABLED
-#define NRFX_SPIM0_ENABLED 0
-#endif
-
-// <q> NRFX_SPIM1_ENABLED  - Enable SPIM1 instance
-
-
-#ifndef NRFX_SPIM1_ENABLED
-#define NRFX_SPIM1_ENABLED 0
-#endif
-
-// <q> NRFX_SPIM2_ENABLED  - Enable SPIM2 instance
-
-
-#ifndef NRFX_SPIM2_ENABLED
-#define NRFX_SPIM2_ENABLED 0
-#endif
-
-// <q> NRFX_SPIM3_ENABLED  - Enable SPIM3 instance
-
-
-#ifndef NRFX_SPIM3_ENABLED
-#define NRFX_SPIM3_ENABLED 0
-#endif
-
-// <q> NRFX_SPIM_EXTENDED_ENABLED  - Enable extended SPIM features
-
-
-#ifndef NRFX_SPIM_EXTENDED_ENABLED
-#define NRFX_SPIM_EXTENDED_ENABLED 0
-#endif
-
-// <o> NRFX_SPIM_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
-#ifndef NRFX_SPIM_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_SPIM_DEFAULT_CONFIG_IRQ_PRIORITY 7
-#endif
-
-// <e> NRFX_SPIM_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
-#ifndef NRFX_SPIM_CONFIG_LOG_ENABLED
-#define NRFX_SPIM_CONFIG_LOG_ENABLED 0
-#endif
-// <o> NRFX_SPIM_CONFIG_LOG_LEVEL  - Default Severity level
-
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
-#ifndef NRFX_SPIM_CONFIG_LOG_LEVEL
-#define NRFX_SPIM_CONFIG_LOG_LEVEL 3
-#endif
-
-// <o> NRFX_SPIM_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_SPIM_CONFIG_INFO_COLOR
-#define NRFX_SPIM_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_SPIM_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_SPIM_CONFIG_DEBUG_COLOR
-#define NRFX_SPIM_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// <q> NRFX_SPIM3_NRF52840_ANOMALY_198_WORKAROUND_ENABLED  - Enables nRF52840 anomaly 198 workaround for SPIM3.
-
-
-// <i> See more in the Errata document located at
-// <i> https://infocenter.nordicsemi.com/
-
-#ifndef NRFX_SPIM3_NRF52840_ANOMALY_198_WORKAROUND_ENABLED
-#define NRFX_SPIM3_NRF52840_ANOMALY_198_WORKAROUND_ENABLED 0
-#endif
-
-// </e>
-
-// <e> NRFX_SPIS_ENABLED - nrfx_spis - SPIS peripheral driver
-//==========================================================
-#ifndef NRFX_SPIS_ENABLED
-#define NRFX_SPIS_ENABLED 0
-#endif
-// <q> NRFX_SPIS0_ENABLED  - Enable SPIS0 instance
-
-
-#ifndef NRFX_SPIS0_ENABLED
-#define NRFX_SPIS0_ENABLED 0
-#endif
-
-// <q> NRFX_SPIS1_ENABLED  - Enable SPIS1 instance
-
-
-#ifndef NRFX_SPIS1_ENABLED
-#define NRFX_SPIS1_ENABLED 0
-#endif
-
-// <q> NRFX_SPIS2_ENABLED  - Enable SPIS2 instance
-
-
-#ifndef NRFX_SPIS2_ENABLED
-#define NRFX_SPIS2_ENABLED 0
-#endif
-
-// <o> NRFX_SPIS_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
-#ifndef NRFX_SPIS_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_SPIS_DEFAULT_CONFIG_IRQ_PRIORITY 7
-#endif
-
-// <e> NRFX_SPIS_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
-#ifndef NRFX_SPIS_CONFIG_LOG_ENABLED
-#define NRFX_SPIS_CONFIG_LOG_ENABLED 0
-#endif
-// <o> NRFX_SPIS_CONFIG_LOG_LEVEL  - Default Severity level
-
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
-#ifndef NRFX_SPIS_CONFIG_LOG_LEVEL
-#define NRFX_SPIS_CONFIG_LOG_LEVEL 3
-#endif
-
-// <o> NRFX_SPIS_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_SPIS_CONFIG_INFO_COLOR
-#define NRFX_SPIS_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_SPIS_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_SPIS_CONFIG_DEBUG_COLOR
-#define NRFX_SPIS_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_SPI_ENABLED - nrfx_spi - SPI peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_SPI_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_SPI_ENABLED
 #define NRFX_SPI_ENABLED 0
 #endif
-// <q> NRFX_SPI0_ENABLED  - Enable SPI0 instance
 
-
-#ifndef NRFX_SPI0_ENABLED
-#define NRFX_SPI0_ENABLED 0
-#endif
-
-// <q> NRFX_SPI1_ENABLED  - Enable SPI1 instance
-
-
-#ifndef NRFX_SPI1_ENABLED
-#define NRFX_SPI1_ENABLED 0
-#endif
-
-// <q> NRFX_SPI2_ENABLED  - Enable SPI2 instance
-
-
-#ifndef NRFX_SPI2_ENABLED
-#define NRFX_SPI2_ENABLED 0
-#endif
-
-// <o> NRFX_SPI_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_SPI_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_SPI_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_SPI_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_SPI_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_SPI_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_SPI_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_SPI_CONFIG_LOG_ENABLED
 #define NRFX_SPI_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_SPI_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_SPI_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_SPI_CONFIG_LOG_LEVEL
 #define NRFX_SPI_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_SPI_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_SPI_CONFIG_INFO_COLOR
-#define NRFX_SPI_CONFIG_INFO_COLOR 0
+/**
+ * @brief NRFX_SPI0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPI0_ENABLED
+#define NRFX_SPI0_ENABLED 0
 #endif
 
-// <o> NRFX_SPI_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_SPI_CONFIG_DEBUG_COLOR
-#define NRFX_SPI_CONFIG_DEBUG_COLOR 0
+/**
+ * @brief NRFX_SPI1_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPI1_ENABLED
+#define NRFX_SPI1_ENABLED 0
 #endif
 
-// </e>
+/**
+ * @brief NRFX_SPI2_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPI2_ENABLED
+#define NRFX_SPI2_ENABLED 0
+#endif
 
-// </e>
+/**
+ * @brief NRFX_SPIM_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPIM_ENABLED
+#define NRFX_SPIM_ENABLED 0
+#endif
 
-// <q> NRFX_SYSTICK_ENABLED  - nrfx_systick - ARM(R) SysTick driver
+/**
+ * @brief NRFX_SPIM_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
+#ifndef NRFX_SPIM_DEFAULT_CONFIG_IRQ_PRIORITY
+#define NRFX_SPIM_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
+#endif
 
+/**
+ * @brief NRFX_SPIM_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPIM_CONFIG_LOG_ENABLED
+#define NRFX_SPIM_CONFIG_LOG_ENABLED 0
+#endif
 
+/**
+ * @brief NRFX_SPIM_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
+#ifndef NRFX_SPIM_CONFIG_LOG_LEVEL
+#define NRFX_SPIM_CONFIG_LOG_LEVEL 3
+#endif
+
+/**
+ * @brief NRFX_SPIM3_NRF52840_ANOMALY_198_WORKAROUND_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPIM3_NRF52840_ANOMALY_198_WORKAROUND_ENABLED
+#define NRFX_SPIM3_NRF52840_ANOMALY_198_WORKAROUND_ENABLED 0
+#endif
+
+/**
+ * @brief NRFX_SPIM0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPIM0_ENABLED
+#define NRFX_SPIM0_ENABLED 0
+#endif
+
+/**
+ * @brief NRFX_SPIM1_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPIM1_ENABLED
+#define NRFX_SPIM1_ENABLED 0
+#endif
+
+/**
+ * @brief NRFX_SPIM2_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPIM2_ENABLED
+#define NRFX_SPIM2_ENABLED 0
+#endif
+
+/**
+ * @brief NRFX_SPIM3_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPIM3_ENABLED
+#define NRFX_SPIM3_ENABLED 0
+#endif
+
+/**
+ * @brief NRFX_SPIS_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPIS_ENABLED
+#define NRFX_SPIS_ENABLED 0
+#endif
+
+/**
+ * @brief NRFX_SPIS_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
+#ifndef NRFX_SPIS_DEFAULT_CONFIG_IRQ_PRIORITY
+#define NRFX_SPIS_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
+#endif
+
+/**
+ * @brief NRFX_SPIS_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPIS_CONFIG_LOG_ENABLED
+#define NRFX_SPIS_CONFIG_LOG_ENABLED 0
+#endif
+
+/**
+ * @brief NRFX_SPIS_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
+#ifndef NRFX_SPIS_CONFIG_LOG_LEVEL
+#define NRFX_SPIS_CONFIG_LOG_LEVEL 3
+#endif
+
+/**
+ * @brief NRFX_SPIS0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPIS0_ENABLED
+#define NRFX_SPIS0_ENABLED 0
+#endif
+
+/**
+ * @brief NRFX_SPIS1_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPIS1_ENABLED
+#define NRFX_SPIS1_ENABLED 0
+#endif
+
+/**
+ * @brief NRFX_SPIS2_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPIS2_ENABLED
+#define NRFX_SPIS2_ENABLED 0
+#endif
+
+/**
+ * @brief NRFX_SYSTICK_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_SYSTICK_ENABLED
 #define NRFX_SYSTICK_ENABLED 0
 #endif
 
-// <e> NRFX_TEMP_ENABLED - nrfx_temp - TEMP peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_TEMP_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_TEMP_ENABLED
 #define NRFX_TEMP_ENABLED 0
 #endif
 
-// <o> NRFX_TEMP_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_TEMP_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_TEMP_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_TEMP_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_TEMP_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// </e>
+/**
+ * @brief NRFX_TEMP_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TEMP_CONFIG_LOG_ENABLED
+#define NRFX_TEMP_CONFIG_LOG_ENABLED 0
+#endif
 
-// <e> NRFX_TIMER_ENABLED - nrfx_timer - TIMER periperal driver
-//==========================================================
+/**
+ * @brief NRFX_TEMP_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
+#ifndef NRFX_TEMP_CONFIG_LOG_LEVEL
+#define NRFX_TEMP_CONFIG_LOG_LEVEL 3
+#endif
+
+/**
+ * @brief NRFX_TIMER_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_TIMER_ENABLED
 #define NRFX_TIMER_ENABLED 0
 #endif
 
-// <q> NRFX_TIMER0_ENABLED  - Enable TIMER0 instance
-
-#ifndef NRFX_TIMER0_ENABLED
-#define NRFX_TIMER0_ENABLED 0
-#endif
-
-// <q> NRFX_TIMER1_ENABLED  - Enable TIMER1 instance
-
-#ifndef NRFX_TIMER1_ENABLED
-#define NRFX_TIMER1_ENABLED 0
-#endif
-
-// <q> NRFX_TIMER2_ENABLED  - Enable TIMER2 instance
-
-#ifndef NRFX_TIMER2_ENABLED
-#define NRFX_TIMER2_ENABLED 0
-#endif
-
-// <q> NRFX_TIMER3_ENABLED  - Enable TIMER3 instance
-
-#ifndef NRFX_TIMER3_ENABLED
-#define NRFX_TIMER3_ENABLED 0
-#endif
-
-// <q> NRFX_TIMER4_ENABLED  - Enable TIMER4 instance
-
-#ifndef NRFX_TIMER4_ENABLED
-#define NRFX_TIMER4_ENABLED 0
-#endif
-
-// <o> NRFX_TIMER_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_TIMER_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_TIMER_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_TIMER_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_TIMER_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_TIMER_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_TIMER_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_TIMER_CONFIG_LOG_ENABLED
 #define NRFX_TIMER_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_TIMER_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_TIMER_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_TIMER_CONFIG_LOG_LEVEL
 #define NRFX_TIMER_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_TIMER_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_TIMER_CONFIG_INFO_COLOR
-#define NRFX_TIMER_CONFIG_INFO_COLOR 0
+/**
+ * @brief NRFX_TIMER0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TIMER0_ENABLED
+#define NRFX_TIMER0_ENABLED 0
 #endif
 
-// <o> NRFX_TIMER_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_TIMER_CONFIG_DEBUG_COLOR
-#define NRFX_TIMER_CONFIG_DEBUG_COLOR 0
+/**
+ * @brief NRFX_TIMER1_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TIMER1_ENABLED
+#define NRFX_TIMER1_ENABLED 0
 #endif
 
-// </e>
-
-// </e>
-
-// <e> NRFX_TWIM_ENABLED - nrfx_twim - TWIM peripheral driver
-//==========================================================
-#ifndef NRFX_TWIM_ENABLED
-#define NRFX_TWIM_ENABLED 0
+/**
+ * @brief NRFX_TIMER2_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TIMER2_ENABLED
+#define NRFX_TIMER2_ENABLED 0
 #endif
 
-// <q> NRFX_TWIM0_ENABLED  - Enable TWIM0 instance
-
-#ifndef NRFX_TWIM0_ENABLED
-#define NRFX_TWIM0_ENABLED 0
+/**
+ * @brief NRFX_TIMER3_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TIMER3_ENABLED
+#define NRFX_TIMER3_ENABLED 0
 #endif
 
-// <q> NRFX_TWIM1_ENABLED  - Enable TWIM1 instance
-
-#ifndef NRFX_TWIM1_ENABLED
-#define NRFX_TWIM1_ENABLED 0
+/**
+ * @brief NRFX_TIMER4_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TIMER4_ENABLED
+#define NRFX_TIMER4_ENABLED 0
 #endif
 
-// <o> NRFX_TWIM_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
-#ifndef NRFX_TWIM_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_TWIM_DEFAULT_CONFIG_IRQ_PRIORITY 7
-#endif
-
-// <e> NRFX_TWIM_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
-#ifndef NRFX_TWIM_CONFIG_LOG_ENABLED
-#define NRFX_TWIM_CONFIG_LOG_ENABLED 0
-#endif
-// <o> NRFX_TWIM_CONFIG_LOG_LEVEL  - Default Severity level
-
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
-#ifndef NRFX_TWIM_CONFIG_LOG_LEVEL
-#define NRFX_TWIM_CONFIG_LOG_LEVEL 3
-#endif
-
-// <o> NRFX_TWIM_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_TWIM_CONFIG_INFO_COLOR
-#define NRFX_TWIM_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_TWIM_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_TWIM_CONFIG_DEBUG_COLOR
-#define NRFX_TWIM_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_TWIS_ENABLED - nrfx_twis - TWIS peripheral driver
-//==========================================================
-#ifndef NRFX_TWIS_ENABLED
-#define NRFX_TWIS_ENABLED 0
-#endif
-
-// <q> NRFX_TWIS0_ENABLED  - Enable TWIS0 instance
-
-#ifndef NRFX_TWIS0_ENABLED
-#define NRFX_TWIS0_ENABLED 0
-#endif
-
-// <q> NRFX_TWIS1_ENABLED  - Enable TWIS1 instance
-
-#ifndef NRFX_TWIS1_ENABLED
-#define NRFX_TWIS1_ENABLED 0
-#endif
-
-// <q> NRFX_TWIS_ASSUME_INIT_AFTER_RESET_ONLY  - Assume that any instance would be initialized only once
-
-// <i> Optimization flag. Registers used by TWIS are shared by other peripherals. Normally, during initialization driver tries to clear all registers to known state before doing the initialization itself. This gives initialization safe procedure, no matter when it would be called. If you activate TWIS only once and do never uninitialize it - set this flag to 1 what gives more optimal code.
-
-#ifndef NRFX_TWIS_ASSUME_INIT_AFTER_RESET_ONLY
-#define NRFX_TWIS_ASSUME_INIT_AFTER_RESET_ONLY 0
-#endif
-
-// <q> NRFX_TWIS_NO_SYNC_MODE  - Remove support for synchronous mode
-
-// <i> Synchronous mode would be used in specific situations. And it uses some additional code and data memory to safely process state machine by polling it in status functions. If this functionality is not required it may be disabled to free some resources.
-
-#ifndef NRFX_TWIS_NO_SYNC_MODE
-#define NRFX_TWIS_NO_SYNC_MODE 0
-#endif
-
-// <o> NRFX_TWIS_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
-#ifndef NRFX_TWIS_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_TWIS_DEFAULT_CONFIG_IRQ_PRIORITY 7
-#endif
-
-// <e> NRFX_TWIS_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
-#ifndef NRFX_TWIS_CONFIG_LOG_ENABLED
-#define NRFX_TWIS_CONFIG_LOG_ENABLED 0
-#endif
-// <o> NRFX_TWIS_CONFIG_LOG_LEVEL  - Default Severity level
-
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
-#ifndef NRFX_TWIS_CONFIG_LOG_LEVEL
-#define NRFX_TWIS_CONFIG_LOG_LEVEL 3
-#endif
-
-// <o> NRFX_TWIS_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_TWIS_CONFIG_INFO_COLOR
-#define NRFX_TWIS_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_TWIS_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_TWIS_CONFIG_DEBUG_COLOR
-#define NRFX_TWIS_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_TWI_ENABLED - nrfx_twi - TWI peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_TWI_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_TWI_ENABLED
 #define NRFX_TWI_ENABLED 0
 #endif
 
-// <q> NRFX_TWI0_ENABLED  - Enable TWI0 instance
-
-#ifndef NRFX_TWI0_ENABLED
-#define NRFX_TWI0_ENABLED 0
-#endif
-
-// <q> NRFX_TWI1_ENABLED  - Enable TWI1 instance
-
-#ifndef NRFX_TWI1_ENABLED
-#define NRFX_TWI1_ENABLED 0
-#endif
-
-// <o> NRFX_TWI_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_TWI_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_TWI_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_TWI_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_TWI_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_TWI_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_TWI_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_TWI_CONFIG_LOG_ENABLED
 #define NRFX_TWI_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_TWI_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_TWI_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_TWI_CONFIG_LOG_LEVEL
 #define NRFX_TWI_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_TWI_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_TWI_CONFIG_INFO_COLOR
-#define NRFX_TWI_CONFIG_INFO_COLOR 0
+/**
+ * @brief NRFX_TWI0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWI0_ENABLED
+#define NRFX_TWI0_ENABLED 0
 #endif
 
-// <o> NRFX_TWI_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_TWI_CONFIG_DEBUG_COLOR
-#define NRFX_TWI_CONFIG_DEBUG_COLOR 0
+/**
+ * @brief NRFX_TWI1_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWI1_ENABLED
+#define NRFX_TWI1_ENABLED 0
 #endif
 
-// </e>
-
-// </e>
-
-// <e> NRFX_UARTE_ENABLED - nrfx_uarte - UARTE peripheral driver
-//==========================================================
-#ifndef NRFX_UARTE_ENABLED
-#define NRFX_UARTE_ENABLED 0
+/**
+ * @brief NRFX_TWIM_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWIM_ENABLED
+#define NRFX_TWIM_ENABLED 0
 #endif
 
-// <q> NRFX_UARTE0_ENABLED - Enable UARTE0 instance
-
-#ifndef NRFX_UARTE0_ENABLED
-#define NRFX_UARTE0_ENABLED 0
+/**
+ * @brief NRFX_TWIM_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
+#ifndef NRFX_TWIM_DEFAULT_CONFIG_IRQ_PRIORITY
+#define NRFX_TWIM_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <q> NRFX_UARTE1_ENABLED - Enable UARTE1 instance
-
-#ifndef NRFX_UARTE1_ENABLED
-#define NRFX_UARTE1_ENABLED 0
+/**
+ * @brief NRFX_TWIM_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWIM_CONFIG_LOG_ENABLED
+#define NRFX_TWIM_CONFIG_LOG_ENABLED 0
 #endif
 
-// <o> NRFX_UARTE_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
-#ifndef NRFX_UARTE_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_UARTE_DEFAULT_CONFIG_IRQ_PRIORITY 7
+/**
+ * @brief NRFX_TWIM_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
+#ifndef NRFX_TWIM_CONFIG_LOG_LEVEL
+#define NRFX_TWIM_CONFIG_LOG_LEVEL 3
 #endif
 
-// <e> NRFX_UARTE_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
-#ifndef NRFX_UARTE_CONFIG_LOG_ENABLED
-#define NRFX_UARTE_CONFIG_LOG_ENABLED 0
-#endif
-// <o> NRFX_UARTE_CONFIG_LOG_LEVEL  - Default Severity level
-
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
-#ifndef NRFX_UARTE_CONFIG_LOG_LEVEL
-#define NRFX_UARTE_CONFIG_LOG_LEVEL 3
+/**
+ * @brief NRFX_TWIM0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWIM0_ENABLED
+#define NRFX_TWIM0_ENABLED 0
 #endif
 
-// <o> NRFX_UARTE_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_UARTE_CONFIG_INFO_COLOR
-#define NRFX_UARTE_CONFIG_INFO_COLOR 0
+/**
+ * @brief NRFX_TWIM1_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWIM1_ENABLED
+#define NRFX_TWIM1_ENABLED 0
 #endif
 
-// <o> NRFX_UARTE_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_UARTE_CONFIG_DEBUG_COLOR
-#define NRFX_UARTE_CONFIG_DEBUG_COLOR 0
+/**
+ * @brief NRFX_TWIS_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWIS_ENABLED
+#define NRFX_TWIS_ENABLED 0
 #endif
 
-// </e>
+/**
+ * @brief NRFX_TWIS_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
+#ifndef NRFX_TWIS_DEFAULT_CONFIG_IRQ_PRIORITY
+#define NRFX_TWIS_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
+#endif
 
-// </e>
+/**
+ * @brief NRFX_TWIS_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWIS_CONFIG_LOG_ENABLED
+#define NRFX_TWIS_CONFIG_LOG_ENABLED 0
+#endif
 
-// <e> NRFX_UART_ENABLED - nrfx_uart - UART peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_TWIS_ASSUME_INIT_AFTER_RESET_ONLY - Assume that any instance would be initialized only once.
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWIS_ASSUME_INIT_AFTER_RESET_ONLY
+#define NRFX_TWIS_ASSUME_INIT_AFTER_RESET_ONLY 0
+#endif
+
+/**
+ * @brief NRFX_TWIS_NO_SYNC_MODE - Remove support for synchronous mode.
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWIS_NO_SYNC_MODE
+#define NRFX_TWIS_NO_SYNC_MODE 0
+#endif
+
+/**
+ * @brief NRFX_TWIS_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
+#ifndef NRFX_TWIS_CONFIG_LOG_LEVEL
+#define NRFX_TWIS_CONFIG_LOG_LEVEL 3
+#endif
+
+/**
+ * @brief NRFX_TWIS0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWIS0_ENABLED
+#define NRFX_TWIS0_ENABLED 0
+#endif
+
+/**
+ * @brief NRFX_TWIS1_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWIS1_ENABLED
+#define NRFX_TWIS1_ENABLED 0
+#endif
+
+/**
+ * @brief NRFX_UART_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_UART_ENABLED
 #define NRFX_UART_ENABLED 0
 #endif
 
-// <q> NRFX_UART0_ENABLED - Enable UART0 instance
-
-#ifndef NRFX_UART0_ENABLED
-#define NRFX_UART0_ENABLED 0
-#endif
-
-// <o> NRFX_UART_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_UART_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_UART_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_UART_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_UART_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_UART_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_UART_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_UART_CONFIG_LOG_ENABLED
 #define NRFX_UART_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_UART_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_UART_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_UART_CONFIG_LOG_LEVEL
 #define NRFX_UART_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_UART_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_UART_CONFIG_INFO_COLOR
-#define NRFX_UART_CONFIG_INFO_COLOR 0
+/**
+ * @brief NRFX_UART0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_UART0_ENABLED
+#define NRFX_UART0_ENABLED 0
 #endif
 
-// <o> NRFX_UART_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_UART_CONFIG_DEBUG_COLOR
-#define NRFX_UART_CONFIG_DEBUG_COLOR 0
+/**
+ * @brief NRFX_UARTE_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_UARTE_ENABLED
+#define NRFX_UARTE_ENABLED 0
 #endif
 
-// </e>
+/**
+ * @brief NRFX_UARTE_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
+#ifndef NRFX_UARTE_DEFAULT_CONFIG_IRQ_PRIORITY
+#define NRFX_UARTE_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
+#endif
 
-// </e>
+/**
+ * @brief NRFX_UARTE_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_UARTE_CONFIG_LOG_ENABLED
+#define NRFX_UARTE_CONFIG_LOG_ENABLED 0
+#endif
 
-// <e> NRFX_USBD_ENABLED - nrfx_usbd - USBD peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_UARTE_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
+#ifndef NRFX_UARTE_CONFIG_LOG_LEVEL
+#define NRFX_UARTE_CONFIG_LOG_LEVEL 3
+#endif
+
+/**
+ * @brief NRFX_UARTE0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_UARTE0_ENABLED
+#define NRFX_UARTE0_ENABLED 0
+#endif
+
+/**
+ * @brief NRFX_UARTE1_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_UARTE1_ENABLED
+#define NRFX_UARTE1_ENABLED 0
+#endif
+
+/**
+ * @brief NRFX_USBD_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_USBD_ENABLED
 #define NRFX_USBD_ENABLED 0
 #endif
-// <o> NRFX_USBD_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
 
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_USBD_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_USBD_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_USBD_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_USBD_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <q> USBD_CONFIG_DMASCHEDULER_ISO_BOOST  - Give priority to isochronous transfers
-
-// <i> This option gives priority to isochronous transfers.
-// <i> Enabling it assures that isochronous transfers are always processed,
-// <i> even if multiple other transfers are pending.
-// <i> Isochronous endpoints are prioritized before the usbd_dma_scheduler_algorithm
-// <i> function is called, so the option is independent of the algorithm chosen.
-
+/**
+ * @brief NRFX_USBD_CONFIG_DMASCHEDULER_ISO_BOOST - Give priority to isochronous transfers
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_USBD_CONFIG_DMASCHEDULER_ISO_BOOST
 #define NRFX_USBD_CONFIG_DMASCHEDULER_ISO_BOOST 1
 #endif
 
-// <q> USBD_CONFIG_ISO_IN_ZLP  - Respond to an IN token on ISO IN endpoint with ZLP when no data is ready
-
-
-// <i> If set, ISO IN endpoint will respond to an IN token with ZLP when no data is ready to be sent.
-// <i> Else, there will be no response.
-
+/**
+ * @brief NRFX_USBD_CONFIG_ISO_IN_ZLP - Respond to an IN token on ISO IN endpoint with ZLP when no data is ready.
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_USBD_CONFIG_ISO_IN_ZLP
 #define NRFX_USBD_CONFIG_ISO_IN_ZLP 0
 #endif
 
-// <e> NRFX_USBD_CONFIG_LOG_ENABLED - Enable logging in the module
-//==========================================================
+/**
+ * @brief NRFX_USBD_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_USBD_CONFIG_LOG_ENABLED
 #define NRFX_USBD_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_USBD_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_USBD_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_USBD_CONFIG_LOG_LEVEL
 #define NRFX_USBD_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_USBD_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_USBD_CONFIG_INFO_COLOR
-#define NRFX_USBD_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_USBD_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_USBD_CONFIG_DEBUG_COLOR
-#define NRFX_USBD_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_WDT_ENABLED - nrfx_wdt - WDT peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_WDT_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_WDT_ENABLED
 #define NRFX_WDT_ENABLED 0
 #endif
 
-// <q> NRFX_WDT0_ENABLED  - Enable WDT0 instance
-
-#ifndef NRFX_WDT0_ENABLED
-#define NRFX_WDT0_ENABLED 0
+/**
+ * @brief NRFX_WDT_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
+#ifndef NRFX_WDT_DEFAULT_CONFIG_IRQ_PRIORITY
+#define NRFX_WDT_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <o> NRFX_WDT_CONFIG_NO_IRQ  - Remove WDT IRQ handling from WDT driver
-
-// <0=> Include WDT IRQ handling
-// <1=> Remove WDT IRQ handling
-
+/**
+ * @brief NRFX_WDT_CONFIG_NO_IRQ - Remove WDT IRQ handling from WDT driver
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_WDT_CONFIG_NO_IRQ
 #define NRFX_WDT_CONFIG_NO_IRQ 0
 #endif
 
-// <o> NRFX_WDT_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
-#ifndef NRFX_WDT_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_WDT_DEFAULT_CONFIG_IRQ_PRIORITY 7
-#endif
-
-// <e> NRFX_WDT_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_WDT_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_WDT_CONFIG_LOG_ENABLED
 #define NRFX_WDT_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_WDT_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_WDT_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_WDT_CONFIG_LOG_LEVEL
 #define NRFX_WDT_CONFIG_LOG_LEVEL 3
 #endif
-
-// <o> NRFX_WDT_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_WDT_CONFIG_INFO_COLOR
-#define NRFX_WDT_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_WDT_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_WDT_CONFIG_DEBUG_COLOR
-#define NRFX_WDT_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// </h>
 
 #endif // NRFX_CONFIG_NRF52840_H__

--- a/nrfx/templates/nrfx_config_nrf5340_application.h
+++ b/nrfx/templates/nrfx_config_nrf5340_application.h
@@ -140,2030 +140,1497 @@
 #define GPIOTE_IRQHandler GPIOTE0_IRQHandler
 #endif
 
-/* Fixups for the QDEC driver. */
-#define NRF_QDEC        NRF_QDEC0
-#define QDEC_IRQHandler QDEC0_IRQHandler
 
-// <<< Use Configuration Wizard in Context Menu >>>\n
+/**
+ * @brief NRFX_DEFAULT_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
+#ifndef NRFX_DEFAULT_IRQ_PRIORITY
+#define NRFX_DEFAULT_IRQ_PRIORITY 7
+#endif
 
-// <h> nRF_Drivers
-
-// <e> NRFX_CLOCK_ENABLED - nrfx_clock - CLOCK peripheral driver.
-//==========================================================
+/**
+ * @brief NRFX_CLOCK_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_CLOCK_ENABLED
 #define NRFX_CLOCK_ENABLED 0
 #endif
-// <o> NRFX_CLOCK_CONFIG_LF_SRC  - LF clock source.
 
-// <0=> ULP
-// <1=> RC
-// <2=> XTAL
-// <3=> Synth
-
-#ifndef NRFX_CLOCK_CONFIG_LF_SRC
-#define NRFX_CLOCK_CONFIG_LF_SRC 2
-#endif
-
-// <q> NRFX_CLOCK_CONFIG_LF_CAL_ENABLED  - Enables LF Clock Calibration Support
-
-#ifndef NRFX_CLOCK_CONFIG_LF_CAL_ENABLED
-#define NRFX_CLOCK_CONFIG_LF_CAL_ENABLED 0
-#endif
-
-// <q> NRFX_CLOCK_CONFIG_LFXO_TWO_STAGE_ENABLED - Enables two-stage LFXO start procedure
-
-// <i> If set to a non-zero value, LFRC will be started before LFXO and corresponding
-// <i> event will be generated. It means that CPU will be woken up when LFRC
-// <i> oscillator starts, but user callback will be invoked only after LFXO
-// <i> finally starts.
-
-#ifndef NRFX_CLOCK_CONFIG_LFXO_TWO_STAGE_ENABLED
-#define NRFX_CLOCK_CONFIG_LFXO_TWO_STAGE_ENABLED 0
-#endif
-
-// <o> NRFX_CLOCK_CONFIG_HFCLK192M_SRC  - HFCLK192M source.
-
-// <0=> HFINT
-// <1=> HFXO
-
+/**
+ * @brief NRFX_CLOCK_CONFIG_HFCLK192M_SRC
+ *
+ * Integer value.
+ * Supported values:
+ * - HFINT = 0
+ * - HFXO  = 1
+ */
 #ifndef NRFX_CLOCK_CONFIG_HFCLK192M_SRC
 #define NRFX_CLOCK_CONFIG_HFCLK192M_SRC 1
 #endif
 
-// <o> NRFX_CLOCK_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority.
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
-#ifndef NRFX_CLOCK_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_CLOCK_DEFAULT_CONFIG_IRQ_PRIORITY 7
+/**
+ * @brief NRFX_CLOCK_CONFIG_LF_SRC
+ *
+ * Integer value.
+ * Supported values:
+ * - RC    = 1
+ * - XTAL  = 2
+ * - Synth = 3
+ */
+#ifndef NRFX_CLOCK_CONFIG_LF_SRC
+#define NRFX_CLOCK_CONFIG_LF_SRC 2
 #endif
 
-// <e> NRFX_CLOCK_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_CLOCK_CONFIG_LF_CAL_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_CLOCK_CONFIG_LF_CAL_ENABLED
+#define NRFX_CLOCK_CONFIG_LF_CAL_ENABLED 0
+#endif
+
+/**
+ * @brief NRFX_CLOCK_CONFIG_LFXO_TWO_STAGE_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_CLOCK_CONFIG_LFXO_TWO_STAGE_ENABLED
+#define NRFX_CLOCK_CONFIG_LFXO_TWO_STAGE_ENABLED 0
+#endif
+
+/**
+ * @brief NRFX_CLOCK_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
+#ifndef NRFX_CLOCK_DEFAULT_CONFIG_IRQ_PRIORITY
+#define NRFX_CLOCK_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
+#endif
+
+/**
+ * @brief NRFX_CLOCK_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_CLOCK_CONFIG_LOG_ENABLED
 #define NRFX_CLOCK_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_CLOCK_CONFIG_LOG_LEVEL  - Default severity level.
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_CLOCK_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_CLOCK_CONFIG_LOG_LEVEL
 #define NRFX_CLOCK_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_CLOCK_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_CLOCK_CONFIG_INFO_COLOR
-#define NRFX_CLOCK_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_CLOCK_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_CLOCK_CONFIG_DEBUG_COLOR
-#define NRFX_CLOCK_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_COMP_ENABLED - nrfx_comp - COMP peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_COMP_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_COMP_ENABLED
 #define NRFX_COMP_ENABLED 0
 #endif
 
-// <o> NRFX_COMP_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_COMP_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_COMP_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_COMP_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_COMP_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_COMP_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_COMP_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_COMP_CONFIG_LOG_ENABLED
 #define NRFX_COMP_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_COMP_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_COMP_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_COMP_CONFIG_LOG_LEVEL
 #define NRFX_COMP_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_COMP_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_COMP_CONFIG_INFO_COLOR
-#define NRFX_COMP_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_COMP_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_COMP_CONFIG_DEBUG_COLOR
-#define NRFX_COMP_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_DPPI_ENABLED - nrfx_dppi - DPPI allocator.
-//==========================================================
+/**
+ * @brief NRFX_DPPI_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_DPPI_ENABLED
 #define NRFX_DPPI_ENABLED 0
 #endif
-// <e> NRFX_DPPI_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+
+/**
+ * @brief NRFX_DPPI_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_DPPI_CONFIG_LOG_ENABLED
 #define NRFX_DPPI_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_DPPI_CONFIG_LOG_LEVEL  - Default severity level.
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_DPPI_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_DPPI_CONFIG_LOG_LEVEL
 #define NRFX_DPPI_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_DPPI_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_DPPI_CONFIG_INFO_COLOR
-#define NRFX_DPPI_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_DPPI_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_DPPI_CONFIG_DEBUG_COLOR
-#define NRFX_DPPI_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_EGU_ENABLED - nrfx_egu - EGU peripheral driver.
-//==========================================================
+/**
+ * @brief NRFX_EGU_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_EGU_ENABLED
 #define NRFX_EGU_ENABLED 0
 #endif
 
-// <q> NRFX_EGU0_ENABLED  - Enable EGU0 instance.
+/**
+ * @brief NRFX_EGU_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
+#ifndef NRFX_EGU_DEFAULT_CONFIG_IRQ_PRIORITY
+#define NRFX_EGU_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
+#endif
 
+/**
+ * @brief NRFX_EGU0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_EGU0_ENABLED
 #define NRFX_EGU0_ENABLED 0
 #endif
 
-// <q> NRFX_EGU1_ENABLED  - Enable EGU1 instance.
-
+/**
+ * @brief NRFX_EGU1_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_EGU1_ENABLED
 #define NRFX_EGU1_ENABLED 0
 #endif
 
-// <q> NRFX_EGU2_ENABLED  - Enable EGU2 instance.
-
+/**
+ * @brief NRFX_EGU2_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_EGU2_ENABLED
 #define NRFX_EGU2_ENABLED 0
 #endif
 
-// <q> NRFX_EGU3_ENABLED  - Enable EGU3 instance.
-
+/**
+ * @brief NRFX_EGU3_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_EGU3_ENABLED
 #define NRFX_EGU3_ENABLED 0
 #endif
 
-// <q> NRFX_EGU4_ENABLED  - Enable EGU4 instance.
-
+/**
+ * @brief NRFX_EGU4_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_EGU4_ENABLED
 #define NRFX_EGU4_ENABLED 0
 #endif
 
-// <q> NRFX_EGU5_ENABLED  - Enable EGU5 instance.
-
+/**
+ * @brief NRFX_EGU5_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_EGU5_ENABLED
 #define NRFX_EGU5_ENABLED 0
 #endif
 
-// <o> NRFX_EGU_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority.
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
-#ifndef NRFX_EGU_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_EGU_DEFAULT_CONFIG_IRQ_PRIORITY 7
-#endif
-
-// </e>
-
-// <e> NRFX_GPIOTE_ENABLED - nrfx_gpiote - GPIOTE peripheral driver.
-//==========================================================
+/**
+ * @brief NRFX_GPIOTE_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_GPIOTE_ENABLED
 #define NRFX_GPIOTE_ENABLED 0
 #endif
 
-// <o> NRFX_GPIOTE_CONFIG_NUM_OF_EVT_HANDLERS - Number of dedicated handlers
+/**
+ * @brief NRFX_GPIOTE_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
+#ifndef NRFX_GPIOTE_DEFAULT_CONFIG_IRQ_PRIORITY
+#define NRFX_GPIOTE_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
+#endif
+
+/**
+ * @brief NRFX_GPIOTE_CONFIG_NUM_OF_EVT_HANDLERS
+ *
+ * Integer value. Minimum: 0 Maximum: 15
+ */
 #ifndef NRFX_GPIOTE_CONFIG_NUM_OF_EVT_HANDLERS
 #define NRFX_GPIOTE_CONFIG_NUM_OF_EVT_HANDLERS 2
 #endif
 
-// <o> NRFX_GPIOTE_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority.
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
-#ifndef NRFX_GPIOTE_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_GPIOTE_DEFAULT_CONFIG_IRQ_PRIORITY 7
-#endif
-
-// <e> NRFX_GPIOTE_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_GPIOTE_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_GPIOTE_CONFIG_LOG_ENABLED
 #define NRFX_GPIOTE_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_GPIOTE_CONFIG_LOG_LEVEL  - Default severity level.
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_GPIOTE_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_GPIOTE_CONFIG_LOG_LEVEL
 #define NRFX_GPIOTE_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_GPIOTE_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_GPIOTE_CONFIG_INFO_COLOR
-#define NRFX_GPIOTE_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_GPIOTE_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_GPIOTE_CONFIG_DEBUG_COLOR
-#define NRFX_GPIOTE_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_I2S_ENABLED - nrfx_i2s - I2S peripheral driver.
-//==========================================================
+/**
+ * @brief NRFX_I2S_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_I2S_ENABLED
 #define NRFX_I2S_ENABLED 0
 #endif
 
-// <o> NRFX_I2S_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority.
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_I2S_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_I2S_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_I2S_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_I2S_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_I2S_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_I2S_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_I2S_CONFIG_LOG_ENABLED
 #define NRFX_I2S_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_I2S_CONFIG_LOG_LEVEL  - Default severity level.
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_I2S_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_I2S_CONFIG_LOG_LEVEL
 #define NRFX_I2S_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_I2S_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_I2S_CONFIG_INFO_COLOR
-#define NRFX_I2S_CONFIG_INFO_COLOR 0
+/**
+ * @brief NRFX_I2S0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_I2S0_ENABLED
+#define NRFX_I2S0_ENABLED 0
 #endif
 
-// <o> NRFX_I2S_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_I2S_CONFIG_DEBUG_COLOR
-#define NRFX_I2S_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_IPC_ENABLED - nrfx_ipc - IPC peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_IPC_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_IPC_ENABLED
 #define NRFX_IPC_ENABLED 0
 #endif
 
-// </e>
-
-// <e> NRFX_LPCOMP_ENABLED - nrfx_lpcomp - LPCOMP peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_LPCOMP_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_LPCOMP_ENABLED
 #define NRFX_LPCOMP_ENABLED 0
 #endif
 
-// <o> NRFX_LPCOMP_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_LPCOMP_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_LPCOMP_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_LPCOMP_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_LPCOMP_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_LPCOMP_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_LPCOMP_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_LPCOMP_CONFIG_LOG_ENABLED
 #define NRFX_LPCOMP_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_LPCOMP_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_LPCOMP_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_LPCOMP_CONFIG_LOG_LEVEL
 #define NRFX_LPCOMP_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_LPCOMP_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_LPCOMP_CONFIG_INFO_COLOR
-#define NRFX_LPCOMP_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_LPCOMP_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_LPCOMP_CONFIG_DEBUG_COLOR
-#define NRFX_LPCOMP_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_NFCT_ENABLED - nrfx_nfct - NFCT peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_NFCT_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_NFCT_ENABLED
 #define NRFX_NFCT_ENABLED 0
 #endif
-// <o> NRFX_NFCT_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
 
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_NFCT_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_NFCT_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_NFCT_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_NFCT_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <o> NRFX_NFCT_CONFIG_TIMER_INSTANCE_ID - Timer instance used for workarounds in the driver.
-
-// <0=> 0
-// <1=> 1
-// <2=> 2
-
+/**
+ * @brief NRFX_NFCT_CONFIG_TIMER_INSTANCE_ID - Timer instance used for workarounds in the driver.
+ *
+ * Integer value. Minimum: 0 Maximum: 5
+ */
 #ifndef NRFX_NFCT_CONFIG_TIMER_INSTANCE_ID
 #define NRFX_NFCT_CONFIG_TIMER_INSTANCE_ID 2
 #endif
 
-// <e> NRFX_NFCT_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_NFCT_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_NFCT_CONFIG_LOG_ENABLED
 #define NRFX_NFCT_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_NFCT_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_NFCT_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_NFCT_CONFIG_LOG_LEVEL
 #define NRFX_NFCT_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_NFCT_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_NFCT_CONFIG_INFO_COLOR
-#define NRFX_NFCT_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_NFCT_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_NFCT_CONFIG_DEBUG_COLOR
-#define NRFX_NFCT_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_NVMC_ENABLED - nrfx_nvmc - NVMC peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_NVMC_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_NVMC_ENABLED
 #define NRFX_NVMC_ENABLED 0
 #endif
 
-// </e>
-
-// <e> NRFX_PDM_ENABLED - nrfx_pdm - PDM peripheral driver.
-//==========================================================
+/**
+ * @brief NRFX_PDM_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_PDM_ENABLED
 #define NRFX_PDM_ENABLED 0
 #endif
 
-// <o> NRFX_PDM_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority.
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_PDM_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_PDM_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_PDM_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_PDM_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_PDM_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_PDM_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_PDM_CONFIG_LOG_ENABLED
 #define NRFX_PDM_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_PDM_CONFIG_LOG_LEVEL  - Default severity level.
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_PDM_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_PDM_CONFIG_LOG_LEVEL
 #define NRFX_PDM_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_PDM_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_PDM_CONFIG_INFO_COLOR
-#define NRFX_PDM_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_PDM_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_PDM_CONFIG_DEBUG_COLOR
-#define NRFX_PDM_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_POWER_ENABLED - nrfx_power - POWER peripheral driver.
-//==========================================================
+/**
+ * @brief NRFX_POWER_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_POWER_ENABLED
 #define NRFX_POWER_ENABLED 0
 #endif
-// <o> NRFX_POWER_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority.
 
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_POWER_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_POWER_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_POWER_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_POWER_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// </e>
-
-// <e> NRFX_PRS_ENABLED - nrfx_prs - Peripheral Resource Sharing (PRS) module.
-//==========================================================
+/**
+ * @brief NRFX_PRS_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_PRS_ENABLED
 #define NRFX_PRS_ENABLED 0
 #endif
-// <q> NRFX_PRS_BOX_0_ENABLED  - Enables box 0 in the module.
 
-
-#ifndef NRFX_PRS_BOX_0_ENABLED
-#define NRFX_PRS_BOX_0_ENABLED 0
-#endif
-
-// <q> NRFX_PRS_BOX_1_ENABLED  - Enables box 1 in the module.
-
-
-#ifndef NRFX_PRS_BOX_1_ENABLED
-#define NRFX_PRS_BOX_1_ENABLED 0
-#endif
-
-// <q> NRFX_PRS_BOX_2_ENABLED  - Enables box 2 in the module.
-
-
-#ifndef NRFX_PRS_BOX_2_ENABLED
-#define NRFX_PRS_BOX_2_ENABLED 0
-#endif
-
-// <q> NRFX_PRS_BOX_3_ENABLED  - Enables box 3 in the module.
-
-
-#ifndef NRFX_PRS_BOX_3_ENABLED
-#define NRFX_PRS_BOX_3_ENABLED 0
-#endif
-
-// <q> NRFX_PRS_BOX_4_ENABLED  - Enables box 4 in the module.
-
-
-#ifndef NRFX_PRS_BOX_4_ENABLED
-#define NRFX_PRS_BOX_4_ENABLED 0
-#endif
-
-
-// <e> NRFX_PRS_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_PRS_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_PRS_CONFIG_LOG_ENABLED
 #define NRFX_PRS_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_PRS_CONFIG_LOG_LEVEL  - Default severity level.
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_PRS_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_PRS_CONFIG_LOG_LEVEL
 #define NRFX_PRS_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_PRS_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_PRS_CONFIG_INFO_COLOR
-#define NRFX_PRS_CONFIG_INFO_COLOR 0
+/**
+ * @brief NRFX_PRS_BOX_0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_PRS_BOX_0_ENABLED
+#define NRFX_PRS_BOX_0_ENABLED 0
 #endif
 
-// <o> NRFX_PRS_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_PRS_CONFIG_DEBUG_COLOR
-#define NRFX_PRS_CONFIG_DEBUG_COLOR 0
+/**
+ * @brief NRFX_PRS_BOX_1_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_PRS_BOX_1_ENABLED
+#define NRFX_PRS_BOX_1_ENABLED 0
 #endif
 
-// </e>
+/**
+ * @brief NRFX_PRS_BOX_2_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_PRS_BOX_2_ENABLED
+#define NRFX_PRS_BOX_2_ENABLED 0
+#endif
 
-// </e>
+/**
+ * @brief NRFX_PRS_BOX_3_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_PRS_BOX_3_ENABLED
+#define NRFX_PRS_BOX_3_ENABLED 0
+#endif
 
-// <e> NRFX_PWM_ENABLED - nrfx_pwm - PWM peripheral driver.
-//==========================================================
+/**
+ * @brief NRFX_PRS_BOX_4_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_PRS_BOX_4_ENABLED
+#define NRFX_PRS_BOX_4_ENABLED 0
+#endif
+
+/**
+ * @brief NRFX_PWM_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_PWM_ENABLED
 #define NRFX_PWM_ENABLED 0
 #endif
-// <q> NRFX_PWM0_ENABLED  - Enables PWM0 instance.
 
-
-#ifndef NRFX_PWM0_ENABLED
-#define NRFX_PWM0_ENABLED 0
-#endif
-
-// <q> NRFX_PWM1_ENABLED  - Enables PWM1 instance.
-
-
-#ifndef NRFX_PWM1_ENABLED
-#define NRFX_PWM1_ENABLED 0
-#endif
-
-// <q> NRFX_PWM2_ENABLED  - Enables PWM2 instance.
-
-
-#ifndef NRFX_PWM2_ENABLED
-#define NRFX_PWM2_ENABLED 0
-#endif
-
-// <q> NRFX_PWM3_ENABLED  - Enables PWM3 instance.
-
-
-#ifndef NRFX_PWM3_ENABLED
-#define NRFX_PWM3_ENABLED 0
-#endif
-
-// <o> NRFX_PWM_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority.
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_PWM_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_PWM_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_PWM_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_PWM_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_PWM_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_PWM_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_PWM_CONFIG_LOG_ENABLED
 #define NRFX_PWM_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_PWM_CONFIG_LOG_LEVEL  - Default severity level.
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_PWM_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_PWM_CONFIG_LOG_LEVEL
 #define NRFX_PWM_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_PWM_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_PWM_CONFIG_INFO_COLOR
-#define NRFX_PWM_CONFIG_INFO_COLOR 0
+/**
+ * @brief NRFX_PWM0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_PWM0_ENABLED
+#define NRFX_PWM0_ENABLED 0
 #endif
 
-// <o> NRFX_PWM_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_PWM_CONFIG_DEBUG_COLOR
-#define NRFX_PWM_CONFIG_DEBUG_COLOR 0
+/**
+ * @brief NRFX_PWM1_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_PWM1_ENABLED
+#define NRFX_PWM1_ENABLED 0
 #endif
 
-// </e>
+/**
+ * @brief NRFX_PWM2_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_PWM2_ENABLED
+#define NRFX_PWM2_ENABLED 0
+#endif
 
-// </e>
+/**
+ * @brief NRFX_PWM3_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_PWM3_ENABLED
+#define NRFX_PWM3_ENABLED 0
+#endif
 
-// <e> NRFX_QDEC_ENABLED - nrfx_qdec - QDEC peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_QDEC_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_QDEC_ENABLED
 #define NRFX_QDEC_ENABLED 0
 #endif
 
-// <o> NRFX_QDEC_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_QDEC_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_QDEC_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_QDEC_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_QDEC_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_QDEC_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_QDEC_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_QDEC_CONFIG_LOG_ENABLED
 #define NRFX_QDEC_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_QDEC_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_QDEC_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_QDEC_CONFIG_LOG_LEVEL
 #define NRFX_QDEC_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_QDEC_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_QDEC_CONFIG_INFO_COLOR
-#define NRFX_QDEC_CONFIG_INFO_COLOR 0
+/**
+ * @brief NRFX_QDEC0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_QDEC0_ENABLED
+#define NRFX_QDEC0_ENABLED 0
 #endif
 
-// <o> NRFX_QDEC_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_QDEC_CONFIG_DEBUG_COLOR
-#define NRFX_QDEC_CONFIG_DEBUG_COLOR 0
+/**
+ * @brief NRFX_QDEC1_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_QDEC1_ENABLED
+#define NRFX_QDEC1_ENABLED 0
 #endif
 
-// </e>
-
-// </e>
-
-// <e> NRFX_QSPI_ENABLED - nrfx_qspi - QSPI peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_QSPI_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_QSPI_ENABLED
 #define NRFX_QSPI_ENABLED 0
 #endif
 
-// <o> NRFX_QSPI_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_QSPI_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_QSPI_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_QSPI_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_QSPI_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// </e>
-
-// <e> NRFX_RTC_ENABLED - nrfx_rtc - RTC peripheral driver.
-//==========================================================
+/**
+ * @brief NRFX_RTC_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_RTC_ENABLED
 #define NRFX_RTC_ENABLED 0
 #endif
-// <q> NRFX_RTC0_ENABLED  - Enables RTC0 instance.
 
-
-#ifndef NRFX_RTC0_ENABLED
-#define NRFX_RTC0_ENABLED 0
-#endif
-
-// <q> NRFX_RTC1_ENABLED  - Enables RTC1 instance.
-
-
-#ifndef NRFX_RTC1_ENABLED
-#define NRFX_RTC1_ENABLED 0
-#endif
-
-// <o> NRFX_RTC_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority.
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_RTC_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_RTC_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_RTC_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_RTC_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_RTC_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_RTC_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_RTC_CONFIG_LOG_ENABLED
 #define NRFX_RTC_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_RTC_CONFIG_LOG_LEVEL  - Default severity level.
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_RTC_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_RTC_CONFIG_LOG_LEVEL
 #define NRFX_RTC_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_RTC_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_RTC_CONFIG_INFO_COLOR
-#define NRFX_RTC_CONFIG_INFO_COLOR 0
+/**
+ * @brief NRFX_RTC0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_RTC0_ENABLED
+#define NRFX_RTC0_ENABLED 0
 #endif
 
-// <o> NRFX_RTC_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_RTC_CONFIG_DEBUG_COLOR
-#define NRFX_RTC_CONFIG_DEBUG_COLOR 0
+/**
+ * @brief NRFX_RTC1_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_RTC1_ENABLED
+#define NRFX_RTC1_ENABLED 0
 #endif
 
-// </e>
-
-// </e>
-
-// <e> NRFX_SAADC_ENABLED - nrfx_saadc - SAADC peripheral driver.
-//==========================================================
+/**
+ * @brief NRFX_SAADC_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_SAADC_ENABLED
 #define NRFX_SAADC_ENABLED 0
 #endif
 
-// <o> NRFX_SAADC_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority.
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_SAADC_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_SAADC_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_SAADC_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_SAADC_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_SAADC_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_SAADC_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_SAADC_CONFIG_LOG_ENABLED
 #define NRFX_SAADC_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_SAADC_CONFIG_LOG_LEVEL  - Default severity level.
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_SAADC_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_SAADC_CONFIG_LOG_LEVEL
 #define NRFX_SAADC_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_SAADC_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_SAADC_CONFIG_INFO_COLOR
-#define NRFX_SAADC_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_SAADC_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_SAADC_CONFIG_DEBUG_COLOR
-#define NRFX_SAADC_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_SPIM_ENABLED - nrfx_spim - SPIM peripheral driver.
-//==========================================================
+/**
+ * @brief NRFX_SPIM_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_SPIM_ENABLED
 #define NRFX_SPIM_ENABLED 0
 #endif
-// <q> NRFX_SPIM0_ENABLED  - Enables SPIM0 instance.
 
-
-#ifndef NRFX_SPIM0_ENABLED
-#define NRFX_SPIM0_ENABLED 0
-#endif
-
-// <q> NRFX_SPIM1_ENABLED  - Enables SPIM1 instance.
-
-
-#ifndef NRFX_SPIM1_ENABLED
-#define NRFX_SPIM1_ENABLED 0
-#endif
-
-// <q> NRFX_SPIM2_ENABLED  - Enables SPIM2 instance.
-
-
-#ifndef NRFX_SPIM2_ENABLED
-#define NRFX_SPIM2_ENABLED 0
-#endif
-
-// <q> NRFX_SPIM3_ENABLED  - Enables SPIM3 instance.
-
-
-#ifndef NRFX_SPIM3_ENABLED
-#define NRFX_SPIM3_ENABLED 0
-#endif
-
-// <q> NRFX_SPIM4_ENABLED  - Enables SPIM4 instance.
-
-
-#ifndef NRFX_SPIM4_ENABLED
-#define NRFX_SPIM4_ENABLED 0
-#endif
-
-// <q> NRFX_SPIM_EXTENDED_ENABLED  - Enable extended SPIM features
-
-
-#ifndef NRFX_SPIM_EXTENDED_ENABLED
-#define NRFX_SPIM_EXTENDED_ENABLED 0
-#endif
-
-// <o> NRFX_SPIM_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority.
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_SPIM_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_SPIM_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_SPIM_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_SPIM_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_SPIM_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_SPIM_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_SPIM_CONFIG_LOG_ENABLED
 #define NRFX_SPIM_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_SPIM_CONFIG_LOG_LEVEL  - Default severity level.
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_SPIM_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_SPIM_CONFIG_LOG_LEVEL
 #define NRFX_SPIM_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_SPIM_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_SPIM_CONFIG_INFO_COLOR
-#define NRFX_SPIM_CONFIG_INFO_COLOR 0
+/**
+ * @brief NRFX_SPIM0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPIM0_ENABLED
+#define NRFX_SPIM0_ENABLED 0
 #endif
 
-// <o> NRFX_SPIM_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_SPIM_CONFIG_DEBUG_COLOR
-#define NRFX_SPIM_CONFIG_DEBUG_COLOR 0
+/**
+ * @brief NRFX_SPIM1_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPIM1_ENABLED
+#define NRFX_SPIM1_ENABLED 0
 #endif
 
-// </e>
+/**
+ * @brief NRFX_SPIM4_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPIM4_ENABLED
+#define NRFX_SPIM4_ENABLED 0
+#endif
 
-// </e>
+/**
+ * @brief NRFX_SPIM2_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPIM2_ENABLED
+#define NRFX_SPIM2_ENABLED 0
+#endif
 
-// <e> NRFX_SPIS_ENABLED - nrfx_spis - SPIS peripheral driver.
-//==========================================================
+/**
+ * @brief NRFX_SPIM3_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPIM3_ENABLED
+#define NRFX_SPIM3_ENABLED 0
+#endif
+
+/**
+ * @brief NRFX_SPIS_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_SPIS_ENABLED
 #define NRFX_SPIS_ENABLED 0
 #endif
-// <q> NRFX_SPIS0_ENABLED  - Enables SPIS0 instance.
 
-
-#ifndef NRFX_SPIS0_ENABLED
-#define NRFX_SPIS0_ENABLED 0
-#endif
-
-// <q> NRFX_SPIS1_ENABLED  - Enables SPIS1 instance.
-
-
-#ifndef NRFX_SPIS1_ENABLED
-#define NRFX_SPIS1_ENABLED 0
-#endif
-
-// <q> NRFX_SPIS2_ENABLED  - Enables SPIS2 instance.
-
-
-#ifndef NRFX_SPIS2_ENABLED
-#define NRFX_SPIS2_ENABLED 0
-#endif
-
-// <q> NRFX_SPIS3_ENABLED  - Enables SPIS3 instance.
-
-
-#ifndef NRFX_SPIS3_ENABLED
-#define NRFX_SPIS3_ENABLED 0
-#endif
-
-// <o> NRFX_SPIS_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority.
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_SPIS_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_SPIS_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_SPIS_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_SPIS_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_SPIS_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_SPIS_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_SPIS_CONFIG_LOG_ENABLED
 #define NRFX_SPIS_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_SPIS_CONFIG_LOG_LEVEL  - Default severity level.
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_SPIS_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_SPIS_CONFIG_LOG_LEVEL
 #define NRFX_SPIS_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_SPIS_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_SPIS_CONFIG_INFO_COLOR
-#define NRFX_SPIS_CONFIG_INFO_COLOR 0
+/**
+ * @brief NRFX_SPIS0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPIS0_ENABLED
+#define NRFX_SPIS0_ENABLED 0
 #endif
 
-// <o> NRFX_SPIS_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_SPIS_CONFIG_DEBUG_COLOR
-#define NRFX_SPIS_CONFIG_DEBUG_COLOR 0
+/**
+ * @brief NRFX_SPIS1_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPIS1_ENABLED
+#define NRFX_SPIS1_ENABLED 0
 #endif
 
-// </e>
+/**
+ * @brief NRFX_SPIS2_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPIS2_ENABLED
+#define NRFX_SPIS2_ENABLED 0
+#endif
 
-// </e>
+/**
+ * @brief NRFX_SPIS3_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPIS3_ENABLED
+#define NRFX_SPIS3_ENABLED 0
+#endif
 
-// <q> NRFX_SYSTICK_ENABLED  - nrfx_systick - ARM(R) SysTick driver.
-
-
+/**
+ * @brief NRFX_SYSTICK_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_SYSTICK_ENABLED
 #define NRFX_SYSTICK_ENABLED 0
 #endif
 
-// <e> NRFX_TIMER_ENABLED - nrfx_timer - TIMER periperal driver.
-//==========================================================
+/**
+ * @brief NRFX_TIMER_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_TIMER_ENABLED
 #define NRFX_TIMER_ENABLED 0
 #endif
-// <q> NRFX_TIMER0_ENABLED  - Enables TIMER0 instance.
 
-
-#ifndef NRFX_TIMER0_ENABLED
-#define NRFX_TIMER0_ENABLED 0
-#endif
-
-// <q> NRFX_TIMER1_ENABLED  - Enables TIMER1 instance.
-
-
-#ifndef NRFX_TIMER1_ENABLED
-#define NRFX_TIMER1_ENABLED 0
-#endif
-
-// <q> NRFX_TIMER2_ENABLED  - Enables TIMER2 instance.
-
-
-#ifndef NRFX_TIMER2_ENABLED
-#define NRFX_TIMER2_ENABLED 0
-#endif
-
-// <o> NRFX_TIMER_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority.
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_TIMER_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_TIMER_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_TIMER_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_TIMER_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_TIMER_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_TIMER_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_TIMER_CONFIG_LOG_ENABLED
 #define NRFX_TIMER_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_TIMER_CONFIG_LOG_LEVEL  - Default severity level.
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_TIMER_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_TIMER_CONFIG_LOG_LEVEL
 #define NRFX_TIMER_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_TIMER_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_TIMER_CONFIG_INFO_COLOR
-#define NRFX_TIMER_CONFIG_INFO_COLOR 0
+/**
+ * @brief NRFX_TIMER0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TIMER0_ENABLED
+#define NRFX_TIMER0_ENABLED 0
 #endif
 
-// <o> NRFX_TIMER_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_TIMER_CONFIG_DEBUG_COLOR
-#define NRFX_TIMER_CONFIG_DEBUG_COLOR 0
+/**
+ * @brief NRFX_TIMER1_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TIMER1_ENABLED
+#define NRFX_TIMER1_ENABLED 0
 #endif
 
-// </e>
+/**
+ * @brief NRFX_TIMER2_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TIMER2_ENABLED
+#define NRFX_TIMER2_ENABLED 0
+#endif
 
-// </e>
-
-// <e> NRFX_TWIM_ENABLED - nrfx_twim - TWIM peripheral driver.
-//==========================================================
+/**
+ * @brief NRFX_TWIM_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_TWIM_ENABLED
 #define NRFX_TWIM_ENABLED 0
 #endif
-// <q> NRFX_TWIM0_ENABLED  - Enables TWIM0 instance.
 
-
-#ifndef NRFX_TWIM0_ENABLED
-#define NRFX_TWIM0_ENABLED 0
-#endif
-
-// <q> NRFX_TWIM1_ENABLED  - Enables TWIM1 instance.
-
-
-#ifndef NRFX_TWIM1_ENABLED
-#define NRFX_TWIM1_ENABLED 0
-#endif
-
-// <q> NRFX_TWIM2_ENABLED  - Enables TWIM2 instance.
-
-
-#ifndef NRFX_TWIM2_ENABLED
-#define NRFX_TWIM2_ENABLED 0
-#endif
-
-// <q> NRFX_TWIM3_ENABLED  - Enables TWIM3 instance.
-
-
-#ifndef NRFX_TWIM3_ENABLED
-#define NRFX_TWIM3_ENABLED 0
-#endif
-
-// <o> NRFX_TWIM_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority.
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_TWIM_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_TWIM_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_TWIM_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_TWIM_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_TWIM_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_TWIM_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_TWIM_CONFIG_LOG_ENABLED
 #define NRFX_TWIM_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_TWIM_CONFIG_LOG_LEVEL  - Default severity level.
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_TWIM_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_TWIM_CONFIG_LOG_LEVEL
 #define NRFX_TWIM_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_TWIM_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_TWIM_CONFIG_INFO_COLOR
-#define NRFX_TWIM_CONFIG_INFO_COLOR 0
+/**
+ * @brief NRFX_TWIM0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWIM0_ENABLED
+#define NRFX_TWIM0_ENABLED 0
 #endif
 
-// <o> NRFX_TWIM_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_TWIM_CONFIG_DEBUG_COLOR
-#define NRFX_TWIM_CONFIG_DEBUG_COLOR 0
+/**
+ * @brief NRFX_TWIM1_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWIM1_ENABLED
+#define NRFX_TWIM1_ENABLED 0
 #endif
 
-// </e>
+/**
+ * @brief NRFX_TWIM2_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWIM2_ENABLED
+#define NRFX_TWIM2_ENABLED 0
+#endif
 
-// </e>
+/**
+ * @brief NRFX_TWIM3_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWIM3_ENABLED
+#define NRFX_TWIM3_ENABLED 0
+#endif
 
-// <e> NRFX_TWIS_ENABLED - nrfx_twis - TWIS peripheral driver.
-//==========================================================
+/**
+ * @brief NRFX_TWIS_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_TWIS_ENABLED
 #define NRFX_TWIS_ENABLED 0
 #endif
 
-// <q> NRFX_TWIS0_ENABLED  - Enables TWIS0 instance.
-
-#ifndef NRFX_TWIS0_ENABLED
-#define NRFX_TWIS0_ENABLED 0
+/**
+ * @brief NRFX_TWIS_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
+#ifndef NRFX_TWIS_DEFAULT_CONFIG_IRQ_PRIORITY
+#define NRFX_TWIS_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <q> NRFX_TWIS1_ENABLED  - Enables TWIS1 instance.
-
-#ifndef NRFX_TWIS1_ENABLED
-#define NRFX_TWIS1_ENABLED 0
+/**
+ * @brief NRFX_TWIS_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWIS_CONFIG_LOG_ENABLED
+#define NRFX_TWIS_CONFIG_LOG_ENABLED 0
 #endif
 
-// <q> NRFX_TWIS2_ENABLED  - Enables TWIS2 instance.
-
-#ifndef NRFX_TWIS2_ENABLED
-#define NRFX_TWIS2_ENABLED 0
-#endif
-
-// <q> NRFX_TWIS3_ENABLED  - Enables TWIS3 instance.
-
-#ifndef NRFX_TWIS3_ENABLED
-#define NRFX_TWIS3_ENABLED 0
-#endif
-
-// <q> NRFX_TWIS_ASSUME_INIT_AFTER_RESET_ONLY  - Assumes that any instance would be initialized only once.
-
-// <i> Optimization flag. Registers used by TWIS are shared by other peripherals. Normally, during initialization driver tries to clear all registers to known state before doing the initialization itself. This gives initialization safe procedure, no matter when it would be called. If you activate TWIS only once and do never uninitialize it - set this flag to 1 what gives more optimal code.
-
+/**
+ * @brief NRFX_TWIS_ASSUME_INIT_AFTER_RESET_ONLY - Assume that any instance would be initialized only once.
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_TWIS_ASSUME_INIT_AFTER_RESET_ONLY
 #define NRFX_TWIS_ASSUME_INIT_AFTER_RESET_ONLY 0
 #endif
 
-// <q> NRFX_TWIS_NO_SYNC_MODE  - Removes support for synchronous mode.
-
-// <i> Synchronous mode would be used in specific situations. And it uses some additional code and data memory to safely process state machine by polling it in status functions. If this functionality is not required it may be disabled to free some resources.
-
+/**
+ * @brief NRFX_TWIS_NO_SYNC_MODE - Remove support for synchronous mode.
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_TWIS_NO_SYNC_MODE
 #define NRFX_TWIS_NO_SYNC_MODE 0
 #endif
 
-// <o> NRFX_TWIS_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority.
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
-#ifndef NRFX_TWIS_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_TWIS_DEFAULT_CONFIG_IRQ_PRIORITY 7
-#endif
-
-// <e> NRFX_TWIS_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
-#ifndef NRFX_TWIS_CONFIG_LOG_ENABLED
-#define NRFX_TWIS_CONFIG_LOG_ENABLED 0
-#endif
-// <o> NRFX_TWIS_CONFIG_LOG_LEVEL  - Default severity level.
-
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_TWIS_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_TWIS_CONFIG_LOG_LEVEL
 #define NRFX_TWIS_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_TWIS_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_TWIS_CONFIG_INFO_COLOR
-#define NRFX_TWIS_CONFIG_INFO_COLOR 0
+/**
+ * @brief NRFX_TWIS0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWIS0_ENABLED
+#define NRFX_TWIS0_ENABLED 0
 #endif
 
-// <o> NRFX_TWIS_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_TWIS_CONFIG_DEBUG_COLOR
-#define NRFX_TWIS_CONFIG_DEBUG_COLOR 0
+/**
+ * @brief NRFX_TWIS1_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWIS1_ENABLED
+#define NRFX_TWIS1_ENABLED 0
 #endif
 
-// </e>
+/**
+ * @brief NRFX_TWIS2_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWIS2_ENABLED
+#define NRFX_TWIS2_ENABLED 0
+#endif
 
-// </e>
+/**
+ * @brief NRFX_TWIS3_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWIS3_ENABLED
+#define NRFX_TWIS3_ENABLED 0
+#endif
 
-// <e> NRFX_UARTE_ENABLED - nrfx_uarte - UARTE peripheral driver.
-//==========================================================
+/**
+ * @brief NRFX_UARTE_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_UARTE_ENABLED
 #define NRFX_UARTE_ENABLED 0
 #endif
-// <o> NRFX_UARTE0_ENABLED - Enables UARTE0 instances
-#ifndef NRFX_UARTE0_ENABLED
-#define NRFX_UARTE0_ENABLED 0
-#endif
 
-// <o> NRFX_UARTE1_ENABLED - Enables UARTE1 instance.
-#ifndef NRFX_UARTE1_ENABLED
-#define NRFX_UARTE1_ENABLED 0
-#endif
-
-// <o> NRFX_UARTE2_ENABLED - Enables UARTE2 instance.
-#ifndef NRFX_UARTE2_ENABLED
-#define NRFX_UARTE2_ENABLED 0
-#endif
-
-// <o> NRFX_UARTE3_ENABLED - Enables UARTE3 instance.
-#ifndef NRFX_UARTE3_ENABLED
-#define NRFX_UARTE3_ENABLED 0
-#endif
-
-// <o> NRFX_UARTE_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority.
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_UARTE_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_UARTE_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_UARTE_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_UARTE_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_UARTE_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_UARTE_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_UARTE_CONFIG_LOG_ENABLED
 #define NRFX_UARTE_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_UARTE_CONFIG_LOG_LEVEL  - Default severity level.
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_UARTE_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_UARTE_CONFIG_LOG_LEVEL
 #define NRFX_UARTE_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_UARTE_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_UARTE_CONFIG_INFO_COLOR
-#define NRFX_UARTE_CONFIG_INFO_COLOR 0
+/**
+ * @brief NRFX_UARTE0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_UARTE0_ENABLED
+#define NRFX_UARTE0_ENABLED 0
 #endif
 
-// <o> NRFX_UARTE_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_UARTE_CONFIG_DEBUG_COLOR
-#define NRFX_UARTE_CONFIG_DEBUG_COLOR 0
+/**
+ * @brief NRFX_UARTE1_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_UARTE1_ENABLED
+#define NRFX_UARTE1_ENABLED 0
 #endif
 
-// </e>
+/**
+ * @brief NRFX_UARTE2_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_UARTE2_ENABLED
+#define NRFX_UARTE2_ENABLED 0
+#endif
 
-// </e>
+/**
+ * @brief NRFX_UARTE3_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_UARTE3_ENABLED
+#define NRFX_UARTE3_ENABLED 0
+#endif
 
-// <e> NRFX_USBD_ENABLED - nrfx_usbd - USBD peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_USBD_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_USBD_ENABLED
 #define NRFX_USBD_ENABLED 0
 #endif
-// <o> NRFX_USBD_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
 
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_USBD_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_USBD_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_USBD_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_USBD_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <q> USBD_CONFIG_DMASCHEDULER_ISO_BOOST  - Give priority to isochronous transfers
-
-// <i> This option gives priority to isochronous transfers.
-// <i> Enabling it assures that isochronous transfers are always processed,
-// <i> even if multiple other transfers are pending.
-// <i> Isochronous endpoints are prioritized before the usbd_dma_scheduler_algorithm
-// <i> function is called, so the option is independent of the algorithm chosen.
-
+/**
+ * @brief NRFX_USBD_CONFIG_DMASCHEDULER_ISO_BOOST - Give priority to isochronous transfers
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_USBD_CONFIG_DMASCHEDULER_ISO_BOOST
 #define NRFX_USBD_CONFIG_DMASCHEDULER_ISO_BOOST 1
 #endif
 
-// <q> USBD_CONFIG_ISO_IN_ZLP  - Respond to an IN token on ISO IN endpoint with ZLP when no data is ready
-
-
-// <i> If set, ISO IN endpoint will respond to an IN token with ZLP when no data is ready to be sent.
-// <i> Else, there will be no response.
-
+/**
+ * @brief NRFX_USBD_CONFIG_ISO_IN_ZLP - Respond to an IN token on ISO IN endpoint with ZLP when no data is ready.
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_USBD_CONFIG_ISO_IN_ZLP
 #define NRFX_USBD_CONFIG_ISO_IN_ZLP 0
 #endif
 
-// <e> NRFX_USBD_CONFIG_LOG_ENABLED - Enable logging in the module
-//==========================================================
+/**
+ * @brief NRFX_USBD_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_USBD_CONFIG_LOG_ENABLED
 #define NRFX_USBD_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_USBD_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_USBD_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_USBD_CONFIG_LOG_LEVEL
 #define NRFX_USBD_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_USBD_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_USBD_CONFIG_INFO_COLOR
-#define NRFX_USBD_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_USBD_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_USBD_CONFIG_DEBUG_COLOR
-#define NRFX_USBD_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_USBREG_ENABLED - nrfx_usbreg - USBREG peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_USBREG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_USBREG_ENABLED
 #define NRFX_USBREG_ENABLED 0
 #endif
-// <o> NRFX_USBREG_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
 
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_USBREG_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_USBREG_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_USBREG_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_USBREG_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// </e>
-
-// </e>
-
-// <e> NRFX_WDT_ENABLED - nrfx_wdt - WDT peripheral driver.
-//==========================================================
+/**
+ * @brief NRFX_WDT_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_WDT_ENABLED
 #define NRFX_WDT_ENABLED 0
 #endif
-// <q> NRFX_WDT0_ENABLED  - Enable WDT0 instance.
 
-
-#ifndef NRFX_WDT0_ENABLED
-#define NRFX_WDT0_ENABLED 0
+/**
+ * @brief NRFX_WDT_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
+#ifndef NRFX_WDT_DEFAULT_CONFIG_IRQ_PRIORITY
+#define NRFX_WDT_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <q> NRFX_WDT1_ENABLED  - Enable WDT1 instance.
-
-
-#ifndef NRFX_WDT1_ENABLED
-#define NRFX_WDT1_ENABLED 0
-#endif
-
-// <o> NRFX_WDT_CONFIG_NO_IRQ  - Remove WDT IRQ handling from WDT driver.
-
-// <0=> Include WDT IRQ handling
-// <1=> Remove WDT IRQ handling
-
+/**
+ * @brief NRFX_WDT_CONFIG_NO_IRQ - Remove WDT IRQ handling from WDT driver
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_WDT_CONFIG_NO_IRQ
 #define NRFX_WDT_CONFIG_NO_IRQ 0
 #endif
 
-// <o> NRFX_WDT_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority.
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
-#ifndef NRFX_WDT_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_WDT_DEFAULT_CONFIG_IRQ_PRIORITY 7
-#endif
-
-// <e> NRFX_WDT_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_WDT_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_WDT_CONFIG_LOG_ENABLED
 #define NRFX_WDT_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_WDT_CONFIG_LOG_LEVEL  - Default severity level.
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_WDT_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_WDT_CONFIG_LOG_LEVEL
 #define NRFX_WDT_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_WDT_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_WDT_CONFIG_INFO_COLOR
-#define NRFX_WDT_CONFIG_INFO_COLOR 0
+/**
+ * @brief NRFX_WDT0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_WDT0_ENABLED
+#define NRFX_WDT0_ENABLED 0
 #endif
 
-// <o> NRFX_WDT_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_WDT_CONFIG_DEBUG_COLOR
-#define NRFX_WDT_CONFIG_DEBUG_COLOR 0
+/**
+ * @brief NRFX_WDT1_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_WDT1_ENABLED
+#define NRFX_WDT1_ENABLED 0
 #endif
-
-// </e>
-
-// </e>
-
-// </h>
 
 #endif // NRFX_CONFIG_NRF5340_APPLICATION_H__

--- a/nrfx/templates/nrfx_config_nrf5340_network.h
+++ b/nrfx/templates/nrfx_config_nrf5340_network.h
@@ -85,1183 +85,821 @@
 #define NRF_VREQCTRL   NRF_VREQCTRL_NS
 #define NRF_WDT        NRF_WDT_NS
 
-// <<< Use Configuration Wizard in Context Menu >>>\n
+/**
+ * @brief NRFX_DEFAULT_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
+#ifndef NRFX_DEFAULT_IRQ_PRIORITY
+#define NRFX_DEFAULT_IRQ_PRIORITY 7
+#endif
 
-// <h> nRF_Drivers
-
-// <e> NRFX_CLOCK_ENABLED - nrfx_clock - CLOCK peripheral driver.
-//==========================================================
+/**
+ * @brief NRFX_CLOCK_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_CLOCK_ENABLED
 #define NRFX_CLOCK_ENABLED 0
 #endif
-// <o> NRFX_CLOCK_CONFIG_LF_SRC  - LF clock source.
 
-// <0=> ULP
-// <1=> RC
-// <2=> XTAL
-// <3=> Synth
-
+/**
+ * @brief NRFX_CLOCK_CONFIG_LF_SRC
+ *
+ * Integer value.
+ * Supported values:
+ * - RC    = 1
+ * - XTAL  = 2
+ * - Synth = 3
+ */
 #ifndef NRFX_CLOCK_CONFIG_LF_SRC
 #define NRFX_CLOCK_CONFIG_LF_SRC 2
 #endif
 
-// <q> NRFX_CLOCK_CONFIG_LF_CAL_ENABLED  - Enables LF Clock Calibration Support
-
+/**
+ * @brief NRFX_CLOCK_CONFIG_LF_CAL_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_CLOCK_CONFIG_LF_CAL_ENABLED
 #define NRFX_CLOCK_CONFIG_LF_CAL_ENABLED 0
 #endif
 
-// <q> NRFX_CLOCK_CONFIG_LFXO_TWO_STAGE_ENABLED - Enables two-stage LFXO start procedure
-
-// <i> If set to a non-zero value, LFRC will be started before LFXO and corresponding
-// <i> event will be generated. It means that CPU will be woken up when LFRC
-// <i> oscillator starts, but user callback will be invoked only after LFXO
-// <i> finally starts.
-
+/**
+ * @brief NRFX_CLOCK_CONFIG_LFXO_TWO_STAGE_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_CLOCK_CONFIG_LFXO_TWO_STAGE_ENABLED
 #define NRFX_CLOCK_CONFIG_LFXO_TWO_STAGE_ENABLED 0
 #endif
 
-// <o> NRFX_CLOCK_CONFIG_HFCLK192M_SRC  - HFCLK192M source.
-
-// <0=> HFINT
-// <1=> HFXO
-
-#ifndef NRFX_CLOCK_CONFIG_HFCLK192M_SRC
-#define NRFX_CLOCK_CONFIG_HFCLK192M_SRC 1
-#endif
-
-
-// <o> NRFX_CLOCK_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority.
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_CLOCK_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_CLOCK_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_CLOCK_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_CLOCK_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_CLOCK_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_CLOCK_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_CLOCK_CONFIG_LOG_ENABLED
 #define NRFX_CLOCK_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_CLOCK_CONFIG_LOG_LEVEL  - Default severity level.
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_CLOCK_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_CLOCK_CONFIG_LOG_LEVEL
 #define NRFX_CLOCK_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_CLOCK_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_CLOCK_CONFIG_INFO_COLOR
-#define NRFX_CLOCK_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_CLOCK_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_CLOCK_CONFIG_DEBUG_COLOR
-#define NRFX_CLOCK_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_DPPI_ENABLED - nrfx_dppi - DPPI allocator.
-//==========================================================
+/**
+ * @brief NRFX_DPPI_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_DPPI_ENABLED
 #define NRFX_DPPI_ENABLED 0
 #endif
-// <e> NRFX_DPPI_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+
+/**
+ * @brief NRFX_DPPI_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_DPPI_CONFIG_LOG_ENABLED
 #define NRFX_DPPI_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_DPPI_CONFIG_LOG_LEVEL  - Default severity level.
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_DPPI_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_DPPI_CONFIG_LOG_LEVEL
 #define NRFX_DPPI_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_DPPI_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_DPPI_CONFIG_INFO_COLOR
-#define NRFX_DPPI_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_DPPI_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_DPPI_CONFIG_DEBUG_COLOR
-#define NRFX_DPPI_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_EGU_ENABLED - nrfx_egu - EGU peripheral driver.
-//==========================================================
+/**
+ * @brief NRFX_EGU_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_EGU_ENABLED
 #define NRFX_EGU_ENABLED 0
 #endif
 
-// <q> NRFX_EGU0_ENABLED  - Enable EGU0 instance.
+/**
+ * @brief NRFX_EGU_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
+#ifndef NRFX_EGU_DEFAULT_CONFIG_IRQ_PRIORITY
+#define NRFX_EGU_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
+#endif
 
+/**
+ * @brief NRFX_EGU0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_EGU0_ENABLED
 #define NRFX_EGU0_ENABLED 0
 #endif
 
-// <o> NRFX_EGU_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority.
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
-#ifndef NRFX_EGU_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_EGU_DEFAULT_CONFIG_IRQ_PRIORITY 7
-#endif
-
-// </e>
-
-// <e> NRFX_GPIOTE_ENABLED - nrfx_gpiote - GPIOTE peripheral driver.
-//==========================================================
+/**
+ * @brief NRFX_GPIOTE_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_GPIOTE_ENABLED
 #define NRFX_GPIOTE_ENABLED 0
 #endif
 
-// <o> NRFX_GPIOTE_CONFIG_NUM_OF_EVT_HANDLERS - Number of dedicated handlers
+/**
+ * @brief NRFX_GPIOTE_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
+#ifndef NRFX_GPIOTE_DEFAULT_CONFIG_IRQ_PRIORITY
+#define NRFX_GPIOTE_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
+#endif
+
+/**
+ * @brief NRFX_GPIOTE_CONFIG_NUM_OF_EVT_HANDLERS
+ *
+ * Integer value. Minimum: 0 Maximum: 15
+ */
 #ifndef NRFX_GPIOTE_CONFIG_NUM_OF_EVT_HANDLERS
 #define NRFX_GPIOTE_CONFIG_NUM_OF_EVT_HANDLERS 2
 #endif
 
-// <o> NRFX_GPIOTE_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority.
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
-#ifndef NRFX_GPIOTE_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_GPIOTE_DEFAULT_CONFIG_IRQ_PRIORITY 7
-#endif
-
-// <e> NRFX_GPIOTE_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_GPIOTE_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_GPIOTE_CONFIG_LOG_ENABLED
 #define NRFX_GPIOTE_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_GPIOTE_CONFIG_LOG_LEVEL  - Default severity level.
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_GPIOTE_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_GPIOTE_CONFIG_LOG_LEVEL
 #define NRFX_GPIOTE_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_GPIOTE_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_GPIOTE_CONFIG_INFO_COLOR
-#define NRFX_GPIOTE_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_GPIOTE_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_GPIOTE_CONFIG_DEBUG_COLOR
-#define NRFX_GPIOTE_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_IPC_ENABLED - nrfx_ipc - IPC peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_IPC_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_IPC_ENABLED
 #define NRFX_IPC_ENABLED 0
 #endif
 
-// </e>
-
-// <e> NRFX_NVMC_ENABLED - nrfx_nvmc - NVMC peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_NVMC_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_NVMC_ENABLED
 #define NRFX_NVMC_ENABLED 0
 #endif
 
-// </e>
-
-// <e> NRFX_POWER_ENABLED - nrfx_power - POWER peripheral driver.
-//==========================================================
+/**
+ * @brief NRFX_POWER_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_POWER_ENABLED
 #define NRFX_POWER_ENABLED 0
 #endif
-// <o> NRFX_POWER_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority.
 
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_POWER_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_POWER_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_POWER_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_POWER_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// </e>
-
-// <e> NRFX_PRS_ENABLED - nrfx_prs - Peripheral Resource Sharing (PRS) module.
-//==========================================================
+/**
+ * @brief NRFX_PRS_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_PRS_ENABLED
 #define NRFX_PRS_ENABLED 0
 #endif
-// <q> NRFX_PRS_BOX_0_ENABLED  - Enables box 0 in the module.
 
-
-#ifndef NRFX_PRS_BOX_0_ENABLED
-#define NRFX_PRS_BOX_0_ENABLED 0
-#endif
-
-
-// <e> NRFX_PRS_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_PRS_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_PRS_CONFIG_LOG_ENABLED
 #define NRFX_PRS_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_PRS_CONFIG_LOG_LEVEL  - Default severity level.
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_PRS_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_PRS_CONFIG_LOG_LEVEL
 #define NRFX_PRS_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_PRS_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_PRS_CONFIG_INFO_COLOR
-#define NRFX_PRS_CONFIG_INFO_COLOR 0
+/**
+ * @brief NRFX_PRS_BOX_0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_PRS_BOX_0_ENABLED
+#define NRFX_PRS_BOX_0_ENABLED 0
 #endif
 
-// <o> NRFX_PRS_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_PRS_CONFIG_DEBUG_COLOR
-#define NRFX_PRS_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_RNG_ENABLED - nrfx_rng - RNG peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_RNG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_RNG_ENABLED
 #define NRFX_RNG_ENABLED 0
 #endif
 
-// <o> NRFX_RNG_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_RNG_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_RNG_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_RNG_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_RNG_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_RNG_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_RNG_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_RNG_CONFIG_LOG_ENABLED
 #define NRFX_RNG_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_RNG_CONFIG_LOG_LEVEL  - Default Severity level
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_RNG_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_RNG_CONFIG_LOG_LEVEL
 #define NRFX_RNG_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_RNG_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_RNG_CONFIG_INFO_COLOR
-#define NRFX_RNG_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_RNG_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_RNG_CONFIG_DEBUG_COLOR
-#define NRFX_RNG_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_RTC_ENABLED - nrfx_rtc - RTC peripheral driver.
-//==========================================================
+/**
+ * @brief NRFX_RTC_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_RTC_ENABLED
 #define NRFX_RTC_ENABLED 0
 #endif
-// <q> NRFX_RTC0_ENABLED  - Enables RTC0 instance.
 
-
-#ifndef NRFX_RTC0_ENABLED
-#define NRFX_RTC0_ENABLED 0
-#endif
-
-// <q> NRFX_RTC1_ENABLED  - Enables RTC1 instance.
-
-
-#ifndef NRFX_RTC1_ENABLED
-#define NRFX_RTC1_ENABLED 0
-#endif
-
-// <o> NRFX_RTC_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority.
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_RTC_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_RTC_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_RTC_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_RTC_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_RTC_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_RTC_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_RTC_CONFIG_LOG_ENABLED
 #define NRFX_RTC_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_RTC_CONFIG_LOG_LEVEL  - Default severity level.
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_RTC_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_RTC_CONFIG_LOG_LEVEL
 #define NRFX_RTC_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_RTC_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_RTC_CONFIG_INFO_COLOR
-#define NRFX_RTC_CONFIG_INFO_COLOR 0
+/**
+ * @brief NRFX_RTC0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_RTC0_ENABLED
+#define NRFX_RTC0_ENABLED 0
 #endif
 
-// <o> NRFX_RTC_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_RTC_CONFIG_DEBUG_COLOR
-#define NRFX_RTC_CONFIG_DEBUG_COLOR 0
+/**
+ * @brief NRFX_RTC1_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_RTC1_ENABLED
+#define NRFX_RTC1_ENABLED 0
 #endif
 
-// </e>
-
-// </e>
-
-
-// <e> NRFX_SPIM_ENABLED - nrfx_spim - SPIM peripheral driver.
-//==========================================================
+/**
+ * @brief NRFX_SPIM_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_SPIM_ENABLED
 #define NRFX_SPIM_ENABLED 0
 #endif
-// <q> NRFX_SPIM0_ENABLED  - Enables SPIM0 instance.
 
-
-#ifndef NRFX_SPIM0_ENABLED
-#define NRFX_SPIM0_ENABLED 0
-#endif
-
-
-// <o> NRFX_SPIM_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority.
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_SPIM_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_SPIM_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_SPIM_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_SPIM_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_SPIM_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_SPIM_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_SPIM_CONFIG_LOG_ENABLED
 #define NRFX_SPIM_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_SPIM_CONFIG_LOG_LEVEL  - Default severity level.
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_SPIM_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_SPIM_CONFIG_LOG_LEVEL
 #define NRFX_SPIM_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_SPIM_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_SPIM_CONFIG_INFO_COLOR
-#define NRFX_SPIM_CONFIG_INFO_COLOR 0
+/**
+ * @brief NRFX_SPIM0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPIM0_ENABLED
+#define NRFX_SPIM0_ENABLED 0
 #endif
 
-// <o> NRFX_SPIM_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_SPIM_CONFIG_DEBUG_COLOR
-#define NRFX_SPIM_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_SPIS_ENABLED - nrfx_spis - SPIS peripheral driver.
-//==========================================================
+/**
+ * @brief NRFX_SPIS_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_SPIS_ENABLED
 #define NRFX_SPIS_ENABLED 0
 #endif
-// <q> NRFX_SPIS0_ENABLED  - Enables SPIS0 instance.
 
-
-#ifndef NRFX_SPIS0_ENABLED
-#define NRFX_SPIS0_ENABLED 0
-#endif
-
-
-// <o> NRFX_SPIS_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority.
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_SPIS_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_SPIS_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_SPIS_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_SPIS_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_SPIS_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_SPIS_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_SPIS_CONFIG_LOG_ENABLED
 #define NRFX_SPIS_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_SPIS_CONFIG_LOG_LEVEL  - Default severity level.
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_SPIS_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_SPIS_CONFIG_LOG_LEVEL
 #define NRFX_SPIS_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_SPIS_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_SPIS_CONFIG_INFO_COLOR
-#define NRFX_SPIS_CONFIG_INFO_COLOR 0
+/**
+ * @brief NRFX_SPIS0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPIS0_ENABLED
+#define NRFX_SPIS0_ENABLED 0
 #endif
 
-// <o> NRFX_SPIS_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_SPIS_CONFIG_DEBUG_COLOR
-#define NRFX_SPIS_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <q> NRFX_SYSTICK_ENABLED  - nrfx_systick - ARM(R) SysTick driver.
-
-
+/**
+ * @brief NRFX_SYSTICK_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_SYSTICK_ENABLED
 #define NRFX_SYSTICK_ENABLED 0
 #endif
 
-// <e> NRFX_TEMP_ENABLED - nrfx_temp - TEMP peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_TEMP_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_TEMP_ENABLED
 #define NRFX_TEMP_ENABLED 0
 #endif
 
-// <o> NRFX_TEMP_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_TEMP_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_TEMP_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_TEMP_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_TEMP_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// </e>
+/**
+ * @brief NRFX_TEMP_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TEMP_CONFIG_LOG_ENABLED
+#define NRFX_TEMP_CONFIG_LOG_ENABLED 0
+#endif
 
-// <e> NRFX_TIMER_ENABLED - nrfx_timer - TIMER periperal driver.
-//==========================================================
+/**
+ * @brief NRFX_TEMP_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
+#ifndef NRFX_TEMP_CONFIG_LOG_LEVEL
+#define NRFX_TEMP_CONFIG_LOG_LEVEL 3
+#endif
+
+/**
+ * @brief NRFX_TIMER_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_TIMER_ENABLED
 #define NRFX_TIMER_ENABLED 0
 #endif
-// <q> NRFX_TIMER0_ENABLED  - Enables TIMER0 instance.
 
-
-#ifndef NRFX_TIMER0_ENABLED
-#define NRFX_TIMER0_ENABLED 0
-#endif
-
-// <q> NRFX_TIMER1_ENABLED  - Enables TIMER1 instance.
-
-
-#ifndef NRFX_TIMER1_ENABLED
-#define NRFX_TIMER1_ENABLED 0
-#endif
-
-// <q> NRFX_TIMER2_ENABLED  - Enables TIMER2 instance.
-
-
-#ifndef NRFX_TIMER2_ENABLED
-#define NRFX_TIMER2_ENABLED 0
-#endif
-
-// <o> NRFX_TIMER_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority.
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_TIMER_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_TIMER_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_TIMER_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_TIMER_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_TIMER_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_TIMER_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_TIMER_CONFIG_LOG_ENABLED
 #define NRFX_TIMER_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_TIMER_CONFIG_LOG_LEVEL  - Default severity level.
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_TIMER_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_TIMER_CONFIG_LOG_LEVEL
 #define NRFX_TIMER_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_TIMER_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_TIMER_CONFIG_INFO_COLOR
-#define NRFX_TIMER_CONFIG_INFO_COLOR 0
+/**
+ * @brief NRFX_TIMER0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TIMER0_ENABLED
+#define NRFX_TIMER0_ENABLED 0
 #endif
 
-// <o> NRFX_TIMER_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_TIMER_CONFIG_DEBUG_COLOR
-#define NRFX_TIMER_CONFIG_DEBUG_COLOR 0
+/**
+ * @brief NRFX_TIMER1_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TIMER1_ENABLED
+#define NRFX_TIMER1_ENABLED 0
 #endif
 
-// </e>
+/**
+ * @brief NRFX_TIMER2_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TIMER2_ENABLED
+#define NRFX_TIMER2_ENABLED 0
+#endif
 
-// </e>
-
-// <e> NRFX_TWIM_ENABLED - nrfx_twim - TWIM peripheral driver.
-//==========================================================
+/**
+ * @brief NRFX_TWIM_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_TWIM_ENABLED
 #define NRFX_TWIM_ENABLED 0
 #endif
-// <q> NRFX_TWIM0_ENABLED  - Enables TWIM0 instance.
 
-
-#ifndef NRFX_TWIM0_ENABLED
-#define NRFX_TWIM0_ENABLED 0
-#endif
-
-// <o> NRFX_TWIM_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority.
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_TWIM_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_TWIM_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_TWIM_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_TWIM_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_TWIM_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_TWIM_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_TWIM_CONFIG_LOG_ENABLED
 #define NRFX_TWIM_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_TWIM_CONFIG_LOG_LEVEL  - Default severity level.
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_TWIM_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_TWIM_CONFIG_LOG_LEVEL
 #define NRFX_TWIM_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_TWIM_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_TWIM_CONFIG_INFO_COLOR
-#define NRFX_TWIM_CONFIG_INFO_COLOR 0
+/**
+ * @brief NRFX_TWIM0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWIM0_ENABLED
+#define NRFX_TWIM0_ENABLED 0
 #endif
 
-// <o> NRFX_TWIM_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_TWIM_CONFIG_DEBUG_COLOR
-#define NRFX_TWIM_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_TWIS_ENABLED - nrfx_twis - TWIS peripheral driver.
-//==========================================================
+/**
+ * @brief NRFX_TWIS_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_TWIS_ENABLED
 #define NRFX_TWIS_ENABLED 0
 #endif
 
-// <q> NRFX_TWIS0_ENABLED  - Enables TWIS0 instance.
-
-#ifndef NRFX_TWIS0_ENABLED
-#define NRFX_TWIS0_ENABLED 0
+/**
+ * @brief NRFX_TWIS_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
+#ifndef NRFX_TWIS_DEFAULT_CONFIG_IRQ_PRIORITY
+#define NRFX_TWIS_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
+/**
+ * @brief NRFX_TWIS_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWIS_CONFIG_LOG_ENABLED
+#define NRFX_TWIS_CONFIG_LOG_ENABLED 0
+#endif
 
-// <q> NRFX_TWIS_ASSUME_INIT_AFTER_RESET_ONLY  - Assumes that any instance would be initialized only once.
-
-// <i> Optimization flag. Registers used by TWIS are shared by other peripherals. Normally, during initialization driver tries to clear all registers to known state before doing the initialization itself. This gives initialization safe procedure, no matter when it would be called. If you activate TWIS only once and do never uninitialize it - set this flag to 1 what gives more optimal code.
-
+/**
+ * @brief NRFX_TWIS_ASSUME_INIT_AFTER_RESET_ONLY - Assume that any instance would be initialized only once.
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_TWIS_ASSUME_INIT_AFTER_RESET_ONLY
 #define NRFX_TWIS_ASSUME_INIT_AFTER_RESET_ONLY 0
 #endif
 
-// <q> NRFX_TWIS_NO_SYNC_MODE  - Removes support for synchronous mode.
-
-// <i> Synchronous mode would be used in specific situations. And it uses some additional code and data memory to safely process state machine by polling it in status functions. If this functionality is not required it may be disabled to free some resources.
-
+/**
+ * @brief NRFX_TWIS_NO_SYNC_MODE - Remove support for synchronous mode.
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_TWIS_NO_SYNC_MODE
 #define NRFX_TWIS_NO_SYNC_MODE 0
 #endif
 
-// <o> NRFX_TWIS_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority.
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
-#ifndef NRFX_TWIS_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_TWIS_DEFAULT_CONFIG_IRQ_PRIORITY 7
-#endif
-
-// <e> NRFX_TWIS_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
-#ifndef NRFX_TWIS_CONFIG_LOG_ENABLED
-#define NRFX_TWIS_CONFIG_LOG_ENABLED 0
-#endif
-// <o> NRFX_TWIS_CONFIG_LOG_LEVEL  - Default severity level.
-
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_TWIS_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_TWIS_CONFIG_LOG_LEVEL
 #define NRFX_TWIS_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_TWIS_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_TWIS_CONFIG_INFO_COLOR
-#define NRFX_TWIS_CONFIG_INFO_COLOR 0
+/**
+ * @brief NRFX_TWIS0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWIS0_ENABLED
+#define NRFX_TWIS0_ENABLED 0
 #endif
 
-// <o> NRFX_TWIS_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_TWIS_CONFIG_DEBUG_COLOR
-#define NRFX_TWIS_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_UARTE_ENABLED - nrfx_uarte - UARTE peripheral driver.
-//==========================================================
+/**
+ * @brief NRFX_UARTE_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_UARTE_ENABLED
 #define NRFX_UARTE_ENABLED 0
 #endif
-// <o> NRFX_UARTE0_ENABLED - Enables UARTE0 instances
-#ifndef NRFX_UARTE0_ENABLED
-#define NRFX_UARTE0_ENABLED 0
-#endif
 
-// <o> NRFX_UARTE_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority.
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_UARTE_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_UARTE_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_UARTE_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_UARTE_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_UARTE_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_UARTE_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_UARTE_CONFIG_LOG_ENABLED
 #define NRFX_UARTE_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_UARTE_CONFIG_LOG_LEVEL  - Default severity level.
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_UARTE_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_UARTE_CONFIG_LOG_LEVEL
 #define NRFX_UARTE_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_UARTE_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_UARTE_CONFIG_INFO_COLOR
-#define NRFX_UARTE_CONFIG_INFO_COLOR 0
+/**
+ * @brief NRFX_UARTE0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_UARTE0_ENABLED
+#define NRFX_UARTE0_ENABLED 0
 #endif
 
-// <o> NRFX_UARTE_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_UARTE_CONFIG_DEBUG_COLOR
-#define NRFX_UARTE_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_WDT_ENABLED - nrfx_wdt - WDT peripheral driver.
-//==========================================================
+/**
+ * @brief NRFX_WDT_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_WDT_ENABLED
 #define NRFX_WDT_ENABLED 0
 #endif
-// <q> NRFX_WDT0_ENABLED  - Enable WDT0 instance.
 
-
-#ifndef NRFX_WDT0_ENABLED
-#define NRFX_WDT0_ENABLED 0
+/**
+ * @brief NRFX_WDT_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
+#ifndef NRFX_WDT_DEFAULT_CONFIG_IRQ_PRIORITY
+#define NRFX_WDT_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <o> NRFX_WDT_CONFIG_NO_IRQ  - Remove WDT IRQ handling from WDT driver.
-
-// <0=> Include WDT IRQ handling
-// <1=> Remove WDT IRQ handling
-
+/**
+ * @brief NRFX_WDT_CONFIG_NO_IRQ - Remove WDT IRQ handling from WDT driver
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_WDT_CONFIG_NO_IRQ
 #define NRFX_WDT_CONFIG_NO_IRQ 0
 #endif
 
-// <o> NRFX_WDT_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority.
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
-#ifndef NRFX_WDT_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_WDT_DEFAULT_CONFIG_IRQ_PRIORITY 7
-#endif
-
-// <e> NRFX_WDT_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_WDT_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_WDT_CONFIG_LOG_ENABLED
 #define NRFX_WDT_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_WDT_CONFIG_LOG_LEVEL  - Default severity level.
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_WDT_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_WDT_CONFIG_LOG_LEVEL
 #define NRFX_WDT_CONFIG_LOG_LEVEL 3
 #endif
-
-// <o> NRFX_WDT_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_WDT_CONFIG_INFO_COLOR
-#define NRFX_WDT_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_WDT_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_WDT_CONFIG_DEBUG_COLOR
-#define NRFX_WDT_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// </h>
 
 #endif // NRFX_CONFIG_NRF5340_NETWORK_H__

--- a/nrfx/templates/nrfx_config_nrf91.h
+++ b/nrfx/templates/nrfx_config_nrf91.h
@@ -123,1535 +123,1138 @@
 #define GPIOTE_IRQHandler GPIOTE0_IRQHandler
 #endif
 
-// <<< Use Configuration Wizard in Context Menu >>>\n
+/**
+ * @brief NRFX_DEFAULT_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
+#ifndef NRFX_DEFAULT_IRQ_PRIORITY
+#define NRFX_DEFAULT_IRQ_PRIORITY 7
+#endif
 
-// <h> nRF_Drivers
-
-// <e> NRFX_CLOCK_ENABLED - nrfx_clock - CLOCK peripheral driver.
-//==========================================================
+/**
+ * @brief NRFX_CLOCK_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_CLOCK_ENABLED
 #define NRFX_CLOCK_ENABLED 0
 #endif
-// <o> NRFX_CLOCK_CONFIG_LF_SRC  - LF clock source.
 
-// <1=> RC
-// <2=> XTAL
-
+/**
+ * @brief NRFX_CLOCK_CONFIG_LF_SRC
+ *
+ * Integer value.
+ * Supported values:
+ * - RC   = 1
+ * - XTAL = 2
+ */
 #ifndef NRFX_CLOCK_CONFIG_LF_SRC
 #define NRFX_CLOCK_CONFIG_LF_SRC 2
 #endif
 
-// <q> NRFX_CLOCK_CONFIG_LFXO_TWO_STAGE_ENABLED - Enables two-stage LFXO start procedure
-
-// <i> If set to a non-zero value, LFRC will be started before LFXO and corresponding
-// <i> event will be generated. It means that CPU will be woken up when LFRC
-// <i> oscillator starts, but user callback will be invoked only after LFXO
-// <i> finally starts.
-
+/**
+ * @brief NRFX_CLOCK_CONFIG_LFXO_TWO_STAGE_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_CLOCK_CONFIG_LFXO_TWO_STAGE_ENABLED
 #define NRFX_CLOCK_CONFIG_LFXO_TWO_STAGE_ENABLED 0
 #endif
 
-// <o> NRFX_CLOCK_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority.
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_CLOCK_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_CLOCK_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_CLOCK_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_CLOCK_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_CLOCK_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_CLOCK_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_CLOCK_CONFIG_LOG_ENABLED
 #define NRFX_CLOCK_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_CLOCK_CONFIG_LOG_LEVEL  - Default severity level.
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_CLOCK_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_CLOCK_CONFIG_LOG_LEVEL
 #define NRFX_CLOCK_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_CLOCK_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_CLOCK_CONFIG_INFO_COLOR
-#define NRFX_CLOCK_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_CLOCK_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_CLOCK_CONFIG_DEBUG_COLOR
-#define NRFX_CLOCK_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_DPPI_ENABLED - nrfx_dppi - DPPI allocator.
-//==========================================================
+/**
+ * @brief NRFX_DPPI_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_DPPI_ENABLED
 #define NRFX_DPPI_ENABLED 0
 #endif
-// <e> NRFX_DPPI_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+
+/**
+ * @brief NRFX_DPPI_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_DPPI_CONFIG_LOG_ENABLED
 #define NRFX_DPPI_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_DPPI_CONFIG_LOG_LEVEL  - Default severity level.
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_DPPI_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_DPPI_CONFIG_LOG_LEVEL
 #define NRFX_DPPI_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_DPPI_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_DPPI_CONFIG_INFO_COLOR
-#define NRFX_DPPI_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_DPPI_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_DPPI_CONFIG_DEBUG_COLOR
-#define NRFX_DPPI_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_EGU_ENABLED - nrfx_egu - EGU peripheral driver.
-//==========================================================
+/**
+ * @brief NRFX_EGU_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_EGU_ENABLED
 #define NRFX_EGU_ENABLED 0
 #endif
 
-// <q> NRFX_EGU0_ENABLED  - Enable EGU0 instance.
+/**
+ * @brief NRFX_EGU_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
+#ifndef NRFX_EGU_DEFAULT_CONFIG_IRQ_PRIORITY
+#define NRFX_EGU_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
+#endif
 
+/**
+ * @brief NRFX_EGU0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_EGU0_ENABLED
 #define NRFX_EGU0_ENABLED 0
 #endif
 
-// <q> NRFX_EGU1_ENABLED  - Enable EGU1 instance.
-
+/**
+ * @brief NRFX_EGU1_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_EGU1_ENABLED
 #define NRFX_EGU1_ENABLED 0
 #endif
 
-// <q> NRFX_EGU2_ENABLED  - Enable EGU2 instance.
-
+/**
+ * @brief NRFX_EGU2_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_EGU2_ENABLED
 #define NRFX_EGU2_ENABLED 0
 #endif
 
-// <q> NRFX_EGU3_ENABLED  - Enable EGU3 instance.
-
+/**
+ * @brief NRFX_EGU3_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_EGU3_ENABLED
 #define NRFX_EGU3_ENABLED 0
 #endif
 
-// <q> NRFX_EGU4_ENABLED  - Enable EGU4 instance.
-
+/**
+ * @brief NRFX_EGU4_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_EGU4_ENABLED
 #define NRFX_EGU4_ENABLED 0
 #endif
 
-// <q> NRFX_EGU5_ENABLED  - Enable EGU5 instance.
-
+/**
+ * @brief NRFX_EGU5_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_EGU5_ENABLED
 #define NRFX_EGU5_ENABLED 0
 #endif
 
-// <o> NRFX_EGU_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority.
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
-#ifndef NRFX_EGU_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_EGU_DEFAULT_CONFIG_IRQ_PRIORITY 7
-#endif
-
-// </e>
-
-// <e> NRFX_GPIOTE_ENABLED - nrfx_gpiote - GPIOTE peripheral driver.
-//==========================================================
+/**
+ * @brief NRFX_GPIOTE_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_GPIOTE_ENABLED
 #define NRFX_GPIOTE_ENABLED 0
 #endif
 
-// <o> NRFX_GPIOTE_CONFIG_NUM_OF_EVT_HANDLERS - Number of dedicated handlers
+/**
+ * @brief NRFX_GPIOTE_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
+#ifndef NRFX_GPIOTE_DEFAULT_CONFIG_IRQ_PRIORITY
+#define NRFX_GPIOTE_DEFAULT_CONFIG_IRQ_PRIORITY 3
+#endif
+
+/**
+ * @brief NRFX_GPIOTE_CONFIG_NUM_OF_EVT_HANDLERS
+ *
+ * Integer value. Minimum: 0 Maximum: 15
+ */
 #ifndef NRFX_GPIOTE_CONFIG_NUM_OF_EVT_HANDLERS
 #define NRFX_GPIOTE_CONFIG_NUM_OF_EVT_HANDLERS 2
 #endif
 
-// <o> NRFX_GPIOTE_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority.
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
-#ifndef NRFX_GPIOTE_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_GPIOTE_DEFAULT_CONFIG_IRQ_PRIORITY 7
-#endif
-
-// <e> NRFX_GPIOTE_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_GPIOTE_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_GPIOTE_CONFIG_LOG_ENABLED
 #define NRFX_GPIOTE_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_GPIOTE_CONFIG_LOG_LEVEL  - Default severity level.
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_GPIOTE_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_GPIOTE_CONFIG_LOG_LEVEL
 #define NRFX_GPIOTE_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_GPIOTE_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_GPIOTE_CONFIG_INFO_COLOR
-#define NRFX_GPIOTE_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_GPIOTE_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_GPIOTE_CONFIG_DEBUG_COLOR
-#define NRFX_GPIOTE_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_I2S_ENABLED - nrfx_i2s - I2S peripheral driver.
-//==========================================================
+/**
+ * @brief NRFX_I2S_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_I2S_ENABLED
 #define NRFX_I2S_ENABLED 0
 #endif
 
-// <o> NRFX_I2S_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority.
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_I2S_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_I2S_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_I2S_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_I2S_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_I2S_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_I2S_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_I2S_CONFIG_LOG_ENABLED
 #define NRFX_I2S_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_I2S_CONFIG_LOG_LEVEL  - Default severity level.
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_I2S_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_I2S_CONFIG_LOG_LEVEL
 #define NRFX_I2S_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_I2S_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_I2S_CONFIG_INFO_COLOR
-#define NRFX_I2S_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_I2S_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_I2S_CONFIG_DEBUG_COLOR
-#define NRFX_I2S_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_IPC_ENABLED - nrfx_ipc - IPC peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_IPC_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_IPC_ENABLED
 #define NRFX_IPC_ENABLED 0
 #endif
 
-// </e>
-
-// <e> NRFX_NVMC_ENABLED - nrfx_nvmc - NVMC peripheral driver
-//==========================================================
+/**
+ * @brief NRFX_NVMC_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_NVMC_ENABLED
 #define NRFX_NVMC_ENABLED 0
 #endif
 
-// </e>
-
-// <e> NRFX_PDM_ENABLED - nrfx_pdm - PDM peripheral driver.
-//==========================================================
+/**
+ * @brief NRFX_PDM_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_PDM_ENABLED
 #define NRFX_PDM_ENABLED 0
 #endif
 
-// <o> NRFX_PDM_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority.
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_PDM_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_PDM_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_PDM_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_PDM_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_PDM_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_PDM_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_PDM_CONFIG_LOG_ENABLED
 #define NRFX_PDM_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_PDM_CONFIG_LOG_LEVEL  - Default severity level.
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_PDM_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_PDM_CONFIG_LOG_LEVEL
 #define NRFX_PDM_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_PDM_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_PDM_CONFIG_INFO_COLOR
-#define NRFX_PDM_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_PDM_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_PDM_CONFIG_DEBUG_COLOR
-#define NRFX_PDM_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_POWER_ENABLED - nrfx_power - POWER peripheral driver.
-//==========================================================
+/**
+ * @brief NRFX_POWER_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_POWER_ENABLED
 #define NRFX_POWER_ENABLED 0
 #endif
-// <o> NRFX_POWER_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority.
 
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_POWER_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_POWER_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_POWER_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_POWER_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// </e>
-
-// <e> NRFX_PRS_ENABLED - nrfx_prs - Peripheral Resource Sharing (PRS) module.
-//==========================================================
+/**
+ * @brief NRFX_PRS_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_PRS_ENABLED
 #define NRFX_PRS_ENABLED 0
 #endif
-// <q> NRFX_PRS_BOX_0_ENABLED  - Enables box 0 in the module.
 
-
-#ifndef NRFX_PRS_BOX_0_ENABLED
-#define NRFX_PRS_BOX_0_ENABLED 0
-#endif
-
-// <q> NRFX_PRS_BOX_1_ENABLED  - Enables box 1 in the module.
-
-
-#ifndef NRFX_PRS_BOX_1_ENABLED
-#define NRFX_PRS_BOX_1_ENABLED 0
-#endif
-
-// <q> NRFX_PRS_BOX_2_ENABLED  - Enables box 2 in the module.
-
-
-#ifndef NRFX_PRS_BOX_2_ENABLED
-#define NRFX_PRS_BOX_2_ENABLED 0
-#endif
-
-// <q> NRFX_PRS_BOX_3_ENABLED  - Enables box 3 in the module.
-
-
-#ifndef NRFX_PRS_BOX_3_ENABLED
-#define NRFX_PRS_BOX_3_ENABLED 0
-#endif
-
-// <e> NRFX_PRS_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_PRS_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_PRS_CONFIG_LOG_ENABLED
 #define NRFX_PRS_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_PRS_CONFIG_LOG_LEVEL  - Default severity level.
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_PRS_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_PRS_CONFIG_LOG_LEVEL
 #define NRFX_PRS_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_PRS_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_PRS_CONFIG_INFO_COLOR
-#define NRFX_PRS_CONFIG_INFO_COLOR 0
+/**
+ * @brief NRFX_PRS_BOX_0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_PRS_BOX_0_ENABLED
+#define NRFX_PRS_BOX_0_ENABLED 0
 #endif
 
-// <o> NRFX_PRS_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_PRS_CONFIG_DEBUG_COLOR
-#define NRFX_PRS_CONFIG_DEBUG_COLOR 0
+/**
+ * @brief NRFX_PRS_BOX_1_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_PRS_BOX_1_ENABLED
+#define NRFX_PRS_BOX_1_ENABLED 0
 #endif
 
-// </e>
+/**
+ * @brief NRFX_PRS_BOX_2_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_PRS_BOX_2_ENABLED
+#define NRFX_PRS_BOX_2_ENABLED 0
+#endif
 
-// </e>
+/**
+ * @brief NRFX_PRS_BOX_3_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_PRS_BOX_3_ENABLED
+#define NRFX_PRS_BOX_3_ENABLED 0
+#endif
 
-// <e> NRFX_PWM_ENABLED - nrfx_pwm - PWM peripheral driver.
-//==========================================================
+/**
+ * @brief NRFX_PWM_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_PWM_ENABLED
 #define NRFX_PWM_ENABLED 0
 #endif
-// <q> NRFX_PWM0_ENABLED  - Enables PWM0 instance.
 
-
-#ifndef NRFX_PWM0_ENABLED
-#define NRFX_PWM0_ENABLED 0
-#endif
-
-// <q> NRFX_PWM1_ENABLED  - Enables PWM1 instance.
-
-
-#ifndef NRFX_PWM1_ENABLED
-#define NRFX_PWM1_ENABLED 0
-#endif
-
-// <q> NRFX_PWM2_ENABLED  - Enables PWM2 instance.
-
-
-#ifndef NRFX_PWM2_ENABLED
-#define NRFX_PWM2_ENABLED 0
-#endif
-
-// <q> NRFX_PWM3_ENABLED  - Enables PWM3 instance.
-
-
-#ifndef NRFX_PWM3_ENABLED
-#define NRFX_PWM3_ENABLED 0
-#endif
-
-// <o> NRFX_PWM_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority.
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_PWM_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_PWM_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_PWM_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_PWM_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_PWM_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_PWM_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_PWM_CONFIG_LOG_ENABLED
 #define NRFX_PWM_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_PWM_CONFIG_LOG_LEVEL  - Default severity level.
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_PWM_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_PWM_CONFIG_LOG_LEVEL
 #define NRFX_PWM_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_PWM_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_PWM_CONFIG_INFO_COLOR
-#define NRFX_PWM_CONFIG_INFO_COLOR 0
+/**
+ * @brief NRFX_PWM0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_PWM0_ENABLED
+#define NRFX_PWM0_ENABLED 0
 #endif
 
-// <o> NRFX_PWM_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_PWM_CONFIG_DEBUG_COLOR
-#define NRFX_PWM_CONFIG_DEBUG_COLOR 0
+/**
+ * @brief NRFX_PWM1_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_PWM1_ENABLED
+#define NRFX_PWM1_ENABLED 0
 #endif
 
-// </e>
+/**
+ * @brief NRFX_PWM2_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_PWM2_ENABLED
+#define NRFX_PWM2_ENABLED 0
+#endif
 
-// </e>
+/**
+ * @brief NRFX_PWM3_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_PWM3_ENABLED
+#define NRFX_PWM3_ENABLED 0
+#endif
 
-// <e> NRFX_RTC_ENABLED - nrfx_rtc - RTC peripheral driver.
-//==========================================================
+/**
+ * @brief NRFX_RTC_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_RTC_ENABLED
 #define NRFX_RTC_ENABLED 0
 #endif
-// <q> NRFX_RTC0_ENABLED  - Enables RTC0 instance.
 
-
-#ifndef NRFX_RTC0_ENABLED
-#define NRFX_RTC0_ENABLED 0
-#endif
-
-// <q> NRFX_RTC1_ENABLED  - Enables RTC1 instance.
-
-
-#ifndef NRFX_RTC1_ENABLED
-#define NRFX_RTC1_ENABLED 0
-#endif
-
-// <o> NRFX_RTC_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority.
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_RTC_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_RTC_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_RTC_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_RTC_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_RTC_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_RTC_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_RTC_CONFIG_LOG_ENABLED
 #define NRFX_RTC_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_RTC_CONFIG_LOG_LEVEL  - Default severity level.
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_RTC_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_RTC_CONFIG_LOG_LEVEL
 #define NRFX_RTC_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_RTC_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_RTC_CONFIG_INFO_COLOR
-#define NRFX_RTC_CONFIG_INFO_COLOR 0
+/**
+ * @brief NRFX_RTC0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_RTC0_ENABLED
+#define NRFX_RTC0_ENABLED 0
 #endif
 
-// <o> NRFX_RTC_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_RTC_CONFIG_DEBUG_COLOR
-#define NRFX_RTC_CONFIG_DEBUG_COLOR 0
+/**
+ * @brief NRFX_RTC1_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_RTC1_ENABLED
+#define NRFX_RTC1_ENABLED 0
 #endif
 
-// </e>
-
-// </e>
-
-// <e> NRFX_SAADC_ENABLED - nrfx_saadc - SAADC peripheral driver.
-//==========================================================
+/**
+ * @brief NRFX_SAADC_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_SAADC_ENABLED
 #define NRFX_SAADC_ENABLED 0
 #endif
 
-// <o> NRFX_SAADC_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority.
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_SAADC_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_SAADC_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_SAADC_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_SAADC_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_SAADC_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_SAADC_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_SAADC_CONFIG_LOG_ENABLED
 #define NRFX_SAADC_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_SAADC_CONFIG_LOG_LEVEL  - Default severity level.
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_SAADC_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_SAADC_CONFIG_LOG_LEVEL
 #define NRFX_SAADC_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_SAADC_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_SAADC_CONFIG_INFO_COLOR
-#define NRFX_SAADC_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_SAADC_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_SAADC_CONFIG_DEBUG_COLOR
-#define NRFX_SAADC_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// <e> NRFX_SPIM_ENABLED - nrfx_spim - SPIM peripheral driver.
-//==========================================================
+/**
+ * @brief NRFX_SPIM_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_SPIM_ENABLED
 #define NRFX_SPIM_ENABLED 0
 #endif
-// <q> NRFX_SPIM0_ENABLED  - Enables SPIM0 instance.
 
-
-#ifndef NRFX_SPIM0_ENABLED
-#define NRFX_SPIM0_ENABLED 0
-#endif
-
-// <q> NRFX_SPIM1_ENABLED  - Enables SPIM1 instance.
-
-
-#ifndef NRFX_SPIM1_ENABLED
-#define NRFX_SPIM1_ENABLED 0
-#endif
-
-// <q> NRFX_SPIM2_ENABLED  - Enables SPIM2 instance.
-
-
-#ifndef NRFX_SPIM2_ENABLED
-#define NRFX_SPIM2_ENABLED 0
-#endif
-
-// <q> NRFX_SPIM3_ENABLED  - Enables SPIM3 instance.
-
-
-#ifndef NRFX_SPIM3_ENABLED
-#define NRFX_SPIM3_ENABLED 0
-#endif
-
-// <o> NRFX_SPIM_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority.
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_SPIM_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_SPIM_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_SPIM_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_SPIM_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_SPIM_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_SPIM_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_SPIM_CONFIG_LOG_ENABLED
 #define NRFX_SPIM_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_SPIM_CONFIG_LOG_LEVEL  - Default severity level.
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_SPIM_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_SPIM_CONFIG_LOG_LEVEL
 #define NRFX_SPIM_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_SPIM_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_SPIM_CONFIG_INFO_COLOR
-#define NRFX_SPIM_CONFIG_INFO_COLOR 0
+/**
+ * @brief NRFX_SPIM0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPIM0_ENABLED
+#define NRFX_SPIM0_ENABLED 0
 #endif
 
-// <o> NRFX_SPIM_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_SPIM_CONFIG_DEBUG_COLOR
-#define NRFX_SPIM_CONFIG_DEBUG_COLOR 0
+/**
+ * @brief NRFX_SPIM1_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPIM1_ENABLED
+#define NRFX_SPIM1_ENABLED 0
 #endif
 
-// </e>
+/**
+ * @brief NRFX_SPIM2_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPIM2_ENABLED
+#define NRFX_SPIM2_ENABLED 0
+#endif
 
-// </e>
+/**
+ * @brief NRFX_SPIM3_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPIM3_ENABLED
+#define NRFX_SPIM3_ENABLED 0
+#endif
 
-// <e> NRFX_SPIS_ENABLED - nrfx_spis - SPIS peripheral driver.
-//==========================================================
+/**
+ * @brief NRFX_SPIS_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_SPIS_ENABLED
 #define NRFX_SPIS_ENABLED 0
 #endif
-// <q> NRFX_SPIS0_ENABLED  - Enables SPIS0 instance.
 
-
-#ifndef NRFX_SPIS0_ENABLED
-#define NRFX_SPIS0_ENABLED 0
-#endif
-
-// <q> NRFX_SPIS1_ENABLED  - Enables SPIS1 instance.
-
-
-#ifndef NRFX_SPIS1_ENABLED
-#define NRFX_SPIS1_ENABLED 0
-#endif
-
-// <q> NRFX_SPIS2_ENABLED  - Enables SPIS2 instance.
-
-
-#ifndef NRFX_SPIS2_ENABLED
-#define NRFX_SPIS2_ENABLED 0
-#endif
-
-// <q> NRFX_SPIS3_ENABLED  - Enables SPIS3 instance.
-
-
-#ifndef NRFX_SPIS3_ENABLED
-#define NRFX_SPIS3_ENABLED 0
-#endif
-
-// <o> NRFX_SPIS_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority.
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_SPIS_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_SPIS_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_SPIS_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_SPIS_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_SPIS_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_SPIS_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_SPIS_CONFIG_LOG_ENABLED
 #define NRFX_SPIS_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_SPIS_CONFIG_LOG_LEVEL  - Default severity level.
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_SPIS_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_SPIS_CONFIG_LOG_LEVEL
 #define NRFX_SPIS_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_SPIS_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_SPIS_CONFIG_INFO_COLOR
-#define NRFX_SPIS_CONFIG_INFO_COLOR 0
+/**
+ * @brief NRFX_SPIS0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPIS0_ENABLED
+#define NRFX_SPIS0_ENABLED 0
 #endif
 
-// <o> NRFX_SPIS_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_SPIS_CONFIG_DEBUG_COLOR
-#define NRFX_SPIS_CONFIG_DEBUG_COLOR 0
+/**
+ * @brief NRFX_SPIS1_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPIS1_ENABLED
+#define NRFX_SPIS1_ENABLED 0
 #endif
 
-// </e>
+/**
+ * @brief NRFX_SPIS2_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPIS2_ENABLED
+#define NRFX_SPIS2_ENABLED 0
+#endif
 
-// </e>
+/**
+ * @brief NRFX_SPIS3_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_SPIS3_ENABLED
+#define NRFX_SPIS3_ENABLED 0
+#endif
 
-// <q> NRFX_SYSTICK_ENABLED  - nrfx_systick - ARM(R) SysTick driver.
-
-
+/**
+ * @brief NRFX_SYSTICK_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_SYSTICK_ENABLED
 #define NRFX_SYSTICK_ENABLED 0
 #endif
 
-// <e> NRFX_TIMER_ENABLED - nrfx_timer - TIMER periperal driver.
-//==========================================================
+/**
+ * @brief NRFX_TIMER_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_TIMER_ENABLED
 #define NRFX_TIMER_ENABLED 0
 #endif
 
-// <q> NRFX_TIMER0_ENABLED  - Enables TIMER0 instance.
-
-#ifndef NRFX_TIMER0_ENABLED
-#define NRFX_TIMER0_ENABLED 0
-#endif
-
-// <q> NRFX_TIMER1_ENABLED  - Enables TIMER1 instance.
-
-#ifndef NRFX_TIMER1_ENABLED
-#define NRFX_TIMER1_ENABLED 0
-#endif
-
-// <q> NRFX_TIMER2_ENABLED  - Enables TIMER2 instance.
-
-#ifndef NRFX_TIMER2_ENABLED
-#define NRFX_TIMER2_ENABLED 0
-#endif
-
-// <o> NRFX_TIMER_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority.
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_TIMER_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_TIMER_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_TIMER_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_TIMER_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_TIMER_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_TIMER_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_TIMER_CONFIG_LOG_ENABLED
 #define NRFX_TIMER_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_TIMER_CONFIG_LOG_LEVEL  - Default severity level.
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_TIMER_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_TIMER_CONFIG_LOG_LEVEL
 #define NRFX_TIMER_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_TIMER_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_TIMER_CONFIG_INFO_COLOR
-#define NRFX_TIMER_CONFIG_INFO_COLOR 0
+/**
+ * @brief NRFX_TIMER0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TIMER0_ENABLED
+#define NRFX_TIMER0_ENABLED 0
 #endif
 
-// <o> NRFX_TIMER_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_TIMER_CONFIG_DEBUG_COLOR
-#define NRFX_TIMER_CONFIG_DEBUG_COLOR 0
+/**
+ * @brief NRFX_TIMER1_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TIMER1_ENABLED
+#define NRFX_TIMER1_ENABLED 0
 #endif
 
-// </e>
+/**
+ * @brief NRFX_TIMER2_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TIMER2_ENABLED
+#define NRFX_TIMER2_ENABLED 0
+#endif
 
-// </e>
-
-// <e> NRFX_TWIM_ENABLED - nrfx_twim - TWIM peripheral driver.
-//==========================================================
+/**
+ * @brief NRFX_TWIM_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_TWIM_ENABLED
 #define NRFX_TWIM_ENABLED 0
 #endif
-// <q> NRFX_TWIM0_ENABLED  - Enables TWIM0 instance.
 
-
-#ifndef NRFX_TWIM0_ENABLED
-#define NRFX_TWIM0_ENABLED 0
-#endif
-
-// <q> NRFX_TWIM1_ENABLED  - Enables TWIM1 instance.
-
-
-#ifndef NRFX_TWIM1_ENABLED
-#define NRFX_TWIM1_ENABLED 0
-#endif
-
-// <q> NRFX_TWIM2_ENABLED  - Enables TWIM2 instance.
-
-
-#ifndef NRFX_TWIM2_ENABLED
-#define NRFX_TWIM2_ENABLED 0
-#endif
-
-// <q> NRFX_TWIM3_ENABLED  - Enables TWIM3 instance.
-
-
-#ifndef NRFX_TWIM3_ENABLED
-#define NRFX_TWIM3_ENABLED 0
-#endif
-
-// <o> NRFX_TWIM_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority.
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_TWIM_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_TWIM_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_TWIM_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_TWIM_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_TWIM_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_TWIM_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_TWIM_CONFIG_LOG_ENABLED
 #define NRFX_TWIM_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_TWIM_CONFIG_LOG_LEVEL  - Default severity level.
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_TWIM_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_TWIM_CONFIG_LOG_LEVEL
 #define NRFX_TWIM_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_TWIM_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_TWIM_CONFIG_INFO_COLOR
-#define NRFX_TWIM_CONFIG_INFO_COLOR 0
+/**
+ * @brief NRFX_TWIM0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWIM0_ENABLED
+#define NRFX_TWIM0_ENABLED 0
 #endif
 
-// <o> NRFX_TWIM_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_TWIM_CONFIG_DEBUG_COLOR
-#define NRFX_TWIM_CONFIG_DEBUG_COLOR 0
+/**
+ * @brief NRFX_TWIM1_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWIM1_ENABLED
+#define NRFX_TWIM1_ENABLED 0
 #endif
 
-// </e>
+/**
+ * @brief NRFX_TWIM2_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWIM2_ENABLED
+#define NRFX_TWIM2_ENABLED 0
+#endif
 
-// </e>
+/**
+ * @brief NRFX_TWIM3_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWIM3_ENABLED
+#define NRFX_TWIM3_ENABLED 0
+#endif
 
-// <e> NRFX_TWIS_ENABLED - nrfx_twis - TWIS peripheral driver.
-//==========================================================
+/**
+ * @brief NRFX_TWIS_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_TWIS_ENABLED
 #define NRFX_TWIS_ENABLED 0
 #endif
-// <q> NRFX_TWIS0_ENABLED  - Enables TWIS0 instance.
 
-
-#ifndef NRFX_TWIS0_ENABLED
-#define NRFX_TWIS0_ENABLED 0
+/**
+ * @brief NRFX_TWIS_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
+#ifndef NRFX_TWIS_DEFAULT_CONFIG_IRQ_PRIORITY
+#define NRFX_TWIS_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <q> NRFX_TWIS1_ENABLED  - Enables TWIS1 instance.
-
-
-#ifndef NRFX_TWIS1_ENABLED
-#define NRFX_TWIS1_ENABLED 0
+/**
+ * @brief NRFX_TWIS_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWIS_CONFIG_LOG_ENABLED
+#define NRFX_TWIS_CONFIG_LOG_ENABLED 0
 #endif
 
-// <q> NRFX_TWIS2_ENABLED  - Enables TWIS2 instance.
-
-
-#ifndef NRFX_TWIS2_ENABLED
-#define NRFX_TWIS2_ENABLED 0
-#endif
-
-// <q> NRFX_TWIS3_ENABLED  - Enables TWIS3 instance.
-
-
-#ifndef NRFX_TWIS3_ENABLED
-#define NRFX_TWIS3_ENABLED 0
-#endif
-
-// <q> NRFX_TWIS_ASSUME_INIT_AFTER_RESET_ONLY  - Assumes that any instance would be initialized only once.
-
-
-// <i> Optimization flag. Registers used by TWIS are shared by other peripherals. Normally, during initialization driver tries to clear all registers to known state before doing the initialization itself. This gives initialization safe procedure, no matter when it would be called. If you activate TWIS only once and do never uninitialize it - set this flag to 1 what gives more optimal code.
-
+/**
+ * @brief NRFX_TWIS_ASSUME_INIT_AFTER_RESET_ONLY - Assume that any instance would be initialized only once.
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_TWIS_ASSUME_INIT_AFTER_RESET_ONLY
 #define NRFX_TWIS_ASSUME_INIT_AFTER_RESET_ONLY 0
 #endif
 
-// <q> NRFX_TWIS_NO_SYNC_MODE  - Removes support for synchronous mode.
-
-// <i> Synchronous mode would be used in specific situations. And it uses some additional code and data memory to safely process state machine by polling it in status functions. If this functionality is not required it may be disabled to free some resources.
-
+/**
+ * @brief NRFX_TWIS_NO_SYNC_MODE - Remove support for synchronous mode.
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_TWIS_NO_SYNC_MODE
 #define NRFX_TWIS_NO_SYNC_MODE 0
 #endif
 
-// <o> NRFX_TWIS_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority.
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
-#ifndef NRFX_TWIS_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_TWIS_DEFAULT_CONFIG_IRQ_PRIORITY 7
-#endif
-
-// <e> NRFX_TWIS_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
-#ifndef NRFX_TWIS_CONFIG_LOG_ENABLED
-#define NRFX_TWIS_CONFIG_LOG_ENABLED 0
-#endif
-// <o> NRFX_TWIS_CONFIG_LOG_LEVEL  - Default severity level.
-
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_TWIS_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_TWIS_CONFIG_LOG_LEVEL
 #define NRFX_TWIS_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_TWIS_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_TWIS_CONFIG_INFO_COLOR
-#define NRFX_TWIS_CONFIG_INFO_COLOR 0
+/**
+ * @brief NRFX_TWIS0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWIS0_ENABLED
+#define NRFX_TWIS0_ENABLED 0
 #endif
 
-// <o> NRFX_TWIS_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_TWIS_CONFIG_DEBUG_COLOR
-#define NRFX_TWIS_CONFIG_DEBUG_COLOR 0
+/**
+ * @brief NRFX_TWIS1_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWIS1_ENABLED
+#define NRFX_TWIS1_ENABLED 0
 #endif
 
-// </e>
+/**
+ * @brief NRFX_TWIS2_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWIS2_ENABLED
+#define NRFX_TWIS2_ENABLED 0
+#endif
 
-// </e>
+/**
+ * @brief NRFX_TWIS3_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWIS3_ENABLED
+#define NRFX_TWIS3_ENABLED 0
+#endif
 
-// <e> NRFX_UARTE_ENABLED - nrfx_uarte - UARTE peripheral driver.
-//==========================================================
+/**
+ * @brief NRFX_UARTE_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_UARTE_ENABLED
 #define NRFX_UARTE_ENABLED 0
 #endif
-// <q> NRFX_UARTE0_ENABLED - Enables UARTE0 instances
-#ifndef NRFX_UARTE0_ENABLED
-#define NRFX_UARTE0_ENABLED 0
-#endif
 
-// <q> NRFX_UARTE1_ENABLED - Enables UARTE1 instance.
-#ifndef NRFX_UARTE1_ENABLED
-#define NRFX_UARTE1_ENABLED 0
-#endif
-
-// <q> NRFX_UARTE2_ENABLED - Enables UARTE2 instance.
-#ifndef NRFX_UARTE2_ENABLED
-#define NRFX_UARTE2_ENABLED 0
-#endif
-
-// <q> NRFX_UARTE3_ENABLED - Enables UARTE3 instance.
-#ifndef NRFX_UARTE3_ENABLED
-#define NRFX_UARTE3_ENABLED 0
-#endif
-
-// <o> NRFX_UARTE_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority.
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
+/**
+ * @brief NRFX_UARTE_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
 #ifndef NRFX_UARTE_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_UARTE_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#define NRFX_UARTE_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <e> NRFX_UARTE_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_UARTE_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_UARTE_CONFIG_LOG_ENABLED
 #define NRFX_UARTE_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_UARTE_CONFIG_LOG_LEVEL  - Default severity level.
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_UARTE_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_UARTE_CONFIG_LOG_LEVEL
 #define NRFX_UARTE_CONFIG_LOG_LEVEL 3
 #endif
 
-// <o> NRFX_UARTE_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_UARTE_CONFIG_INFO_COLOR
-#define NRFX_UARTE_CONFIG_INFO_COLOR 0
+/**
+ * @brief NRFX_UARTE0_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_UARTE0_ENABLED
+#define NRFX_UARTE0_ENABLED 0
 #endif
 
-// <o> NRFX_UARTE_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_UARTE_CONFIG_DEBUG_COLOR
-#define NRFX_UARTE_CONFIG_DEBUG_COLOR 0
+/**
+ * @brief NRFX_UARTE1_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_UARTE1_ENABLED
+#define NRFX_UARTE1_ENABLED 0
 #endif
 
-// </e>
+/**
+ * @brief NRFX_UARTE2_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_UARTE2_ENABLED
+#define NRFX_UARTE2_ENABLED 0
+#endif
 
-// </e>
+/**
+ * @brief NRFX_UARTE3_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_UARTE3_ENABLED
+#define NRFX_UARTE3_ENABLED 0
+#endif
 
-// <e> NRFX_WDT_ENABLED - nrfx_wdt - WDT peripheral driver.
-//==========================================================
+/**
+ * @brief NRFX_WDT_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_WDT_ENABLED
 #define NRFX_WDT_ENABLED 0
 #endif
-// <q> NRFX_WDT0_ENABLED  - Enable WDT0 instance.
 
-
-#ifndef NRFX_WDT0_ENABLED
-#define NRFX_WDT0_ENABLED 0
+/**
+ * @brief NRFX_WDT_DEFAULT_CONFIG_IRQ_PRIORITY
+ *
+ * Integer value. Minimum: 0 Maximum: 7
+ */
+#ifndef NRFX_WDT_DEFAULT_CONFIG_IRQ_PRIORITY
+#define NRFX_WDT_DEFAULT_CONFIG_IRQ_PRIORITY NRFX_DEFAULT_IRQ_PRIORITY
 #endif
 
-// <o> NRFX_WDT_CONFIG_NO_IRQ  - Remove WDT IRQ handling from WDT driver.
-
-// <0=> Include WDT IRQ handling
-// <1=> Remove WDT IRQ handling
-
+/**
+ * @brief NRFX_WDT_CONFIG_NO_IRQ - Remove WDT IRQ handling from WDT driver
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_WDT_CONFIG_NO_IRQ
 #define NRFX_WDT_CONFIG_NO_IRQ 0
 #endif
 
-// <o> NRFX_WDT_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority.
-
-// <0=> 0 (highest)
-// <1=> 1
-// <2=> 2
-// <3=> 3
-// <4=> 4
-// <5=> 5
-// <6=> 6
-// <7=> 7
-
-#ifndef NRFX_WDT_DEFAULT_CONFIG_IRQ_PRIORITY
-#define NRFX_WDT_DEFAULT_CONFIG_IRQ_PRIORITY 7
-#endif
-
-// <e> NRFX_WDT_CONFIG_LOG_ENABLED - Enables logging in the module.
-//==========================================================
+/**
+ * @brief NRFX_WDT_CONFIG_LOG_ENABLED
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
 #ifndef NRFX_WDT_CONFIG_LOG_ENABLED
 #define NRFX_WDT_CONFIG_LOG_ENABLED 0
 #endif
-// <o> NRFX_WDT_CONFIG_LOG_LEVEL  - Default severity level.
 
-// <0=> Off
-// <1=> Error
-// <2=> Warning
-// <3=> Info
-// <4=> Debug
-
+/**
+ * @brief NRFX_WDT_CONFIG_LOG_LEVEL
+ *
+ * Integer value.
+ * Supported values:
+ * - Off     = 0
+ * - Error   = 1
+ * - Warning = 2
+ * - Info    = 3
+ * - Debug   = 4
+ */
 #ifndef NRFX_WDT_CONFIG_LOG_LEVEL
 #define NRFX_WDT_CONFIG_LOG_LEVEL 3
 #endif
-
-// <o> NRFX_WDT_CONFIG_INFO_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_WDT_CONFIG_INFO_COLOR
-#define NRFX_WDT_CONFIG_INFO_COLOR 0
-#endif
-
-// <o> NRFX_WDT_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
-
-// <0=> Default
-// <1=> Black
-// <2=> Red
-// <3=> Green
-// <4=> Yellow
-// <5=> Blue
-// <6=> Magenta
-// <7=> Cyan
-// <8=> White
-
-#ifndef NRFX_WDT_CONFIG_DEBUG_COLOR
-#define NRFX_WDT_CONFIG_DEBUG_COLOR 0
-#endif
-
-// </e>
-
-// </e>
-
-// </h>
 
 #endif // NRFX_CONFIG_NRF91_H__

--- a/nrfx/templates/nrfx_glue.h
+++ b/nrfx/templates/nrfx_glue.h
@@ -276,6 +276,33 @@ extern "C" {
 
 //------------------------------------------------------------------------------
 
+/**
+ * @brief Macro for writing back cache lines associated with the specified buffer.
+ *
+ * @param[in] p_buffer Pointer to the buffer.
+ * @param[in] size     Size of the buffer.
+ */
+#define NRFY_CACHE_WB(p_buffer, size)
+
+/**
+ * @brief Macro for invalidating cache lines associated with the specified buffer.
+ *
+ * @param[in] p_buffer Pointer to the buffer.
+ * @param[in] size     Size of the buffer.
+ */
+#define NRFY_CACHE_INV(p_buffer, size)
+
+/**
+ * @brief Macro for writing back and invalidating cache lines associated with
+ *        the specified buffer.
+ *
+ * @param[in] p_buffer Pointer to the buffer.
+ * @param[in] size     Size of the buffer.
+ */
+#define NRFY_CACHE_WBINV(p_buffer, size)
+
+//------------------------------------------------------------------------------
+
 /** @brief Bitmask that defines DPPI channels that are reserved for use outside of the nrfx library. */
 #define NRFX_DPPI_CHANNELS_USED   0
 


### PR DESCRIPTION
Update nrfx to the recently released version. See
https://github.com/NordicSemiconductor/nrfx/blob/v3.0.0/CHANGELOG.md for a list of changes that this version introduces.

Origin: nrfx
License: BSD 3-Clause
URL: https://github.com/NordicSemiconductor/nrfx/tree/v3.0.0
commit: 1c721175f22dbb1bf125a570a427b53f810881bb
Purpose: Provide peripheral drivers for Nordic SoCs
Maintained-by: External

mirror of the https://github.com/zephyrproject-rtos/hal_nordic/pull/131 PR with resolved conflicts