### PR TITLE
nrfx: drivers: nrfx_lpcomp: dis all interrupts on stop

### DIFF
--- a/nrfx/drivers/src/nrfx_lpcomp.c
+++ b/nrfx/drivers/src/nrfx_lpcomp.c
@@ -250,6 +250,11 @@ void nrfx_lpcomp_stop(void)
     NRFX_ASSERT(m_state == NRFX_DRV_STATE_POWERED_ON);
     nrfy_lpcomp_disable(NRF_LPCOMP);
     nrfy_lpcomp_task_trigger(NRF_LPCOMP, NRF_LPCOMP_TASK_STOP);
+    nrfy_lpcomp_int_disable(NRF_LPCOMP,
+                            NRF_LPCOMP_INT_READY_MASK |
+                            NRF_LPCOMP_INT_DOWN_MASK |
+                            NRF_LPCOMP_INT_UP_MASK |
+                            NRF_LPCOMP_INT_CROSS_MASK);
     m_state = NRFX_DRV_STATE_INITIALIZED;
     NRFX_LOG_INFO("Disabled.");
 }


### PR DESCRIPTION
The LPCOMP driver currently only disables all interrupts when first initialized. starting or reconfiguring the comparator from here only ever enables additional interrupts using nrfy_lpcomp_int_enable() which results in it not being possible to disable an interrupt source when it has been enabled.

This commit adds a call to nrfy_lpcomp_int_disable() which disables all interrupts when the comparator is stopped using nrfx_lpcomp_stop(). A new interrupt mask is provided by the next call to nrfx_lpcomp_start() .