### PR TITLE
nrfx: hal: nrf_comp: patch main_mode and speed_mode set

### DIFF
--- a/nrfx/hal/nrf_comp.h
+++ b/nrfx/hal/nrf_comp.h
@@ -481,13 +481,13 @@ NRF_STATIC_INLINE void nrf_comp_th_set(NRF_COMP_Type * p_reg, nrf_comp_th_t thre
 NRF_STATIC_INLINE void nrf_comp_main_mode_set(NRF_COMP_Type *      p_reg,
                                               nrf_comp_main_mode_t main_mode)
 {
-    p_reg->MODE |= (main_mode << COMP_MODE_MAIN_Pos);
+    p_reg->MODE = (p_reg->MODE & ~(COMP_MODE_MAIN_Msk)) | (main_mode << COMP_MODE_MAIN_Pos);
 }
 
 NRF_STATIC_INLINE void nrf_comp_speed_mode_set(NRF_COMP_Type *    p_reg,
                                                nrf_comp_sp_mode_t speed_mode)
 {
-    p_reg->MODE |= (speed_mode << COMP_MODE_SP_Pos);
+    p_reg->MODE = (p_reg->MODE & ~(COMP_MODE_SP_Msk)) | (speed_mode << COMP_MODE_SP_Pos);
 }
 
 NRF_STATIC_INLINE void nrf_comp_hysteresis_set(NRF_COMP_Type * p_reg, nrf_comp_hyst_t hyst)


### PR DESCRIPTION
The functions for setting the main and speed modes don't clear their fields before setting the desired value. This results in not being able to set the main mode to single-ended (0) after having set the mode to differential (1), similarly, the speed mode can not be set to low (0) after being set to medium (1) or high (2), and it can be set to the reserved value 3.