### PR TITLE
nrfx: hal: Add accessor functions for FICR addr, er and ir

### DIFF
--- a/nrfx/hal/nrf_ficr.h
+++ b/nrfx/hal/nrf_ficr.h
@@ -104,6 +104,48 @@ extern "C" {
 #define NRF_FICR_HAS_NFC_TAGHEADER_ARRAY 0
 #endif
 
+#if defined(FICR_DEVICEADDR_DEVICEADDR_Msk) || defined(NRF51) || defined(__NRFX_DOXYGEN__)
+/** @brief Symbol indicating whether FICR DEVICEADDR[n] registers are present. */
+#define NRF_FICR_HAS_DEVICE_ADDR 1
+#else
+#define NRF_FICR_HAS_DEVICE_ADDR 0
+#endif
+
+#if defined(FICR_BLE_ADDR_ADDR_Msk) || defined(__NRFX_DOXYGEN__)
+/** @brief Symbol indicating whether FICR BLE.ADDR[n] registers are present. */
+#define NRF_FICR_HAS_BLE_ADDR 1
+#else
+#define NRF_FICR_HAS_BLE_ADDR 0
+#endif
+
+#if defined(FICR_ER_ER_Msk) || defined(NRF51) || defined(__NRFX_DOXYGEN__)
+/** @brief Symbol indicating whether FICR ER[n] registers are present. */
+#define NRF_FICR_HAS_ER 1
+#else
+#define NRF_FICR_HAS_ER 0
+#endif
+
+#if defined(FICR_BLE_ER_ER_Msk) || defined(__NRFX_DOXYGEN__)
+/** @brief Symbol indicating whether FICR BLE.ER[n] registers are present. */
+#define NRF_FICR_HAS_BLE_ER 1
+#else
+#define NRF_FICR_HAS_BLE_ER 0
+#endif
+
+#if defined(FICR_IR_IR_Msk) || defined(NRF51) || defined(__NRFX_DOXYGEN__)
+/** @brief Symbol indicating whether FICR IR[n] registers are present. */
+#define NRF_FICR_HAS_IR 1
+#else
+#define NRF_FICR_HAS_IR 0
+#endif
+
+#if defined(FICR_BLE_IR_IR_Msk) || defined(__NRFX_DOXYGEN__)
+/** @brief Symbol indicating whether FICR BLE.IR[n] registers are present. */
+#define NRF_FICR_HAS_BLE_IR 1
+#else
+#define NRF_FICR_HAS_BLE_IR 0
+#endif
+
 #if NRF_FICR_HAS_CODE_PAGE_SIZE || NRF_FICR_HAS_INFO_CODE_PAGE_SIZE
 /**
  * @brief Function for getting the size of the code memory page.
@@ -149,6 +191,42 @@ NRF_STATIC_INLINE uint32_t nrf_ficr_deviceid_get(NRF_FICR_Type const * p_reg, ui
  */
 NRF_STATIC_INLINE uint32_t nrf_ficr_nfc_tagheader_get(NRF_FICR_Type const * p_reg,
                                                       uint32_t              tagheader_id);
+#endif
+
+#if NRF_FICR_HAS_DEVICE_ADDR || NRF_FICR_HAS_BLE_ADDR
+/**
+ * @brief Function for getting the unique device address.
+ *
+ * @param[in] p_reg  Pointer to the structure of registers of the peripheral.
+ * @param[in] reg_id Register index.
+ *
+ * @return Unique device address.
+ */
+NRF_STATIC_INLINE uint32_t nrf_ficr_deviceaddr_get(NRF_FICR_Type const * p_reg, uint32_t reg_id);
+#endif
+
+#if NRF_FICR_HAS_ER || NRF_FICR_HAS_BLE_ER
+/**
+ * @brief Function for getting the unique encryption root.
+ *
+ * @param[in] p_reg  Pointer to the structure of registers of the peripheral.
+ * @param[in] reg_id Register index.
+ *
+ * @return Unique encryption root.
+ */
+NRF_STATIC_INLINE uint32_t nrf_ficr_er_get(NRF_FICR_Type const * p_reg, uint32_t reg_id);
+#endif
+
+#if NRF_FICR_HAS_IR || NRF_FICR_HAS_BLE_IR
+/**
+ * @brief Function for getting the unique identity root.
+ *
+ * @param[in] p_reg  Pointer to the structure of registers of the peripheral.
+ * @param[in] reg_id Register index.
+ *
+ * @return Unique identity root.
+ */
+NRF_STATIC_INLINE uint32_t nrf_ficr_ir_get(NRF_FICR_Type const * p_reg, uint32_t reg_id);
 #endif
 
 #ifndef NRF_DECLARE_ONLY
@@ -216,6 +294,39 @@ NRF_STATIC_INLINE uint32_t nrf_ficr_nfc_tagheader_get(NRF_FICR_Type const * p_re
         default:
             return 0;
     }
+#endif
+}
+#endif
+
+#if NRF_FICR_HAS_DEVICE_ADDR || NRF_FICR_HAS_BLE_ADDR
+NRF_STATIC_INLINE uint32_t nrf_ficr_deviceaddr_get(NRF_FICR_Type const * p_reg, uint32_t reg_id)
+{
+#if NRF_FICR_HAS_BLE_ADDR
+    return p_reg->BLE.ADDR[reg_id];
+#else
+    return p_reg->DEVICEADDR[reg_id];
+#endif
+}
+#endif
+
+#if NRF_FICR_HAS_ER || NRF_FICR_HAS_BLE_ER
+NRF_STATIC_INLINE uint32_t nrf_ficr_er_get(NRF_FICR_Type const * p_reg, uint32_t reg_id)
+{
+#if NRF_FICR_HAS_BLE_ER
+    return p_reg->BLE.ER[reg_id];
+#else
+    return p_reg->ER[reg_id];
+#endif
+}
+#endif
+
+#if NRF_FICR_HAS_IR || NRF_FICR_HAS_BLE_IR
+NRF_STATIC_INLINE uint32_t nrf_ficr_ir_get(NRF_FICR_Type const * p_reg, uint32_t reg_id)
+{
+#if NRF_FICR_HAS_BLE_IR
+    return p_reg->BLE.IR[reg_id];
+#else
+    return p_reg->IR[reg_id];
 #endif
 }
 #endif


### PR DESCRIPTION
Abstract the access to three BLE-related settings in FICR for different nRF SoCs, so the user does not need to worry about differences among series.