### PR TITLE
nrfs: update medlow oppoint FICR trim index

### DIFF
--- a/nrfs/helpers/dvfs_oppoint.c
+++ b/nrfs/helpers/dvfs_oppoint.c
@@ -75,7 +75,7 @@ static const struct dvfs_oppoint_data dvfs_oppoints_data[DVFS_FREQ_COUNT] = {
 		.abb_lockrange	  = ABB_LOCKRANGE(75, 168, 65, 176),
 		.abb_pvtmoncycles = 4,
 		.new_f_mult	  = 8,
-		.new_f_trim_entry = 5,
+		.new_f_trim_entry = 2,
 		.max_hsfll_freq	  = 128,
 	},
 	/* ABB oppoint 0.5V */


### PR DESCRIPTION
Medlow DVFS oppoint was using current limit mode FICR index (5) since there was no other that was supporting 128MHz. Now medlow index in FICR (2) is using 128MHz so this one needs to be used. This also fixes on all idle issues when switching to medlow DVFS oppoint.