### PR TITLE
Adding workaround for nrf52 anomaly 89

### DIFF
--- a/nrfx/drivers/src/nrfx_twim.c
+++ b/nrfx/drivers/src/nrfx_twim.c
@@ -375,6 +375,11 @@ void nrfx_twim_disable(nrfx_twim_t const * p_instance)
 
     p_cb->int_mask = 0;
     nrfy_twim_stop(p_instance->p_twim);
+#if NRFX_CHECK(NRFX_TWIM_NRF52_ANOMALY_89_WORKAROUND_ENABLED)
+    p_instance->p_twim->POWER = 0;
+    p_instance->p_twim->POWER;
+    p_instance->p_twim->POWER = 1;
+#endif
     p_cb->state = NRFX_DRV_STATE_INITIALIZED;
     p_cb->busy = false;
     NRFX_LOG_INFO("Instance disabled: %d.", p_instance->drv_inst_idx);

--- a/nrfx/mdk/nrf52.h
+++ b/nrfx/mdk/nrf52.h
@@ -1339,7 +1339,9 @@ typedef struct {                                /*!< (@ 0x40003000) TWIM0 Struct
   __IOM TWIM_TXD_Type TXD;                      /*!< (@ 0x00000544) TXD EasyDMA channel                                        */
   __IM  uint32_t  RESERVED14[13];
   __IOM uint32_t  ADDRESS;                      /*!< (@ 0x00000588) Address used in the TWI transfer                           */
-} NRF_TWIM_Type;                                /*!< Size = 1420 (0x58c)                                                       */
+  __IM  uint32_t  RESERVED15[668];
+  __IOM uint32_t  POWER;                        /*!< (@ 0x00000FFC) Peripheral power control                                   */
+} NRF_TWIM_Type;                                /*!< Size = 4096 (0x1000)                                                      */
 
 
 

--- a/nrfx/templates/nrfx_config_nrf52832.h
+++ b/nrfx/templates/nrfx_config_nrf52832.h
@@ -1354,6 +1354,15 @@
 #endif
 
 /**
+ * @brief NRFX_TWIM_NRF52_ANOMALY_89_WORKAROUND_ENABLED - Enables nRF52 Anomaly 89 workaround for TWIM.
+ *
+ * Boolean. Accepted values 0 and 1.
+ */
+#ifndef NRFX_TWIM_NRF52_ANOMALY_89_WORKAROUND_ENABLED
+#define NRFX_TWIM_NRF52_ANOMALY_89_WORKAROUND_ENABLED 0
+#endif
+
+/**
  * @brief NRFX_TWIM_CONFIG_LOG_LEVEL
  *
  * Integer value.


### PR DESCRIPTION
doing exactly what is written here:
https://infocenter.nordicsemi.com/topic/errata_nRF52832_Rev2/ERR/nRF52832/Rev2/latest/anomaly_832_89.html

This should be seen in cooperation with https://github.com/zephyrproject-rtos/zephyr/pull/72621