### PR TITLE
Revert "nrfx: drivers: nrfx_uarte: skip flush workaround for BSIM target

### DIFF
--- a/nrfx/drivers/src/nrfx_uarte.c
+++ b/nrfx/drivers/src/nrfx_uarte.c
@@ -66,11 +66,7 @@
 #define MIN_RX_CACHE_SIZE 8
 // There is a HW bug which results in RX amount value not being updated when FIFO was empty.
 // It is then hard to determine if FIFO contained anything or not.
-#if defined(CONFIG_SOC_SERIES_BSIM_NRFXX)
-#define USE_WORKAROUND_FOR_FLUSHRX_ANOMALY 0
-#else
 #define USE_WORKAROUND_FOR_FLUSHRX_ANOMALY 1
-#endif
 
 // Size of the RX HW FIFO
 #define UARTE_HW_RX_FIFO_SIZE 5


### PR DESCRIPTION
This reverts commit 54bde38c6f6ffb3780b26ae728cf79426184384e.

Let's not treat differently the simulated targets than others. The workaround works on them with the updated HW models.