### PR TITLE
nrfx_qspi: Correct use of workaround for anomaly 215 and 43 in nrfx_qspi

### DIFF
--- a/nrfx/drivers/include/nrfx_qspi.h
+++ b/nrfx/drivers/include/nrfx_qspi.h
@@ -236,7 +236,12 @@ nrfx_err_t nrfx_qspi_init(nrfx_qspi_config_t const * p_config,
  */
 nrfx_err_t nrfx_qspi_reconfigure(nrfx_qspi_config_t const * p_config);
 
-/** @brief Function for uninitializing the QSPI driver instance. */
+/**
+ * @brief Function for uninitializing the QSPI driver instance.
+ *
+ * @note If a custom instruction long transfer is ongoing when the function is called,
+ *       the transfer will be interrupted.
+ */
 void nrfx_qspi_uninit(void);
 
 /**
@@ -250,7 +255,11 @@ void nrfx_qspi_uninit(void);
  */
 nrfx_err_t nrfx_qspi_activate(bool wait);
 
-/** @brief Function for deactivating the QSPI driver instance.
+/**
+ * @brief Function for deactivating the QSPI driver instance.
+ *
+ * @note If a custom instruction long transfer is ongoing when the function is called,
+ *       the transfer will be interrupted.
  *
  * @retval NRFX_SUCCESS    The driver instance has been activated.
  * @retval NRFX_ERROR_BUSY The driver is during transaction.

--- a/nrfx/drivers/src/nrfx_qspi.c
+++ b/nrfx/drivers/src/nrfx_qspi.c
@@ -372,11 +372,6 @@ static void qspi_deactivate(void)
 {
     m_cb.activated = false;
 
-    if (nrf_qspi_cinstr_long_transfer_is_ongoing(NRF_QSPI))
-    {
-        nrf_qspi_cinstr_long_transfer_continue(NRF_QSPI, NRF_QSPI_CINSTR_LEN_1B, true);
-    }
-
     nrf_qspi_int_disable(NRF_QSPI, NRF_QSPI_INT_READY_MASK);
 
     nrf_qspi_task_trigger(NRF_QSPI, NRF_QSPI_TASK_DEACTIVATE);
@@ -508,14 +503,6 @@ nrfx_err_t nrfx_qspi_cinstr_xfer(nrf_qspi_cinstr_conf_t const * p_config,
         return NRFX_ERROR_TIMEOUT;
     }
 
-    /* In some cases, only opcode should be sent. To prevent execution, set function code is
-     * surrounded by an if.
-     */
-    if (p_tx_buffer)
-    {
-        nrf_qspi_cinstrdata_set(NRF_QSPI, p_config->length, p_tx_buffer);
-    }
-
     /* For custom instruction transfer driver has to switch to blocking mode.
      * If driver was previously configured to non-blocking mode, interrupts
      * will get reenabled before next standard transfer.
@@ -529,6 +516,14 @@ nrfx_err_t nrfx_qspi_cinstr_xfer(nrf_qspi_cinstr_conf_t const * p_config,
     if (NRF52_ERRATA_215_ENABLE_WORKAROUND || NRF53_ERRATA_43_ENABLE_WORKAROUND)
     {
         qspi_workaround_apply();
+    }
+
+    /* In some cases, only opcode should be sent. To prevent execution, set function code is
+     * surrounded by an if.
+     */
+    if (p_tx_buffer)
+    {
+        nrf_qspi_cinstrdata_set(NRF_QSPI, p_config->length, p_tx_buffer);
     }
 
     m_cb.timeout_signal = false;


### PR DESCRIPTION
The code that accesses QSPI registers above 0x600 needs to apply workaround for anomaly 215 on nRF52840 or anomaly 43 on nRF5340.

The commit removes check if a custom instruction long transfer is ongoing from deactivate function. The check could trigger anomalies and now it's user responsibility to be sure that custom instruction long transfer has ended otherwise it will be interrupted.

Change affects behaviour of nrfx_qspi_uinit() and nrfx_qspi_deactivate() what is mentioned in documentation for that functions.