### PR TITLE
nrf_ccm: Fix events and tasks for nRF51 SoCs

### DIFF
--- a/nrfx/hal/nrf_ccm.h
+++ b/nrfx/hal/nrf_ccm.h
@@ -50,14 +50,14 @@ extern "C" {
  * @brief   Hardware access layer for managing the AES CCM peripheral.
  */
 
-#if defined(CCM_TASKS_KSGEN_TASKS_KSGEN_Msk) || defined(__NRFX_DOXYGEN__)
+#if defined(CCM_TASKS_KSGEN_TASKS_KSGEN_Msk) || defined(NRF51) || defined(__NRFX_DOXYGEN__)
 /** @brief Presence of the KSGEN task. */
 #define NRF_CCM_HAS_TASK_KSGEN 1
 #else
 #define NRF_CCM_HAS_TASK_KSGEN 0
 #endif
 
-#if defined(CCM_TASKS_CRYPT_TASKS_CRYPT_Msk) || defined(__NRFX_DOXYGEN__)
+#if defined(CCM_TASKS_CRYPT_TASKS_CRYPT_Msk) || defined(NRF51) || defined(__NRFX_DOXYGEN__)
 /** @brief Presence of the CRYPT task. */
 #define NRF_CCM_HAS_TASK_CRYPT 1
 #else


### PR DESCRIPTION
Definition of KSGEN and CRYPT tasks and corresponding events enumerators are guarded by contional symbols that values are based on MDK symbols. MDK for nRF51 SoCs is lacking of the symbols despite having KSGEN/CRYPT events.