### PR TITLE
wifi: Fix Rx processing

### DIFF
--- a/drivers/nrf_wifi/fw_if/umac_if/inc/default/fmac_structs.h
+++ b/drivers/nrf_wifi/fw_if/umac_if/inc/default/fmac_structs.h
@@ -131,13 +131,13 @@ struct nrf_wifi_fmac_callbk_fns {
 				  unsigned int event_len,
 				  bool more_res);
 
-#if defined(CONFIG_WIFI_MGMT_RAW_SCAN_RESULTS) || defined(__DOXYGEN__)
+#if defined(WIFI_MGMT_RAW_SCAN_RESULTS) || defined(__DOXYGEN__)
 	/** Callback function to be called when a beacon/probe response is received. */
 	void (*rx_bcn_prb_resp_callbk_fn)(void *os_vif_ctx,
 					  void *frm,
 					  unsigned short frequency,
 					  signed short signal);
-#endif /* CONFIG_WIFI_MGMT_RAW_SCAN_RESULTS */
+#endif /* WIFI_MGMT_RAW_SCAN_RESULTS */
 
 #if defined(NRF70_STA_MODE) || defined(__DOXYGEN__)
 	/** Callback function to be called when an interface association state changes. */

--- a/drivers/nrf_wifi/fw_if/umac_if/src/rx.c
+++ b/drivers/nrf_wifi/fw_if/umac_if/src/rx.c
@@ -249,7 +249,7 @@ enum nrf_wifi_status nrf_wifi_fmac_rx_event_process(struct nrf_wifi_fmac_dev_ctx
 					      __func__,
 					      desc_id);
 			status = NRF_WIFI_STATUS_FAIL;
-			goto out;
+			continue;
 		}
 
 		status = nrf_wifi_fmac_map_desc_to_pool(fmac_dev_ctx,
@@ -259,7 +259,8 @@ enum nrf_wifi_status nrf_wifi_fmac_rx_event_process(struct nrf_wifi_fmac_dev_ctx
 		if (status != NRF_WIFI_STATUS_SUCCESS) {
 			nrf_wifi_osal_log_err("%s: nrf_wifi_fmac_map_desc_to_pool failed",
 					      __func__);
-			goto out;
+			status = NRF_WIFI_STATUS_FAIL;
+			continue;
 		}
 
 		nwb_data = (void *)nrf_wifi_hal_buf_unmap_rx(fmac_dev_ctx->hal_dev_ctx,
@@ -270,7 +271,8 @@ enum nrf_wifi_status nrf_wifi_fmac_rx_event_process(struct nrf_wifi_fmac_dev_ctx
 		if (!nwb_data) {
 			nrf_wifi_osal_log_err("%s: nrf_wifi_hal_buf_unmap_rx failed",
 					      __func__);
-			goto out;
+			status = NRF_WIFI_STATUS_FAIL;
+			continue;
 		}
 
 		rx_buf_info = &def_dev_ctx->rx_buf_info[desc_id];
@@ -345,7 +347,7 @@ enum nrf_wifi_status nrf_wifi_fmac_rx_event_process(struct nrf_wifi_fmac_dev_ctx
 						      __func__,
 						      (config->rx_buff_info[i].pkt_type));
 				status = NRF_WIFI_STATUS_FAIL;
-				goto out;
+				continue;
 			}
 			def_priv->callbk_fns.rx_frm_callbk_fn(vif_ctx->os_vif_ctx,
 									 nwb);
@@ -360,7 +362,7 @@ enum nrf_wifi_status nrf_wifi_fmac_rx_event_process(struct nrf_wifi_fmac_dev_ctx
 #endif /* CONFIG_WIFI_MGMT_RAW_SCAN_RESULTS */
 			nrf_wifi_osal_nbuf_free(nwb);
 #ifdef NRF_WIFI_MGMT_BUFF_OFFLOAD
-			goto out;
+			continue;
 #endif /* NRF_WIFI_MGMT_BUFF_OFFLOAD */
 		}
 #if defined(NRF70_RAW_DATA_RX) || defined(NRF70_PROMISC_DATA_RX)
@@ -396,7 +398,7 @@ enum nrf_wifi_status nrf_wifi_fmac_rx_event_process(struct nrf_wifi_fmac_dev_ctx
 					      __func__,
 					      config->rx_pkt_type);
 			status = NRF_WIFI_STATUS_FAIL;
-			goto out;
+			continue;
 		}
 
 		status = nrf_wifi_fmac_rx_cmd_send(fmac_dev_ctx,
@@ -406,9 +408,10 @@ enum nrf_wifi_status nrf_wifi_fmac_rx_event_process(struct nrf_wifi_fmac_dev_ctx
 		if (status != NRF_WIFI_STATUS_SUCCESS) {
 			nrf_wifi_osal_log_err("%s: nrf_wifi_fmac_rx_cmd_send failed",
 					      __func__);
-			goto out;
+			continue;
 		}
 	}
-out:
+
+	/* A single failure returns failure for the entire event */
 	return status;
 }

--- a/drivers/nrf_wifi/fw_if/umac_if/src/rx.c
+++ b/drivers/nrf_wifi/fw_if/umac_if/src/rx.c
@@ -398,6 +398,7 @@ enum nrf_wifi_status nrf_wifi_fmac_rx_event_process(struct nrf_wifi_fmac_dev_ctx
 					      __func__,
 					      config->rx_pkt_type);
 			status = NRF_WIFI_STATUS_FAIL;
+			nrf_wifi_osal_nbuf_free(nwb);
 			continue;
 		}
 

--- a/drivers/nrf_wifi/fw_if/umac_if/src/rx.c
+++ b/drivers/nrf_wifi/fw_if/umac_if/src/rx.c
@@ -353,13 +353,13 @@ enum nrf_wifi_status nrf_wifi_fmac_rx_event_process(struct nrf_wifi_fmac_dev_ctx
 									 nwb);
 #endif /* NRF70_STA_MODE */
 		} else if (config->rx_pkt_type == NRF_WIFI_RX_PKT_BCN_PRB_RSP) {
-#ifdef CONFIG_WIFI_MGMT_RAW_SCAN_RESULTS
+#ifdef WIFI_MGMT_RAW_SCAN_RESULTS
 			def_priv->callbk_fns.rx_bcn_prb_resp_callbk_fn(
 							vif_ctx->os_vif_ctx,
 							nwb,
 							config->frequency,
 							config->signal);
-#endif /* CONFIG_WIFI_MGMT_RAW_SCAN_RESULTS */
+#endif /* WIFI_MGMT_RAW_SCAN_RESULTS */
 			nrf_wifi_osal_nbuf_free(nwb);
 #ifdef NRF_WIFI_MGMT_BUFF_OFFLOAD
 			continue;


### PR DESCRIPTION
Potential fix for a warning `RX deinit called for unmapped RX buffer`.