### PR TITLE
Fixes for nrfx_uarte

### DIFF
--- a/nrfx/drivers/src/nrfx_uarte.c
+++ b/nrfx/drivers/src/nrfx_uarte.c
@@ -1508,6 +1508,10 @@ static void wait_for_rx_completion(NRF_UARTE_Type *        p_uarte,
     while(nrfy_uarte_event_check(p_uarte, NRF_UARTE_EVENT_RXTO) == false)
     {}
 
+    nrfy_uarte_event_clear(p_uarte, NRF_UARTE_EVENT_RXSTARTED);
+    nrfy_uarte_event_clear(p_uarte, NRF_UARTE_EVENT_ENDRX);
+    nrfy_uarte_event_clear(p_uarte, NRF_UARTE_EVENT_RXTO);
+
     rx_flush(p_uarte, p_cb);
     disable_hw_from_rx(p_uarte);
 

--- a/nrfx/mdk/nrf54l15_application_peripherals.h
+++ b/nrfx/mdk/nrf54l15_application_peripherals.h
@@ -507,8 +507,8 @@ POSSIBILITY OF SUCH DAMAGE.
 #define UARTE_COUNT 5
 
 #define UARTE00_EASYDMA_MAXCNT_MIN 0                 /*!< (unspecified)                                                        */
-#define UARTE00_EASYDMA_MAXCNT_MAX 7                 /*!< (unspecified)                                                        */
-#define UARTE00_EASYDMA_MAXCNT_SIZE 8                /*!< (unspecified)                                                        */
+#define UARTE00_EASYDMA_MAXCNT_MAX 15                /*!< (unspecified)                                                        */
+#define UARTE00_EASYDMA_MAXCNT_SIZE 16               /*!< (unspecified)                                                        */
 #define UARTE00_TIMEOUT_INTERRUPT 1                  /*!< (unspecified)                                                        */
 #define UARTE00_CONFIGURABLE_DATA_FRAME_SIZE 1       /*!< (unspecified)                                                        */
 #define UARTE00_CORE_FREQUENCY 128                   /*!< Peripheral clock frequency is 128 MHz.                               */
@@ -517,8 +517,8 @@ POSSIBILITY OF SUCH DAMAGE.
 #define UARTE00_EASYDMA_CURRENT_AMOUNT_REGISTER_INCLUDED 0 /*!< (unspecified)                                                  */
 
 #define UARTE20_EASYDMA_MAXCNT_MIN 0                 /*!< (unspecified)                                                        */
-#define UARTE20_EASYDMA_MAXCNT_MAX 7                 /*!< (unspecified)                                                        */
-#define UARTE20_EASYDMA_MAXCNT_SIZE 8                /*!< (unspecified)                                                        */
+#define UARTE20_EASYDMA_MAXCNT_MAX 15                /*!< (unspecified)                                                        */
+#define UARTE20_EASYDMA_MAXCNT_SIZE 16               /*!< (unspecified)                                                        */
 #define UARTE20_TIMEOUT_INTERRUPT 1                  /*!< (unspecified)                                                        */
 #define UARTE20_CONFIGURABLE_DATA_FRAME_SIZE 1       /*!< (unspecified)                                                        */
 #define UARTE20_CORE_FREQUENCY 16                    /*!< Peripheral clock frequency is 16 MHz.                                */
@@ -527,8 +527,8 @@ POSSIBILITY OF SUCH DAMAGE.
 #define UARTE20_EASYDMA_CURRENT_AMOUNT_REGISTER_INCLUDED 0 /*!< (unspecified)                                                  */
 
 #define UARTE21_EASYDMA_MAXCNT_MIN 0                 /*!< (unspecified)                                                        */
-#define UARTE21_EASYDMA_MAXCNT_MAX 7                 /*!< (unspecified)                                                        */
-#define UARTE21_EASYDMA_MAXCNT_SIZE 8                /*!< (unspecified)                                                        */
+#define UARTE21_EASYDMA_MAXCNT_MAX 15                /*!< (unspecified)                                                        */
+#define UARTE21_EASYDMA_MAXCNT_SIZE 16               /*!< (unspecified)                                                        */
 #define UARTE21_TIMEOUT_INTERRUPT 1                  /*!< (unspecified)                                                        */
 #define UARTE21_CONFIGURABLE_DATA_FRAME_SIZE 1       /*!< (unspecified)                                                        */
 #define UARTE21_CORE_FREQUENCY 16                    /*!< Peripheral clock frequency is 16 MHz.                                */
@@ -537,8 +537,8 @@ POSSIBILITY OF SUCH DAMAGE.
 #define UARTE21_EASYDMA_CURRENT_AMOUNT_REGISTER_INCLUDED 0 /*!< (unspecified)                                                  */
 
 #define UARTE22_EASYDMA_MAXCNT_MIN 0                 /*!< (unspecified)                                                        */
-#define UARTE22_EASYDMA_MAXCNT_MAX 7                 /*!< (unspecified)                                                        */
-#define UARTE22_EASYDMA_MAXCNT_SIZE 8                /*!< (unspecified)                                                        */
+#define UARTE22_EASYDMA_MAXCNT_MAX 15                /*!< (unspecified)                                                        */
+#define UARTE22_EASYDMA_MAXCNT_SIZE 16               /*!< (unspecified)                                                        */
 #define UARTE22_TIMEOUT_INTERRUPT 1                  /*!< (unspecified)                                                        */
 #define UARTE22_CONFIGURABLE_DATA_FRAME_SIZE 1       /*!< (unspecified)                                                        */
 #define UARTE22_CORE_FREQUENCY 16                    /*!< Peripheral clock frequency is 16 MHz.                                */
@@ -547,8 +547,8 @@ POSSIBILITY OF SUCH DAMAGE.
 #define UARTE22_EASYDMA_CURRENT_AMOUNT_REGISTER_INCLUDED 0 /*!< (unspecified)                                                  */
 
 #define UARTE30_EASYDMA_MAXCNT_MIN 0                 /*!< (unspecified)                                                        */
-#define UARTE30_EASYDMA_MAXCNT_MAX 7                 /*!< (unspecified)                                                        */
-#define UARTE30_EASYDMA_MAXCNT_SIZE 8                /*!< (unspecified)                                                        */
+#define UARTE30_EASYDMA_MAXCNT_MAX 15                /*!< (unspecified)                                                        */
+#define UARTE30_EASYDMA_MAXCNT_SIZE 16               /*!< (unspecified)                                                        */
 #define UARTE30_TIMEOUT_INTERRUPT 1                  /*!< (unspecified)                                                        */
 #define UARTE30_CONFIGURABLE_DATA_FRAME_SIZE 1       /*!< (unspecified)                                                        */
 #define UARTE30_CORE_FREQUENCY 16                    /*!< Peripheral clock frequency is 16 MHz.                                */

--- a/nrfx/mdk/nrf54l15_enga_application_peripherals.h
+++ b/nrfx/mdk/nrf54l15_enga_application_peripherals.h
@@ -507,8 +507,8 @@ POSSIBILITY OF SUCH DAMAGE.
 #define UARTE_COUNT 5
 
 #define UARTE00_EASYDMA_MAXCNT_MIN 0                 /*!< (unspecified)                                                        */
-#define UARTE00_EASYDMA_MAXCNT_MAX 7                 /*!< (unspecified)                                                        */
-#define UARTE00_EASYDMA_MAXCNT_SIZE 8                /*!< (unspecified)                                                        */
+#define UARTE00_EASYDMA_MAXCNT_MAX 15                /*!< (unspecified)                                                        */
+#define UARTE00_EASYDMA_MAXCNT_SIZE 16               /*!< (unspecified)                                                        */
 #define UARTE00_TIMEOUT_INTERRUPT 1                  /*!< (unspecified)                                                        */
 #define UARTE00_CONFIGURABLE_DATA_FRAME_SIZE 1       /*!< (unspecified)                                                        */
 #define UARTE00_CORE_FREQUENCY 128                   /*!< Peripheral clock frequency is 128 MHz.                               */
@@ -517,8 +517,8 @@ POSSIBILITY OF SUCH DAMAGE.
 #define UARTE00_EASYDMA_CURRENT_AMOUNT_REGISTER_INCLUDED 0 /*!< (unspecified)                                                  */
 
 #define UARTE20_EASYDMA_MAXCNT_MIN 0                 /*!< (unspecified)                                                        */
-#define UARTE20_EASYDMA_MAXCNT_MAX 7                 /*!< (unspecified)                                                        */
-#define UARTE20_EASYDMA_MAXCNT_SIZE 8                /*!< (unspecified)                                                        */
+#define UARTE20_EASYDMA_MAXCNT_MAX 15                /*!< (unspecified)                                                        */
+#define UARTE20_EASYDMA_MAXCNT_SIZE 16               /*!< (unspecified)                                                        */
 #define UARTE20_TIMEOUT_INTERRUPT 1                  /*!< (unspecified)                                                        */
 #define UARTE20_CONFIGURABLE_DATA_FRAME_SIZE 1       /*!< (unspecified)                                                        */
 #define UARTE20_CORE_FREQUENCY 16                    /*!< Peripheral clock frequency is 16 MHz.                                */
@@ -527,8 +527,8 @@ POSSIBILITY OF SUCH DAMAGE.
 #define UARTE20_EASYDMA_CURRENT_AMOUNT_REGISTER_INCLUDED 0 /*!< (unspecified)                                                  */
 
 #define UARTE21_EASYDMA_MAXCNT_MIN 0                 /*!< (unspecified)                                                        */
-#define UARTE21_EASYDMA_MAXCNT_MAX 7                 /*!< (unspecified)                                                        */
-#define UARTE21_EASYDMA_MAXCNT_SIZE 8                /*!< (unspecified)                                                        */
+#define UARTE21_EASYDMA_MAXCNT_MAX 15                /*!< (unspecified)                                                        */
+#define UARTE21_EASYDMA_MAXCNT_SIZE 16               /*!< (unspecified)                                                        */
 #define UARTE21_TIMEOUT_INTERRUPT 1                  /*!< (unspecified)                                                        */
 #define UARTE21_CONFIGURABLE_DATA_FRAME_SIZE 1       /*!< (unspecified)                                                        */
 #define UARTE21_CORE_FREQUENCY 16                    /*!< Peripheral clock frequency is 16 MHz.                                */
@@ -537,8 +537,8 @@ POSSIBILITY OF SUCH DAMAGE.
 #define UARTE21_EASYDMA_CURRENT_AMOUNT_REGISTER_INCLUDED 0 /*!< (unspecified)                                                  */
 
 #define UARTE22_EASYDMA_MAXCNT_MIN 0                 /*!< (unspecified)                                                        */
-#define UARTE22_EASYDMA_MAXCNT_MAX 7                 /*!< (unspecified)                                                        */
-#define UARTE22_EASYDMA_MAXCNT_SIZE 8                /*!< (unspecified)                                                        */
+#define UARTE22_EASYDMA_MAXCNT_MAX 15                /*!< (unspecified)                                                        */
+#define UARTE22_EASYDMA_MAXCNT_SIZE 16               /*!< (unspecified)                                                        */
 #define UARTE22_TIMEOUT_INTERRUPT 1                  /*!< (unspecified)                                                        */
 #define UARTE22_CONFIGURABLE_DATA_FRAME_SIZE 1       /*!< (unspecified)                                                        */
 #define UARTE22_CORE_FREQUENCY 16                    /*!< Peripheral clock frequency is 16 MHz.                                */
@@ -547,8 +547,8 @@ POSSIBILITY OF SUCH DAMAGE.
 #define UARTE22_EASYDMA_CURRENT_AMOUNT_REGISTER_INCLUDED 0 /*!< (unspecified)                                                  */
 
 #define UARTE30_EASYDMA_MAXCNT_MIN 0                 /*!< (unspecified)                                                        */
-#define UARTE30_EASYDMA_MAXCNT_MAX 7                 /*!< (unspecified)                                                        */
-#define UARTE30_EASYDMA_MAXCNT_SIZE 8                /*!< (unspecified)                                                        */
+#define UARTE30_EASYDMA_MAXCNT_MAX 15                /*!< (unspecified)                                                        */
+#define UARTE30_EASYDMA_MAXCNT_SIZE 16               /*!< (unspecified)                                                        */
 #define UARTE30_TIMEOUT_INTERRUPT 1                  /*!< (unspecified)                                                        */
 #define UARTE30_CONFIGURABLE_DATA_FRAME_SIZE 1       /*!< (unspecified)                                                        */
 #define UARTE30_CORE_FREQUENCY 16                    /*!< Peripheral clock frequency is 16 MHz.                                */

--- a/nrfx/mdk/nrf54l15_enga_flpr_peripherals.h
+++ b/nrfx/mdk/nrf54l15_enga_flpr_peripherals.h
@@ -485,8 +485,8 @@ POSSIBILITY OF SUCH DAMAGE.
 #define UARTE_COUNT 5
 
 #define UARTE00_EASYDMA_MAXCNT_MIN 0                 /*!< (unspecified)                                                        */
-#define UARTE00_EASYDMA_MAXCNT_MAX 7                 /*!< (unspecified)                                                        */
-#define UARTE00_EASYDMA_MAXCNT_SIZE 8                /*!< (unspecified)                                                        */
+#define UARTE00_EASYDMA_MAXCNT_MAX 15                /*!< (unspecified)                                                        */
+#define UARTE00_EASYDMA_MAXCNT_SIZE 16               /*!< (unspecified)                                                        */
 #define UARTE00_TIMEOUT_INTERRUPT 1                  /*!< (unspecified)                                                        */
 #define UARTE00_CONFIGURABLE_DATA_FRAME_SIZE 1       /*!< (unspecified)                                                        */
 #define UARTE00_CORE_FREQUENCY 128                   /*!< Peripheral clock frequency is 128 MHz.                               */
@@ -495,8 +495,8 @@ POSSIBILITY OF SUCH DAMAGE.
 #define UARTE00_EASYDMA_CURRENT_AMOUNT_REGISTER_INCLUDED 0 /*!< (unspecified)                                                  */
 
 #define UARTE20_EASYDMA_MAXCNT_MIN 0                 /*!< (unspecified)                                                        */
-#define UARTE20_EASYDMA_MAXCNT_MAX 7                 /*!< (unspecified)                                                        */
-#define UARTE20_EASYDMA_MAXCNT_SIZE 8                /*!< (unspecified)                                                        */
+#define UARTE20_EASYDMA_MAXCNT_MAX 15                /*!< (unspecified)                                                        */
+#define UARTE20_EASYDMA_MAXCNT_SIZE 16               /*!< (unspecified)                                                        */
 #define UARTE20_TIMEOUT_INTERRUPT 1                  /*!< (unspecified)                                                        */
 #define UARTE20_CONFIGURABLE_DATA_FRAME_SIZE 1       /*!< (unspecified)                                                        */
 #define UARTE20_CORE_FREQUENCY 16                    /*!< Peripheral clock frequency is 16 MHz.                                */
@@ -505,8 +505,8 @@ POSSIBILITY OF SUCH DAMAGE.
 #define UARTE20_EASYDMA_CURRENT_AMOUNT_REGISTER_INCLUDED 0 /*!< (unspecified)                                                  */
 
 #define UARTE21_EASYDMA_MAXCNT_MIN 0                 /*!< (unspecified)                                                        */
-#define UARTE21_EASYDMA_MAXCNT_MAX 7                 /*!< (unspecified)                                                        */
-#define UARTE21_EASYDMA_MAXCNT_SIZE 8                /*!< (unspecified)                                                        */
+#define UARTE21_EASYDMA_MAXCNT_MAX 15                /*!< (unspecified)                                                        */
+#define UARTE21_EASYDMA_MAXCNT_SIZE 16               /*!< (unspecified)                                                        */
 #define UARTE21_TIMEOUT_INTERRUPT 1                  /*!< (unspecified)                                                        */
 #define UARTE21_CONFIGURABLE_DATA_FRAME_SIZE 1       /*!< (unspecified)                                                        */
 #define UARTE21_CORE_FREQUENCY 16                    /*!< Peripheral clock frequency is 16 MHz.                                */
@@ -515,8 +515,8 @@ POSSIBILITY OF SUCH DAMAGE.
 #define UARTE21_EASYDMA_CURRENT_AMOUNT_REGISTER_INCLUDED 0 /*!< (unspecified)                                                  */
 
 #define UARTE22_EASYDMA_MAXCNT_MIN 0                 /*!< (unspecified)                                                        */
-#define UARTE22_EASYDMA_MAXCNT_MAX 7                 /*!< (unspecified)                                                        */
-#define UARTE22_EASYDMA_MAXCNT_SIZE 8                /*!< (unspecified)                                                        */
+#define UARTE22_EASYDMA_MAXCNT_MAX 15                /*!< (unspecified)                                                        */
+#define UARTE22_EASYDMA_MAXCNT_SIZE 16               /*!< (unspecified)                                                        */
 #define UARTE22_TIMEOUT_INTERRUPT 1                  /*!< (unspecified)                                                        */
 #define UARTE22_CONFIGURABLE_DATA_FRAME_SIZE 1       /*!< (unspecified)                                                        */
 #define UARTE22_CORE_FREQUENCY 16                    /*!< Peripheral clock frequency is 16 MHz.                                */
@@ -525,8 +525,8 @@ POSSIBILITY OF SUCH DAMAGE.
 #define UARTE22_EASYDMA_CURRENT_AMOUNT_REGISTER_INCLUDED 0 /*!< (unspecified)                                                  */
 
 #define UARTE30_EASYDMA_MAXCNT_MIN 0                 /*!< (unspecified)                                                        */
-#define UARTE30_EASYDMA_MAXCNT_MAX 7                 /*!< (unspecified)                                                        */
-#define UARTE30_EASYDMA_MAXCNT_SIZE 8                /*!< (unspecified)                                                        */
+#define UARTE30_EASYDMA_MAXCNT_MAX 15                /*!< (unspecified)                                                        */
+#define UARTE30_EASYDMA_MAXCNT_SIZE 16               /*!< (unspecified)                                                        */
 #define UARTE30_TIMEOUT_INTERRUPT 1                  /*!< (unspecified)                                                        */
 #define UARTE30_CONFIGURABLE_DATA_FRAME_SIZE 1       /*!< (unspecified)                                                        */
 #define UARTE30_CORE_FREQUENCY 16                    /*!< Peripheral clock frequency is 16 MHz.                                */

--- a/nrfx/mdk/nrf54l15_flpr_peripherals.h
+++ b/nrfx/mdk/nrf54l15_flpr_peripherals.h
@@ -485,8 +485,8 @@ POSSIBILITY OF SUCH DAMAGE.
 #define UARTE_COUNT 5
 
 #define UARTE00_EASYDMA_MAXCNT_MIN 0                 /*!< (unspecified)                                                        */
-#define UARTE00_EASYDMA_MAXCNT_MAX 7                 /*!< (unspecified)                                                        */
-#define UARTE00_EASYDMA_MAXCNT_SIZE 8                /*!< (unspecified)                                                        */
+#define UARTE00_EASYDMA_MAXCNT_MAX 15                /*!< (unspecified)                                                        */
+#define UARTE00_EASYDMA_MAXCNT_SIZE 16               /*!< (unspecified)                                                        */
 #define UARTE00_TIMEOUT_INTERRUPT 1                  /*!< (unspecified)                                                        */
 #define UARTE00_CONFIGURABLE_DATA_FRAME_SIZE 1       /*!< (unspecified)                                                        */
 #define UARTE00_CORE_FREQUENCY 128                   /*!< Peripheral clock frequency is 128 MHz.                               */
@@ -495,8 +495,8 @@ POSSIBILITY OF SUCH DAMAGE.
 #define UARTE00_EASYDMA_CURRENT_AMOUNT_REGISTER_INCLUDED 0 /*!< (unspecified)                                                  */
 
 #define UARTE20_EASYDMA_MAXCNT_MIN 0                 /*!< (unspecified)                                                        */
-#define UARTE20_EASYDMA_MAXCNT_MAX 7                 /*!< (unspecified)                                                        */
-#define UARTE20_EASYDMA_MAXCNT_SIZE 8                /*!< (unspecified)                                                        */
+#define UARTE20_EASYDMA_MAXCNT_MAX 15                /*!< (unspecified)                                                        */
+#define UARTE20_EASYDMA_MAXCNT_SIZE 16               /*!< (unspecified)                                                        */
 #define UARTE20_TIMEOUT_INTERRUPT 1                  /*!< (unspecified)                                                        */
 #define UARTE20_CONFIGURABLE_DATA_FRAME_SIZE 1       /*!< (unspecified)                                                        */
 #define UARTE20_CORE_FREQUENCY 16                    /*!< Peripheral clock frequency is 16 MHz.                                */
@@ -505,8 +505,8 @@ POSSIBILITY OF SUCH DAMAGE.
 #define UARTE20_EASYDMA_CURRENT_AMOUNT_REGISTER_INCLUDED 0 /*!< (unspecified)                                                  */
 
 #define UARTE21_EASYDMA_MAXCNT_MIN 0                 /*!< (unspecified)                                                        */
-#define UARTE21_EASYDMA_MAXCNT_MAX 7                 /*!< (unspecified)                                                        */
-#define UARTE21_EASYDMA_MAXCNT_SIZE 8                /*!< (unspecified)                                                        */
+#define UARTE21_EASYDMA_MAXCNT_MAX 15                /*!< (unspecified)                                                        */
+#define UARTE21_EASYDMA_MAXCNT_SIZE 16               /*!< (unspecified)                                                        */
 #define UARTE21_TIMEOUT_INTERRUPT 1                  /*!< (unspecified)                                                        */
 #define UARTE21_CONFIGURABLE_DATA_FRAME_SIZE 1       /*!< (unspecified)                                                        */
 #define UARTE21_CORE_FREQUENCY 16                    /*!< Peripheral clock frequency is 16 MHz.                                */
@@ -515,8 +515,8 @@ POSSIBILITY OF SUCH DAMAGE.
 #define UARTE21_EASYDMA_CURRENT_AMOUNT_REGISTER_INCLUDED 0 /*!< (unspecified)                                                  */
 
 #define UARTE22_EASYDMA_MAXCNT_MIN 0                 /*!< (unspecified)                                                        */
-#define UARTE22_EASYDMA_MAXCNT_MAX 7                 /*!< (unspecified)                                                        */
-#define UARTE22_EASYDMA_MAXCNT_SIZE 8                /*!< (unspecified)                                                        */
+#define UARTE22_EASYDMA_MAXCNT_MAX 15                /*!< (unspecified)                                                        */
+#define UARTE22_EASYDMA_MAXCNT_SIZE 16               /*!< (unspecified)                                                        */
 #define UARTE22_TIMEOUT_INTERRUPT 1                  /*!< (unspecified)                                                        */
 #define UARTE22_CONFIGURABLE_DATA_FRAME_SIZE 1       /*!< (unspecified)                                                        */
 #define UARTE22_CORE_FREQUENCY 16                    /*!< Peripheral clock frequency is 16 MHz.                                */
@@ -525,8 +525,8 @@ POSSIBILITY OF SUCH DAMAGE.
 #define UARTE22_EASYDMA_CURRENT_AMOUNT_REGISTER_INCLUDED 0 /*!< (unspecified)                                                  */
 
 #define UARTE30_EASYDMA_MAXCNT_MIN 0                 /*!< (unspecified)                                                        */
-#define UARTE30_EASYDMA_MAXCNT_MAX 7                 /*!< (unspecified)                                                        */
-#define UARTE30_EASYDMA_MAXCNT_SIZE 8                /*!< (unspecified)                                                        */
+#define UARTE30_EASYDMA_MAXCNT_MAX 15                /*!< (unspecified)                                                        */
+#define UARTE30_EASYDMA_MAXCNT_SIZE 16               /*!< (unspecified)                                                        */
 #define UARTE30_TIMEOUT_INTERRUPT 1                  /*!< (unspecified)                                                        */
 #define UARTE30_CONFIGURABLE_DATA_FRAME_SIZE 1       /*!< (unspecified)                                                        */
 #define UARTE30_CORE_FREQUENCY 16                    /*!< Peripheral clock frequency is 16 MHz.                                */


### PR DESCRIPTION
3 fixes:
- Fix MDK for nrf54l15 to use correct values for MAX EasyDMA transfer length for UARTE. Without this fix transfers are limited to 127 bytes.
- Add clearing of RX events after blocking RX disable so that receiver starts with clean state on the following RX enabling.
- Fix race condition in the interrupt handler.