### PR TITLE
haly gpiote: Make bitwise shift portable way

### DIFF
--- a/nrfx/haly/nrfy_common.h
+++ b/nrfx/haly/nrfy_common.h
@@ -70,7 +70,7 @@ extern "C" {
  *
  * @return Interrupt bitmask.
  */
-#define NRFY_EVENT_TO_INT_BITMASK(event) (1 << NRFY_EVENT_TO_INT_BITPOS(event))
+#define NRFY_EVENT_TO_INT_BITMASK(event) (1U << NRFY_EVENT_TO_INT_BITPOS(event))
 
 /** @sa NRFX_IRQ_PRIORITY_SET */
 #define NRFY_IRQ_PRIORITY_SET(irq_number, priority) NRFX_IRQ_PRIORITY_SET(irq_number, priority)


### PR DESCRIPTION
The value to shift is casted to unsigned exclusively to make operation portable.

This issue is catched by UBSAN as
"left shift of 1 by 31 places cannot be represented in type int"