### PR TITLE
nrf_wifi: Fix rssi API call when promiscuous mode is enabled

### DIFF
--- a/drivers/nrf_wifi/fw_if/umac_if/src/rx.c
+++ b/drivers/nrf_wifi/fw_if/umac_if/src/rx.c
@@ -235,8 +235,10 @@ enum nrf_wifi_status nrf_wifi_fmac_rx_event_process(struct nrf_wifi_fmac_dev_ctx
 	vif_ctx = def_dev_ctx->vif_ctx[config->wdev_id];
 
 #ifdef NRF70_STA_MODE
-	def_priv->callbk_fns.process_rssi_from_rx(vif_ctx->os_vif_ctx,
-							     config->signal);
+	if (config->rx_pkt_type != NRF_WIFI_RAW_RX_PKT) {
+		def_priv->callbk_fns.process_rssi_from_rx(vif_ctx->os_vif_ctx,
+							  config->signal);
+	}
 #endif /* NRF70_STA_MODE */
 	num_pkts = config->rx_pkt_cnt;
 


### PR DESCRIPTION
when promiscuous mode is enabled, the rssi callback in driver is invoked for all packets and not for station connected profile only. Invoke the rssi callback only when packet is received for the station connected profile.

Fixes SHEL-3255