### PR TITLE
nrfx: Fix overflow of pin_flags array on nRF52820 in GPIOTE driver

### DIFF
--- a/nrfx/drivers/src/nrfx_gpiote.c
+++ b/nrfx/drivers/src/nrfx_gpiote.c
@@ -45,8 +45,13 @@
 /* Macro returning number of pins in the port */
 #define GPIO_PIN_NUM(periph, prefix, i, _) NRFX_CONCAT(periph, prefix, i, _PIN_NUM)
 
+#if defined(NRF52820_XXAA)
+/* nRF52820 has gaps between available pins. The symbol can't be based on P0_PIN_NUM. */
+#define MAX_PIN_NUMBER 32
+#else
 /* Macro for calculating total number of pins. */
 #define MAX_PIN_NUMBER NRFX_FOREACH_PRESENT(P, GPIO_PIN_NUM, (+), (0), _)
+#endif
 
 /* Macro returns true if port has 32 pins. */
 #define GPIO_IS_FULL_PORT(periph, prefix, i, _) \


### PR DESCRIPTION
GPIOTE driver was incorrectly defining the size of the `pin_flags` array on nRF52820 SoC. The target has 18 pins - as the value of the `P0_PIN_NUM` symbol. However, those pins are not consecutive pins from 0 to 17. The nRF52820 has routed pins 0-8, 14-18, 20 and 28-30.

As a result, accessing pin 18 and above marks in reads/writes that exceed the boundary of the `pin_flags` array. To mitigate that issue, the `MAX_PIN_NUMBER` symbol that is used to define the `pin_flags` array size is now defined as 32 for the nRF52820 device.