### PR TITLE
drivers: nrf_802154: utils: timestamp conversion PHR -> MHR

### DIFF
--- a/drivers/nrf_802154/common/include/nrf_802154_common_utils.h
+++ b/drivers/nrf_802154/common/include/nrf_802154_common_utils.h
@@ -135,6 +135,18 @@ uint64_t nrf_802154_timestamp_end_to_phr_convert(uint64_t end_timestamp, uint8_t
 uint64_t nrf_802154_timestamp_phr_to_shr_convert(uint64_t phr_timestamp);
 
 /**
+ * @brief  Converts the timestamp of the frame's PHR to the timestamp of the start of its MHR.
+ *
+ * This function converts the time when the first symbol of the frame's PHR is at the local antenna
+ * to the timestamp of the start of the frame's MHR.
+ *
+ * @param[in]  phr_timestamp  Timestamp of the frame's PHR.
+ *
+ * @return  Timestamp of the start of the MHR of a given frame, in microseconds.
+ */
+uint64_t nrf_802154_timestamp_phr_to_mhr_convert(uint64_t phr_timestamp);
+
+/**
  * @}
  */
 

--- a/drivers/nrf_802154/common/src/nrf_802154_common_utils.c
+++ b/drivers/nrf_802154/common/src/nrf_802154_common_utils.c
@@ -81,3 +81,8 @@ uint64_t nrf_802154_timestamp_phr_to_shr_convert(uint64_t phr_timestamp)
 {
     return phr_timestamp - (PHY_SHR_SYMBOLS * PHY_US_PER_SYMBOL);
 }
+
+uint64_t nrf_802154_timestamp_phr_to_mhr_convert(uint64_t phr_timestamp)
+{
+    return phr_timestamp + (PHR_SIZE * PHY_SYMBOLS_PER_OCTET * PHY_US_PER_SYMBOL);
+}


### PR DESCRIPTION
Introduces a method to convert from a PHR timestamp to an MHR timestamp.

Required to support conversion from IEEE 802.15.4 standard SFD timestamps to CSL "start of MHR" timestamps, e.g. for CSL anchor calculation.

See https://github.com/zephyrproject-rtos/zephyr/issues/62918