### PR TITLE
PPIB: Strict C compliance warning waive

### DIFF
--- a/nrfx/hal/nrf_ppib.h
+++ b/nrfx/hal/nrf_ppib.h
@@ -127,6 +127,11 @@ typedef enum
     NRF_PPIB_EVENT_RECEIVE_31 = offsetof(NRF_PPIB_Type, EVENTS_RECEIVE[31]), /**< Receive 31 event. */
 } nrf_ppib_event_t;
 
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
+
 /** @brief Send task mask. */
 typedef enum
 {
@@ -163,6 +168,10 @@ typedef enum
     NRF_PPIB_SEND_30_MASK = PPIB_OVERFLOW_SEND_SEND30_Msk, /* Send task 30 mask. */
     NRF_PPIB_SEND_31_MASK = PPIB_OVERFLOW_SEND_SEND31_Msk, /* Send task 31 mask. */
 } nrf_ppib_send_mask_t;
+
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
 /**
  * @brief Function for returning the specified PPIB SEND task.


### PR DESCRIPTION
Enumerate values need to fit in the range of
int if we are to be strictly standad compliant.
But for this emum in question, its highest value
is generated from a bitmask of the 31st bit,
which, as a possitive number is out the int range.

This can cause warnings for compilers
which are run in a pedantic enough mode.
GCC is one of this, producing a warning like:
"warning: ISO C restricts enumerator values to range of ‘int’" when run with "-Wpedantic"
Let's disable these warnings for this enum definition when building for GCC.
Apart from this warning, GCC seems to properly handle this case.

Note that as this definitions are in headers, the issue is triggered when a user tries to compile their code with the corresponding warnings enabled.

---

Zephyr test PR: https://github.com/zephyrproject-rtos/zephyr/pull/71766