### PR TITLE
drivers: nrf_wifi: Add check for wrong regulatory domain

### DIFF
--- a/drivers/nrf_wifi/fw_if/umac_if/inc/offload_raw_tx/fmac_structs.h
+++ b/drivers/nrf_wifi/fw_if/umac_if/inc/offload_raw_tx/fmac_structs.h
@@ -20,6 +20,8 @@
 
 #include "host_rpu_sys_if.h"
 
+#define NRF_WIFI_FMAC_PARAMS_RECV_TIMEOUT 100 /* ms */
+
 /**
  * @brief  Structure to hold per device context information for the UMAC IF layer.
  *
@@ -29,6 +31,7 @@
 struct nrf_wifi_off_raw_tx_fmac_dev_ctx {
     enum nrf_wifi_cmd_status off_raw_tx_cmd_status;
     bool off_raw_tx_cmd_done;
+    unsigned char country_code[NRF_WIFI_COUNTRY_CODE_LEN];
 };
 
 // extern struct nrf_wifi_off_raw_tx_fmac_dev_ctx *def_dev_ctx_off_raw_tx;

--- a/drivers/nrf_wifi/fw_if/umac_if/src/event.c
+++ b/drivers/nrf_wifi/fw_if/umac_if/src/event.c
@@ -150,6 +150,9 @@ static enum nrf_wifi_status umac_event_ctrl_process(struct nrf_wifi_fmac_dev_ctx
 #elif NRF70_RADIO_TEST
 	struct nrf_wifi_reg *get_reg_event = NULL;
 	struct nrf_wifi_event_regulatory_change *reg_change_event = NULL;
+#elif NRF70_OFFLOADED_RAW_TX
+	struct nrf_wifi_off_raw_tx_fmac_dev_ctx *def_dev_ctx_off_raw_tx = NULL;
+	struct nrf_wifi_reg *get_reg_event = NULL;
 #endif /* !NRF70_RADIO_TEST && !NRF70_OFFLOADED_RAW_TX */
 	unsigned char if_id = 0;
 	unsigned int event_num = 0;
@@ -169,6 +172,10 @@ static enum nrf_wifi_status umac_event_ctrl_process(struct nrf_wifi_fmac_dev_ctx
 	}
 
 #endif /* !NRF70_RADIO_TEST && !NRF70_OFFLOADED_RAW_TX */
+
+#ifdef NRF70_OFFLOADED_RAW_TX
+	def_dev_ctx_off_raw_tx = wifi_dev_priv(fmac_dev_ctx);
+#endif /* NRF70_OFFLOADED_RAW_TX */
 
 	umac_hdr = event_data;
 	if_id = umac_hdr->ids.wdev_id;
@@ -219,6 +226,14 @@ static enum nrf_wifi_status umac_event_ctrl_process(struct nrf_wifi_fmac_dev_ctx
 				      sizeof(get_reg_event->nrf_wifi_alpha2));
 		fmac_dev_ctx->alpha2_valid = true;
 #endif /* NRF70_RADIO_TEST */
+#ifdef NRF70_OFFLOADED_RAW_TX
+		get_reg_event = (struct nrf_wifi_reg *)event_data;
+
+		nrf_wifi_osal_mem_cpy(&def_dev_ctx_off_raw_tx->country_code,
+				      &get_reg_event->nrf_wifi_alpha2,
+				      sizeof(get_reg_event->nrf_wifi_alpha2));
+		fmac_dev_ctx->alpha2_valid = true;
+#endif /* NRF70_OFFLOADED_RAW_TX */
 		break;
 	case NRF_WIFI_UMAC_EVENT_REG_CHANGE:
 #ifdef NRF70_STA_MODE

--- a/drivers/nrf_wifi/fw_if/umac_if/src/fmac_api_common.c
+++ b/drivers/nrf_wifi/fw_if/umac_if/src/fmac_api_common.c
@@ -849,6 +849,7 @@ out:
 
 	return status;
 }
+#endif /* !NRF70_OFFLOADED_RAW_TX */
 
 enum nrf_wifi_status nrf_wifi_fmac_get_reg(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
 					   struct nrf_wifi_fmac_reg_info *reg_info)
@@ -911,7 +912,6 @@ err:
 	}
 	return status;
 }
-#endif
 
 int nrf_wifi_phy_rf_params_init(struct nrf_wifi_phy_rf_params *prf,
 				unsigned int package_info,


### PR DESCRIPTION
If parameters is not set correctly return error for regulatory domain. Check current regulatory domain.