### PR TITLE
nrf_wifi: Bring in Promiscuous mode filtering support in driver

### DIFF
--- a/drivers/nrf_wifi/fw_if/umac_if/inc/default/fmac_structs.h
+++ b/drivers/nrf_wifi/fw_if/umac_if/inc/default/fmac_structs.h
@@ -270,10 +270,10 @@ struct nrf_wifi_fmac_callbk_fns {
 				     signed short signal);
 #endif /* NRF70_STA_MODE */
 #if defined(NRF70_RAW_DATA_RX) || defined(NRF70_PROMISC_DATA_RX)
-	void (*rx_sniffer_frm_callbk_fn)(void *os_vif_ctx,
-					 void *frm,
-					 struct raw_rx_pkt_header *,
-					 bool pkt_free);
+	void (*sniffer_callbk_fn)(void *os_vif_ctx,
+				  void *frm,
+				  struct raw_rx_pkt_header *,
+				  bool pkt_free);
 #endif /* NRF70_RAW_DATA_RX || NRF70_PROMISC_DATA_RX */
 	void (*reg_change_callbk_fn)(void *os_vif_ctx,
 				     struct nrf_wifi_event_regulatory_change *reg_change,

--- a/drivers/nrf_wifi/fw_if/umac_if/inc/fmac_promisc.h
+++ b/drivers/nrf_wifi/fw_if/umac_if/inc/fmac_promisc.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/**
+ * @brief Header containing code to support promiscuous mode
+ * for the FMAC IF Layer of the Wi-Fi driver.
+ */
+#ifndef __FMAC_PROMISC_H__
+#define __FMAC_PROMISC_H__
+#include "fmac_structs.h"
+#include "pack_def.h"
+
+/** 802.11 Packet-type */
+enum nrf_wifi_fmac_frame_type {
+	/** 802.11 management packet type */
+	NRF_WIFI_MGMT_PKT_TYPE = 0x0,
+	/** 802.11 control packet type */
+	NRF_WIFI_CTRL_PKT_TYPE,
+	/** 802.11 data packet type */
+	NRF_WIFI_DATA_PKT_TYPE,
+};
+
+/** Packet filter settings in driver */
+enum nrf_wifi_packet_filter {
+	/** Filter management packets only */
+	FILTER_MGMT_ONLY = 0x2,
+	/** Filter data packets only */
+	FILTER_DATA_ONLY = 0x4,
+	/** Filter data and management packets */
+	FILTER_DATA_MGMT = 0x6,
+	/** Filter control packets only */
+	FILTER_CTRL_ONLY = 0x8,
+	/** Filter control and management packets */
+	FILTER_CTRL_MGMT = 0xa,
+	/** Filter data and control packets */
+	FILTER_DATA_CTRL = 0xc
+};
+
+/** Frame Control structure which
+ *  depends on the endianness in the system.
+ *  For example 0x8842 in big endian would
+ *  become 0x4288 in little endian. The bytes
+ *  are swapped.
+ **/
+#if defined(CONFIG_LITTLE_ENDIAN)
+struct nrf_wifi_fmac_frame_ctrl {
+	unsigned short protocolVersion : 2;
+	unsigned short type            : 2;
+	unsigned short subtype         : 4;
+	unsigned short toDS            : 1;
+	unsigned short fromDS          : 1;
+	unsigned short moreFragments   : 1;
+	unsigned short retry           : 1;
+	unsigned short powerManagement : 1;
+	unsigned short moreData        : 1;
+	unsigned short protectedFrame  : 1;
+	unsigned short order           : 1;
+} __NRF_WIFI_PKD;
+#else
+struct nrf_wifi_fmac_frame_ctrl {
+	unsigned short toDS            : 1;
+	unsigned short fromDS          : 1;
+	unsigned short moreFragments   : 1;
+	unsigned short retry           : 1;
+	unsigned short powerManagement : 1;
+	unsigned short moreData        : 1;
+	unsigned short protectedFrame  : 1;
+	unsigned short order           : 1;
+	unsigned short protocolVersion : 2;
+	unsigned short type            : 2;
+	unsigned short subtype         : 4;
+} __NRF_WIFI_PKD;
+#endif
+
+bool nrf_wifi_util_check_filt_setting(struct nrf_wifi_fmac_vif_ctx *vif,
+				      unsigned short *frame_control);
+#endif /* __FMAC_PROMISC_H__ */

--- a/drivers/nrf_wifi/fw_if/umac_if/src/fmac_promisc.c
+++ b/drivers/nrf_wifi/fw_if/umac_if/src/fmac_promisc.c
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/**
+ * @brief File containing promiscuous mode
+ * support functions for the FMAC IF Layer
+ * of the Wi-Fi driver.
+ */
+
+#include "osal_api.h"
+#include "fmac_structs.h"
+#include "fmac_promisc.h"
+
+bool nrf_wifi_util_check_filt_setting(struct nrf_wifi_fmac_vif_ctx *vif,
+				      unsigned short *frame_control)
+{
+	bool filter_check = false;
+	struct nrf_wifi_fmac_frame_ctrl *frm_ctrl =
+	(struct nrf_wifi_fmac_frame_ctrl *)frame_control;
+
+	switch (vif->packet_filter) {
+		case FILTER_MGMT_ONLY:
+			if (frm_ctrl->type == NRF_WIFI_MGMT_PKT_TYPE) {
+				filter_check = true;
+			}
+			break;
+		case FILTER_DATA_ONLY:
+			if (frm_ctrl->type == NRF_WIFI_DATA_PKT_TYPE) {
+				filter_check = true;
+			}
+			break;
+		case FILTER_DATA_MGMT:
+			if ((frm_ctrl->type == NRF_WIFI_DATA_PKT_TYPE) ||
+			    (frm_ctrl->type == NRF_WIFI_MGMT_PKT_TYPE)) {
+				filter_check = true;
+			}
+			break;
+		case FILTER_CTRL_ONLY:
+			if (frm_ctrl->type == NRF_WIFI_CTRL_PKT_TYPE) {
+				filter_check = true;
+			}
+			break;
+		case FILTER_CTRL_MGMT:
+			if ((frm_ctrl->type == NRF_WIFI_CTRL_PKT_TYPE) ||
+			    (frm_ctrl->type == NRF_WIFI_MGMT_PKT_TYPE)) {
+				filter_check = true;
+			}
+			break;
+		case FILTER_DATA_CTRL:
+			if ((frm_ctrl->type == NRF_WIFI_DATA_PKT_TYPE) ||
+			    (frm_ctrl->type == NRF_WIFI_CTRL_PKT_TYPE)) {
+				filter_check = true;
+			}
+			break;
+		/* all other packet_filter cases - bit 0 is set and hence all
+		 * packet types are allowed or in the case of 0xE - all packet
+		 * type bits are enabled */
+		default:
+			filter_check = true;
+			break;
+	}
+	return filter_check;
+}


### PR DESCRIPTION
This set of changes brings in promiscuous mode filtering support in the driver. Since, firmware woulld be unable to filter packets in the case of promiscuous mode as it would lead to connection issues, filtering support is moved to the driver for promiscuous mode.