### PR TITLE
mdk: Align with ARM's definition of __VECTOR_TABLE_ATTRIBUTE

### DIFF
--- a/nrfx/mdk/compiler_abstraction.h
+++ b/nrfx/mdk/compiler_abstraction.h
@@ -338,7 +338,7 @@ POSSIBILITY OF SUCH DAMAGE.
     #endif
 
     #ifndef __VECTOR_TABLE_ATTRIBUTE
-        #define __VECTOR_TABLE_ATTRIBUTE  __attribute__((used, section(".isr_vector")))
+        #define __VECTOR_TABLE_ATTRIBUTE  __attribute__((used, section(".vectors")))
     #endif
 
     #ifndef __STACK_ATTRIBUTES


### PR DESCRIPTION
nrfx has defined __VECTOR_TABLE_ATTRIBUTE to have the section name .isr_vector, but this breaks projects that have previously been using ARM's CMSIS implementation.

https://github.com/ARM-software/CMSIS_5/blob/develop/CMSIS/Core/Include/cmsis_gcc.h#L188

I don't see why nrfx should use a different default value from ARM.