### PR TITLE
2 header fixes

### DIFF
--- a/nrfx/drivers/include/nrfx_ppib.h
+++ b/nrfx/drivers/include/nrfx_ppib.h
@@ -210,9 +210,9 @@ NRFX_STATIC_INLINE uint32_t nrfx_ppib_receive_event_address_get(nrfx_ppib_t cons
  * @param[in] task       Task for which to set the configuration.
  * @param[in] channel    Channel through which to subscribe events.
  */
-NRF_STATIC_INLINE void nrfx_ppib_subscribe_set(nrfx_ppib_t const * p_instance,
-                                               nrf_ppib_task_t     task,
-                                               uint8_t             channel);
+NRFX_STATIC_INLINE void nrfx_ppib_subscribe_set(nrfx_ppib_t const * p_instance,
+                                                nrf_ppib_task_t     task,
+                                                uint8_t             channel);
 
 /**
  * @brief Function for clearing the subscribe configuration for a given
@@ -221,8 +221,8 @@ NRF_STATIC_INLINE void nrfx_ppib_subscribe_set(nrfx_ppib_t const * p_instance,
  * @param[in] p_instance Pointer to the driver instance structure.
  * @param[in] task       Task for which to clear the configuration.
  */
-NRF_STATIC_INLINE void nrfx_ppib_subscribe_clear(nrfx_ppib_t const * p_instance,
-                                                 nrf_ppib_task_t     task);
+NRFX_STATIC_INLINE void nrfx_ppib_subscribe_clear(nrfx_ppib_t const * p_instance,
+                                                  nrf_ppib_task_t     task);
 
 /**
  * @brief Function for setting the publish configuration for a given event.
@@ -231,17 +231,17 @@ NRF_STATIC_INLINE void nrfx_ppib_subscribe_clear(nrfx_ppib_t const * p_instance,
  * @param[in] event      Event for which to set the configuration.
  * @param[in] channel    PPIB channel through which to publish the event.
  */
-NRF_STATIC_INLINE void nrfx_ppib_publish_set(nrfx_ppib_t const * p_instance,
-                                             nrf_ppib_event_t    event,
-                                             uint8_t             channel);
+NRFX_STATIC_INLINE void nrfx_ppib_publish_set(nrfx_ppib_t const * p_instance,
+                                              nrf_ppib_event_t    event,
+                                              uint8_t             channel);
 /**
  * @brief Function for clearing the publish configuration for a given event.
  *
  * @param[in] p_instance Pointer to the driver instance structure.
  * @param[in] event      Event for which to clear the configuration.
  */
-NRF_STATIC_INLINE void nrfx_ppib_publish_clear(nrfx_ppib_t const * p_instance,
-                                               nrf_ppib_event_t    event);
+NRFX_STATIC_INLINE void nrfx_ppib_publish_clear(nrfx_ppib_t const * p_instance,
+                                                nrf_ppib_event_t    event);
 #ifndef NRFX_DECLARE_ONLY
 
 NRFX_STATIC_INLINE nrf_ppib_task_t nrfx_ppib_send_task_get(nrfx_ppib_t const * p_instance,
@@ -272,28 +272,28 @@ NRFX_STATIC_INLINE uint32_t nrfx_ppib_receive_event_address_get(nrfx_ppib_t cons
     return nrf_ppib_event_address_get(p_instance->p_reg, nrf_ppib_receive_event_get(channel));
 }
 
-NRF_STATIC_INLINE void nrfx_ppib_subscribe_set(nrfx_ppib_t const * p_instance,
-                                               nrf_ppib_task_t     task,
-                                               uint8_t             channel)
+NRFX_STATIC_INLINE void nrfx_ppib_subscribe_set(nrfx_ppib_t const * p_instance,
+                                                nrf_ppib_task_t     task,
+                                                uint8_t             channel)
 {
     nrf_ppib_subscribe_set(p_instance->p_reg, task, channel);
 }
 
-NRF_STATIC_INLINE void nrfx_ppib_subscribe_clear(nrfx_ppib_t const * p_instance,
-                                                 nrf_ppib_task_t     task)
+NRFX_STATIC_INLINE void nrfx_ppib_subscribe_clear(nrfx_ppib_t const * p_instance,
+                                                  nrf_ppib_task_t     task)
 {
     nrf_ppib_subscribe_clear(p_instance->p_reg, task);
 }
 
-NRF_STATIC_INLINE void nrfx_ppib_publish_set(nrfx_ppib_t const * p_instance,
-                                             nrf_ppib_event_t    event,
-                                             uint8_t             channel)
+NRFX_STATIC_INLINE void nrfx_ppib_publish_set(nrfx_ppib_t const * p_instance,
+                                              nrf_ppib_event_t    event,
+                                              uint8_t             channel)
 {
     nrf_ppib_publish_set(p_instance->p_reg, event, channel);
 }
 
-NRF_STATIC_INLINE void nrfx_ppib_publish_clear(nrfx_ppib_t const * p_instance,
-                                               nrf_ppib_event_t    event)
+NRFX_STATIC_INLINE void nrfx_ppib_publish_clear(nrfx_ppib_t const * p_instance,
+                                                nrf_ppib_event_t    event)
 {
     nrf_ppib_publish_clear(p_instance->p_reg, event);
 }

--- a/nrfx/hal/nrf_common.h
+++ b/nrfx/hal/nrf_common.h
@@ -181,6 +181,30 @@ NRF_STATIC_INLINE bool nrf_event_check(void const * p_reg, uint32_t event);
 
 NRF_STATIC_INLINE uint32_t nrf_task_event_address_get(void const * p_reg, uint32_t task_event);
 
+#if defined(ADDRESS_DOMAIN_Msk)
+NRF_STATIC_INLINE uint8_t nrf_address_domain_get(uint32_t addr);
+#endif
+
+#if defined(ADDRESS_REGION_Msk)
+NRF_STATIC_INLINE nrf_region_t nrf_address_region_get(uint32_t addr);
+#endif
+
+#if defined(ADDRESS_SECURITY_Msk)
+NRF_STATIC_INLINE bool nrf_address_security_get(uint32_t addr);
+#endif
+
+#if defined(ADDRESS_BUS_Msk)
+NRF_STATIC_INLINE uint8_t nrf_address_bus_get(uint32_t addr, size_t size);
+#endif
+
+#if defined(ADDRESS_SLAVE_Msk)
+NRF_STATIC_INLINE uint8_t nrf_address_slave_get(uint32_t addr);
+#endif
+
+#if defined(ADDRESS_PERIPHID_Msk)
+NRF_STATIC_INLINE uint16_t nrf_address_periphid_get(uint32_t addr);
+#endif
+
 #ifndef NRF_DECLARE_ONLY
 
 NRF_STATIC_INLINE void nrf_event_readback(void * p_event_reg)


### PR DESCRIPTION
    drivers nrfx_ppib: Use appropriate static inline macro
    
    Use the NRFX static inline macro for the nrfx code,
    so this code works properly for simulation too.
    
-----

    hal: nrf_common: Add missing prototypes
    
    We need prototypes for all functions so that when NRF_DECLARE_ONLY
    is set we still at least get them.

Related to https://github.com/zephyrproject-rtos/zephyr/pull/83280
Zephyr test PR: https://github.com/zephyrproject-rtos/zephyr/pull/83302