### PR TITLE
nrfx: nrfx_ram_ctrl: fix bitmask offset for VMC RAM retention setting

### DIFF
--- a/nrfx/helpers/nrfx_ram_ctrl.h
+++ b/nrfx/helpers/nrfx_ram_ctrl.h
@@ -137,6 +137,7 @@ __STATIC_INLINE void nrfx_ram_ctrl_section_retention_mask_enable_set(uint8_t  bl
 #endif
 
 #elif defined(NRF_VMC)
+    section_mask <<= VMC_RAM_POWER_S0RETENTION_Pos;
     if (enable)
     {
         nrf_vmc_ram_block_retention_set(NRF_VMC, block_idx, (nrf_vmc_retention_t)section_mask);


### PR DESCRIPTION
Lower sixteen bits are for RAM section power configuration, while sixteen upper bits are for RAM section retention configuration.