### PR TITLE
nrfx: lpcomp: align nrfx_lpcomp to Zephyr shim and patch comp modes

### DIFF
--- a/nrfx/drivers/include/nrfx_comp.h
+++ b/nrfx/drivers/include/nrfx_comp.h
@@ -66,7 +66,11 @@ extern "C" {
  */
 typedef void (* nrfx_comp_event_handler_t)(nrf_comp_event_t event);
 
-/** @brief COMP shortcut masks. */
+/**
+ * @brief COMP shortcut masks.
+ *
+ * @deprecated Use @ref nrf_comp_short_mask_t instead.
+*/
 typedef enum
 {
     NRFX_COMP_SHORT_STOP_AFTER_CROSS_EVT = NRF_COMP_SHORT_STOP_CROSS_MASK, ///< Shortcut between the CROSS event and the STOP task.
@@ -74,7 +78,11 @@ typedef enum
     NRFX_COMP_SHORT_STOP_AFTER_DOWN_EVT  = NRF_COMP_SHORT_STOP_DOWN_MASK   ///< Shortcut between the DOWN event and the STOP task.
 } nrfx_comp_short_mask_t;
 
-/** @brief COMP events masks. */
+/**
+ * @brief COMP events masks.
+ *
+ * @deprecated Use @ref nrf_comp_int_mask_t instead.
+*/
 typedef enum
 {
     NRFX_COMP_EVT_EN_CROSS_MASK = NRF_COMP_INT_CROSS_MASK, ///< CROSS event (generated after VIN+ == VIN-).
@@ -197,9 +205,9 @@ void nrfx_comp_pin_select(nrf_comp_input_t psel);
  * enables the COMP peripheral and its interrupts.
  *
  * @param[in] comp_evt_en_mask Mask of events to be enabled. This parameter is to be built as
- *                             an OR of elements from @ref nrfx_comp_evt_en_mask_t.
+ *                             an OR of elements from @ref nrf_comp_int_mask_t.
  * @param[in] comp_shorts_mask Mask of shortcuts to be enabled. This parameter is to be built as
- *                             an OR of elements from @ref nrfx_comp_short_mask_t.
+ *                             an OR of elements from @ref nrf_comp_short_mask_t.
  *
  * @sa nrfx_comp_init
  */

--- a/nrfx/drivers/include/nrfx_lpcomp.h
+++ b/nrfx/drivers/include/nrfx_lpcomp.h
@@ -126,6 +126,17 @@ nrfx_err_t nrfx_lpcomp_init(nrfx_lpcomp_config_t const * p_config,
                             nrfx_lpcomp_event_handler_t  event_handler);
 
 /**
+ * @brief Function for reconfiguring the LPCOMP driver.
+ *
+ * @param[in] p_config Pointer to the structure with the configuration.
+ *
+ * @retval NRFX_SUCCESS             Reconfiguration was successful.
+ * @retval NRFX_ERROR_BUSY          The driver is running and cannot be reconfigured.
+ * @retval NRFX_ERROR_INVALID_STATE The driver is uninitialized.
+ */
+nrfx_err_t nrfx_lpcomp_reconfigure(nrfx_lpcomp_config_t const * p_config);
+
+/**
  * @brief Function for uninitializing the LPCOMP driver.
  *
  * This function uninitializes the LPCOMP driver. The LPCOMP peripheral and
@@ -146,24 +157,75 @@ void  nrfx_lpcomp_uninit(void);
 bool nrfx_lpcomp_init_check(void);
 
 /**
+ * @brief Function for starting the LPCOMP peripheral and interrupts.
+ *
+ * Before calling this function, the driver must be initialized. This function
+ * enables the LPCOMP peripheral and its interrupts.
+ *
+ * @param[in] lpcomp_evt_en_mask Mask of events to be enabled. This parameter is to be built as
+ *                               an OR of elements from @ref nrf_lpcomp_int_mask_t.
+ * @param[in] lpcomp_shorts_mask Mask of shortcuts to be enabled. This parameter is to be built as
+ *                               an OR of elements from @ref nrf_lpcomp_short_mask_t.
+ *
+ * @sa nrfx_lpcomp_init
+ */
+void nrfx_lpcomp_start(uint32_t lpcomp_evt_en_mask, uint32_t lpcomp_shorts_mask);
+
+/**
  * @brief Function for enabling the LPCOMP peripheral and interrupts.
+ *
+ * @deprecated Use @ref nrfx_lpcomp_start instead.
  *
  * Before calling this function, the driver must be initialized. This function
  * enables the LPCOMP peripheral and its interrupts.
  *
  * @sa nrfx_lpcomp_disable
  */
-void nrfx_lpcomp_enable(void);
+NRFX_STATIC_INLINE void nrfx_lpcomp_enable(void);
+
+/**
+ * @brief Function for stopping the LPCOMP peripheral.
+ *
+ * Before calling this function, the driver must be enabled. This function disables the LPCOMP
+ * peripheral and its interrupts.
+ *
+ * @sa nrfx_lpcomp_uninit
+ */
+void nrfx_lpcomp_stop(void);
 
 /**
  * @brief Function for disabling the LPCOMP peripheral.
+ *
+ * @deprecated Use @ref nrfx_lpcomp_stop instead.
  *
  * Before calling this function, the driver must be initialized. This function disables the LPCOMP
  * peripheral and its interrupts.
  *
  * @sa nrfx_lpcomp_enable
  */
-void nrfx_lpcomp_disable(void);
+NRFX_STATIC_INLINE void nrfx_lpcomp_disable(void);
+
+/**
+ * @brief Function for copying the current state of the low power comparator result to the RESULT register.
+ *
+ * @retval 0 The input voltage is below the threshold (VIN+ < VIN-).
+ * @retval 1 The input voltage is above the threshold (VIN+ > VIN-).
+ */
+uint32_t nrfx_lpcomp_sample(void);
+
+#ifndef NRFX_DECLARE_ONLY
+
+NRFX_STATIC_INLINE void nrfx_lpcomp_enable(void)
+{
+    nrfx_lpcomp_start(0, 0);
+}
+
+NRFX_STATIC_INLINE void nrfx_lpcomp_disable(void)
+{
+    nrfx_lpcomp_stop();
+}
+
+#endif // NRFX_DECLARE_ONLY
 
 /** @} */
 

--- a/nrfx/hal/nrf_comp.h
+++ b/nrfx/hal/nrf_comp.h
@@ -481,13 +481,13 @@ NRF_STATIC_INLINE void nrf_comp_th_set(NRF_COMP_Type * p_reg, nrf_comp_th_t thre
 NRF_STATIC_INLINE void nrf_comp_main_mode_set(NRF_COMP_Type *      p_reg,
                                               nrf_comp_main_mode_t main_mode)
 {
-    p_reg->MODE |= (main_mode << COMP_MODE_MAIN_Pos);
+    p_reg->MODE = (p_reg->MODE & ~(COMP_MODE_MAIN_Msk)) | (main_mode << COMP_MODE_MAIN_Pos);
 }
 
 NRF_STATIC_INLINE void nrf_comp_speed_mode_set(NRF_COMP_Type *    p_reg,
                                                nrf_comp_sp_mode_t speed_mode)
 {
-    p_reg->MODE |= (speed_mode << COMP_MODE_SP_Pos);
+    p_reg->MODE = (p_reg->MODE & ~(COMP_MODE_SP_Msk)) | (speed_mode << COMP_MODE_SP_Pos);
 }
 
 NRF_STATIC_INLINE void nrf_comp_hysteresis_set(NRF_COMP_Type * p_reg, nrf_comp_hyst_t hyst)

--- a/nrfx/haly/nrfy_lpcomp.h
+++ b/nrfx/haly/nrfy_lpcomp.h
@@ -153,6 +153,23 @@ NRFY_STATIC_INLINE uint32_t nrfy_lpcomp_events_process(NRF_LPCOMP_Type * p_reg,
 }
 
 /**
+ * @brief Function for reading the current state of the LPCOMP.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ *
+ * @retval 0 The input voltage is below the threshold.
+ * @retval 1 The input voltage is above the threshold.
+ */
+NRFY_STATIC_INLINE uint32_t nrfy_lpcomp_sample(NRF_LPCOMP_Type * p_reg)
+{
+    nrf_lpcomp_task_trigger(p_reg, NRF_LPCOMP_TASK_SAMPLE);
+    nrf_barrier_rw();
+    uint32_t sample = nrf_lpcomp_result_get(p_reg);
+    nrf_barrier_r();
+    return sample;
+}
+
+/**
  * @brief Function for reading the current state of the LPCOMP input.
  *
  * @param[in] p_reg Pointer to the structure of registers of the peripheral.
@@ -162,11 +179,7 @@ NRFY_STATIC_INLINE uint32_t nrfy_lpcomp_events_process(NRF_LPCOMP_Type * p_reg,
  */
 NRFY_STATIC_INLINE bool nrfy_lpcomp_sample_check(NRF_LPCOMP_Type * p_reg)
 {
-    nrf_lpcomp_task_trigger(p_reg, NRF_LPCOMP_TASK_SAMPLE);
-    nrf_barrier_rw();
-    bool sample = nrf_lpcomp_result_get(p_reg);
-    nrf_barrier_r();
-    return sample;
+    return (bool)nrfy_lpcomp_sample(p_reg);
 }
 
 /** @refhal{nrf_lpcomp_ref_set} */


### PR DESCRIPTION
API for Low Power Comparator and regular comparator used different naming. LPCOMP API also lacked
`nrfx_lpcomp_reconfigure` and `nrfx_lpcomp_sample` functions, which are now provided.

New function `nrfx_lpcomp_start` extends `nrfx_lpcomp_enable` with shorts and events parameters. `_enable` now calls `_start` with zeros as arguments.

New function `nrfx_lpcomp_stop` replaces `nrfx_lpcomp_disable`. `_disable` is still provided, but simply calls` _stop`.

Added new HALY function `nrfy_lpcomp_sample` that return sample as `uint32_t`.

Regular comp mode setting is patched.