### PR TITLE
nrfx: hal: saadc: Expand support for 8bit transfers in nRF54

### DIFF
--- a/nrfx/hal/nrf_saadc.h
+++ b/nrfx/hal/nrf_saadc.h
@@ -122,7 +122,7 @@ extern "C" {
 #define NRF_SAADC_LIN_CAL_MAX SAADC_TRIM_LINCALCOEFF_VAL_Max
 #endif
 
-#if defined(NRF54H20_ENGA_XXAA) || defined(NRF54L15_ENGA_XXAA) || defined(__NRFX_DOXYGEN__)
+#if defined(NRF54H_SERIES) || defined(NRF54L_SERIES) || defined(__NRFX_DOXYGEN__)
 /** @brief Symbol specifying width of the 8-bit sample in bits. */
 #define NRF_SAADC_8BIT_SAMPLE_WIDTH 8
 #else


### PR DESCRIPTION
Add support for 8bit transfers for all devices in nRF54 family.