### PR TITLE
nrfx_wdt: Remove incorrect assertion

### DIFF
--- a/nrfx/drivers/src/nrfx_wdt.c
+++ b/nrfx/drivers/src/nrfx_wdt.c
@@ -104,7 +104,6 @@ static nrfx_err_t wdt_init(nrfx_wdt_t const *        p_instance,
                            nrfx_wdt_event_handler_t  wdt_event_handler,
                            void *                    p_context)
 {
-    NRFX_ASSERT(p_config);
     nrfx_err_t err_code;
 
     wdt_control_block_t * p_cb = &m_cb[p_instance->drv_inst_idx];


### PR DESCRIPTION
Since nrfx 3.0.0 it is allowed to initialize the driver without providing an initial configuration. Remove an assertion that still ensures that such configuration was actually provided.