### PR TITLE
nrfx: Fix compilation failures in nrfx_gppi_dppi_ppib.c

### DIFF
--- a/nrfx/helpers/nrfx_gppi_dppi_ppib.c
+++ b/nrfx/helpers/nrfx_gppi_dppi_ppib.c
@@ -40,7 +40,6 @@
 #include <soc/interconnect/ipct/nrfx_interconnect_ipct.h>
 #include <hal/nrf_ppib.h>
 #include <helpers/nrfx_flag32_allocator.h>
-#include <soc/nrfx_atomic.h>
 
 #define CHANNEL_INVALID UINT8_MAX
 
@@ -101,8 +100,8 @@ static nrfx_err_t channel_allocate(nrfx_atomic_t * p_channels_available,
             chan_to_alloc = (uint8_t)(31UL - NRF_CLZ(chan_avail_masked));
         }
 
-        prev_mask = nrfx_atomic_u32_fetch_and((nrfx_atomic_u32_t *)p_channels_available,
-                                              ~NRFX_BIT(chan_to_alloc));
+        prev_mask = NRFX_ATOMIC_FETCH_AND(p_channels_available,
+                                          ~NRFX_BIT(chan_to_alloc));
     } while (prev_mask == *p_channels_available);
     *p_channel = chan_to_alloc;
     return NRFX_SUCCESS;

--- a/nrfx/soc/interconnect/ipct/nrfx_interconnect_ipct.h
+++ b/nrfx/soc/interconnect/ipct/nrfx_interconnect_ipct.h
@@ -36,7 +36,7 @@
 
 #include <nrfx.h>
 #include <hal/nrf_ipct.h>
-#include <interconnect/apb/nrfx_interconnect_apb.h>
+#include <soc/interconnect/apb/nrfx_interconnect_apb.h>
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
Remove dependency on the nrfx_atomic component that is not present in hal_nordic.
Add missing `soc/` part in one interconnect header inclusion.

These are temporary changes in files imported from the nrfx repository and they are supposed to be overwritten by the next update of nrfx.