### PR TITLE
Draft of hal_nordic layer

### DIFF
--- a/eperipherals/app/eperiphs_backend.h
+++ b/eperipherals/app/eperiphs_backend.h
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef EPERIPHS_BACKEND_H
+#define EPERIPHS_BACKEND_H
+
+#include "eperiph_common.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @brief FLPR EGPIO opcodes. */
+typedef enum
+{
+    NRF_ICMG_EGPIO_PIN_CLEAR    = 0, ///< Clear eGPIO pin.
+    NRF_ICMG_EGPIO_PIN_SET      = 1, ///< Set eGPIO pin.
+    NRF_ICMG_EGPIO_PIN_TOGGLE   = 2, ///< Toggle eGPIO pin.
+} nrf_icmg_egpio_opcode_t;
+
+/** @brief EGPIO data packet. */
+struct data_packet {
+	unsigned int opcode;	/* Config type (nrf_icmg_config_t) in configuration step, operation to perform (nrf_icmg_egpio_opcode_t) in non-configure step*/
+	unsigned int pin;		/* Pin number. */
+	unsigned long flags;	/* Configuration flags in configure step (gpio_flags_t), not used in other cases. */
+};
+
+K_SEM_DEFINE(bound_sem, 0, 1);
+
+
+static void ep_bound(void *priv)
+{
+	k_sem_give(&bound_sem);
+	LOG_INF("Ep bounded");
+}
+
+static void ep_recv(const void *data, size_t len, void *priv)
+{
+}
+
+static struct ipc_ept_cfg ep_cfg = {
+	.cb = {
+		.bound    = ep_bound,
+		.received = ep_recv,
+	},
+};
+
+struct ipc_ept ep;
+
+int eperiphs_init(void)
+{
+	int ret;
+
+	const struct device *ipc0_instance = DEVICE_DT_GET(DT_NODELABEL(ipc0));
+
+	ret = ipc_service_open_instance(ipc0_instance);
+	if ((ret < 0) && (ret != -EALREADY)) {
+		LOG_ERR("ipc_service_open_instance() failure");
+		return ret;
+	}
+
+	ret = ipc_service_register_endpoint(ipc0_instance, &ep, &ep_cfg);
+	if (ret < 0) {
+		LOG_ERR("ipc_service_register_endpoint() failure");
+		return ret;
+	}
+
+	k_sem_take(&bound_sem, K_FOREVER);
+
+	return 0;
+}
+
+int eperiphs_send(struct data_packet *message, size_t size)
+{
+	return ipc_service_send(ep, (void*)msg, size);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* EPERIPHS_BACKEND_H */

--- a/eperipherals/app/eperiphs_common.h
+++ b/eperipherals/app/eperiphs_common.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef EPERIPHS_COMMON_H
+#define EPERIPHS_COMMON_H
+
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+
+#include <zephyr/ipc/ipc_service.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @brief FLPR ePeripheral configuration type. */
+typedef enum
+{
+    NRF_ICMG_CONFIG_EGPIO  = 0, ///< Configure FLPR to work as Emulated GPIO.
+} nrf_icmg_config_t;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* EPERIPHS_COMMON_H */


### PR DESCRIPTION
Draft of hal_nordic layer for emulated GPIO.

This layer is a backend layer for emulated GPIO. It contains a function for establishing communication with FLPR (`eperiphs_init`) and a function for sending data to FLPR (`eperiphs_send`). `eperiphs_send` can be used to send GPIO configuration data to FLPR (initial pin state, open drain/open source, etc.) or to change state of a given GPIO (set, clear or toggle).
Function for receiving data is not needed for emulated GPIO, so I left it empty for now.

I assumed that FLPR could be in two states: firstly, FLPR would be in configuration/initialization step where it would wait for configuration data and eperipheral selection (which eperipheral should be used, for example: GPIO, QSPI, etc.). Sending eperipheral selection and configuration is not needed for now (it could be done by default by FLPR), since we only have GPIO, but it's not much more work I thought it would be nice to have it already.

The second state of FLPR would be to wait for any messages with new GPIO state (or data to send in other eperipherals).

The intention was that GPIO SHIM on APP would call `eperiphs_init` and `eperiphs_send` with configuration in its init function and other SHIM functions would call `eperiphs_send` with new GPIO pin state.

GPIO SHIM part is still in progress, but I thought I would share it with you already in case it needed some changing or this whole concept was wrong and ended up in trash 😒 

I assumed that reconfiguring eperipheral and changing eperipheral selection is not possible. This means, that only one pin can be used with eGPIO (Zephyr configures only one pin at a time). However, reconfiguration of eperipheral can be added by modifying configuration "frame".

Please, review only the general concept. Names of functions and structs can be changed, I just used the first ones that came to my mind.

@masz-nordic, please, check, if this is what you had in mind.