### PR TITLE
mdk: nrf54l15: Fixes NFCT pins as GPIO configuration

### DIFF
--- a/nrfx/mdk/system_nrf54l.c
+++ b/nrfx/mdk/system_nrf54l.c
@@ -114,7 +114,7 @@ void SystemInit(void)
         #endif
 
         #if !defined(NRF_TRUSTZONE_NONSECURE) && defined(__ARM_FEATURE_CMSE)
-            #if defined(NRF_CONFIG_NFCT_PINS_AS_GPIOS)
+            #if defined(CONFIG_NFCT_PINS_AS_GPIOS)
                 NRF_NFCT_S->PADCONFIG = (NFCT_PADCONFIG_ENABLE_Disabled << NFCT_PADCONFIG_ENABLE_Pos);
             #endif 
 


### PR DESCRIPTION
The define `NRF_CONFIG_NFCT_PINS_AS_GPIOS` does not exist. Zephyr does define `CONFIG_NFCT_PINS_AS_GPIOS` based on hal_nordic/nrfx/CMakeList.txt. It was therefore not possible to use the NFC-capable pins as GPIOs.