### PR TITLE
nrfx: samples: use native YAML lists

### DIFF
--- a/nrfx/samples/src/nrfx_egu/sample.yaml
+++ b/nrfx/samples/src/nrfx_egu/sample.yaml
@@ -5,9 +5,12 @@ tests:
   examples.nrfx_egu:
     tags: egu
     filter: dt_compat_enabled("nordic,nrf-egu")
-    platform_allow: |
-      nrf52dk/nrf52832 nrf52833dk/nrf52833 nrf52840dk/nrf52840
-      nrf5340dk/nrf5340/cpuapp nrf9160dk/nrf9160
+    platform_allow:
+      - nrf52dk/nrf52832
+      - nrf52833dk/nrf52833
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf9160dk/nrf9160
     integration_platforms:
       - nrf52dk/nrf52832
       - nrf52833dk/nrf52833

--- a/nrfx/samples/src/nrfx_gppi/fork/sample.yaml
+++ b/nrfx/samples/src/nrfx_gppi/fork/sample.yaml
@@ -5,9 +5,12 @@ tests:
   examples.nrfx_gppi.fork:
     tags: gppi
     filter: dt_compat_enabled("nordic,nrf-ppi") or dt_compat_enabled("nordic,nrf-dppic")
-    platform_allow: |
-      nrf52dk/nrf52832 nrf52833dk/nrf52833 nrf52840dk/nrf52840
-      nrf5340dk/nrf5340/cpuapp nrf9160dk/nrf9160
+    platform_allow:
+      - nrf52dk/nrf52832
+      - nrf52833dk/nrf52833
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf9160dk/nrf9160
     integration_platforms:
       - nrf52dk/nrf52832
       - nrf52833dk/nrf52833

--- a/nrfx/samples/src/nrfx_gppi/one_to_one/sample.yaml
+++ b/nrfx/samples/src/nrfx_gppi/one_to_one/sample.yaml
@@ -5,9 +5,12 @@ tests:
   examples.nrfx_gppi.one_to_one:
     tags: gppi
     filter: dt_compat_enabled("nordic,nrf-ppi") or dt_compat_enabled("nordic,nrf-dppic")
-    platform_allow: |
-      nrf52dk/nrf52832 nrf52833dk/nrf52833 nrf52840dk/nrf52840
-      nrf5340dk/nrf5340/cpuapp nrf9160dk/nrf9160
+    platform_allow:
+      - nrf52dk/nrf52832
+      - nrf52833dk/nrf52833
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf9160dk/nrf9160
     integration_platforms:
       - nrf52dk/nrf52832
       - nrf52833dk/nrf52833

--- a/nrfx/samples/src/nrfx_pwm/common_mode/sample.yaml
+++ b/nrfx/samples/src/nrfx_pwm/common_mode/sample.yaml
@@ -5,9 +5,12 @@ tests:
   examples.nrfx_pwm.common_mode:
     tags: pwm
     filter: dt_compat_enabled("nordic,nrf-pwm")
-    platform_allow: |
-      nrf52dk/nrf52832 nrf52833dk/nrf52833 nrf52840dk/nrf52840
-      nrf5340dk/nrf5340/cpuapp nrf9160dk/nrf9160
+    platform_allow:
+      - nrf52dk/nrf52832
+      - nrf52833dk/nrf52833
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf9160dk/nrf9160
     integration_platforms:
       - nrf52dk/nrf52832
       - nrf52833dk/nrf52833

--- a/nrfx/samples/src/nrfx_pwm/grouped_mode/sample.yaml
+++ b/nrfx/samples/src/nrfx_pwm/grouped_mode/sample.yaml
@@ -5,9 +5,12 @@ tests:
   examples.nrfx_pwm.grouped_mode:
     tags: pwm
     filter: dt_compat_enabled("nordic,nrf-pwm")
-    platform_allow: |
-      nrf52dk/nrf52832 nrf52833dk/nrf52833 nrf52840dk/nrf52840
-      nrf5340dk/nrf5340/cpuapp nrf9160dk/nrf9160
+    platform_allow:
+      - nrf52dk/nrf52832
+      - nrf52833dk/nrf52833
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf9160dk/nrf9160
     integration_platforms:
       - nrf52dk/nrf52832
       - nrf52833dk/nrf52833

--- a/nrfx/samples/src/nrfx_rng/sample.yaml
+++ b/nrfx/samples/src/nrfx_rng/sample.yaml
@@ -5,9 +5,11 @@ tests:
   examples.nrfx_rng:
     tags: rng
     filter: dt_compat_enabled("nordic,nrf-rng")
-    platform_allow: |
-      nrf52833dk/nrf52833 nrf52840dk/nrf52840
-      nrf5340dk/nrf5340/cpuapp nrf9160dk/nrf9160
+    platform_allow:
+      - nrf52833dk/nrf52833
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf9160dk/nrf9160
     integration_platforms:
       - nrf52833dk/nrf52833
       - nrf52840dk/nrf52840

--- a/nrfx/samples/src/nrfx_saadc/advanced_blocking/sample.yaml
+++ b/nrfx/samples/src/nrfx_saadc/advanced_blocking/sample.yaml
@@ -5,9 +5,12 @@ tests:
   examples.nrfx_saadc.advanced_blocking:
     tags: saadc
     filter: dt_compat_enabled("nordic,nrf-saadc")
-    platform_allow: |
-      nrf52dk/nrf52832 nrf52833dk/nrf52833 nrf52840dk/nrf52840
-      nrf5340dk/nrf5340/cpuapp nrf9160dk/nrf9160
+    platform_allow:
+      - nrf52dk/nrf52832
+      - nrf52833dk/nrf52833
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf9160dk/nrf9160
     integration_platforms:
       - nrf52dk/nrf52832
       - nrf52833dk/nrf52833

--- a/nrfx/samples/src/nrfx_saadc/advanced_non_blocking_internal_timer/sample.yaml
+++ b/nrfx/samples/src/nrfx_saadc/advanced_non_blocking_internal_timer/sample.yaml
@@ -5,9 +5,11 @@ tests:
   examples.nrfx_saadc.advanced_non_blocking_internal_timer:
     tags: saadc
     filter: dt_compat_enabled("nordic,nrf-saadc")
-    platform_allow: |
-      nrf52833dk/nrf52833 nrf52840dk/nrf52840
-      nrf5340dk/nrf5340/cpuapp nrf9160dk/nrf9160
+    platform_allow:
+      - nrf52833dk/nrf52833
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf9160dk/nrf9160
     integration_platforms:
       - nrf52833dk/nrf52833
       - nrf52840dk/nrf52840

--- a/nrfx/samples/src/nrfx_saadc/maximum_performance/sample.yaml
+++ b/nrfx/samples/src/nrfx_saadc/maximum_performance/sample.yaml
@@ -5,9 +5,10 @@ tests:
   examples.nrfx_saadc.maximum_performance:
     tags: saadc
     filter: dt_compat_enabled("nordic,nrf-saadc")
-    platform_allow: |
-      nrf52833dk/nrf52833 nrf52840dk/nrf52840
-      nrf9160dk/nrf9160
+    platform_allow:
+      - nrf52833dk/nrf52833
+      - nrf52840dk/nrf52840
+      - nrf9160dk/nrf9160
     integration_platforms:
       - nrf52833dk/nrf52833
       - nrf52840dk/nrf52840

--- a/nrfx/samples/src/nrfx_saadc/simple_blocking/sample.yaml
+++ b/nrfx/samples/src/nrfx_saadc/simple_blocking/sample.yaml
@@ -5,9 +5,12 @@ tests:
   examples.nrfx_saadc.simple_blocking:
     tags: saadc
     filter: dt_compat_enabled("nordic,nrf-saadc")
-    platform_allow: |
-      nrf52dk/nrf52832 nrf52833dk/nrf52833 nrf52840dk/nrf52840
-      nrf5340dk/nrf5340/cpuapp nrf9160dk/nrf9160
+    platform_allow:
+      - nrf52dk/nrf52832
+      - nrf52833dk/nrf52833
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf9160dk/nrf9160
     integration_platforms:
       - nrf52dk/nrf52832
       - nrf52833dk/nrf52833

--- a/nrfx/samples/src/nrfx_saadc/simple_non_blocking/sample.yaml
+++ b/nrfx/samples/src/nrfx_saadc/simple_non_blocking/sample.yaml
@@ -5,9 +5,12 @@ tests:
   examples.nrfx_saadc.simple_non_blocking:
     tags: saadc
     filter: dt_compat_enabled("nordic,nrf-saadc")
-    platform_allow: |
-      nrf52dk/nrf52832 nrf52833dk/nrf52833 nrf52840dk/nrf52840
-      nrf5340dk/nrf5340/cpuapp nrf9160dk/nrf9160
+    platform_allow:
+      - nrf52dk/nrf52832
+      - nrf52833dk/nrf52833
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf9160dk/nrf9160
     integration_platforms:
       - nrf52dk/nrf52832
       - nrf52833dk/nrf52833

--- a/nrfx/samples/src/nrfx_spim/blocking/sample.yaml
+++ b/nrfx/samples/src/nrfx_spim/blocking/sample.yaml
@@ -5,9 +5,12 @@ tests:
   examples.nrfx_spim.blocking:
     tags: spim
     filter: dt_compat_enabled("nordic,nrf-spim")
-    platform_allow: |
-      nrf52dk/nrf52832 nrf52833dk/nrf52833 nrf52840dk/nrf52840
-      nrf5340dk/nrf5340/cpuapp nrf9160dk/nrf9160
+    platform_allow:
+      - nrf52dk/nrf52832
+      - nrf52833dk/nrf52833
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf9160dk/nrf9160
     integration_platforms:
       - nrf52dk/nrf52832
       - nrf52833dk/nrf52833

--- a/nrfx/samples/src/nrfx_spim/non_blocking/sample.yaml
+++ b/nrfx/samples/src/nrfx_spim/non_blocking/sample.yaml
@@ -5,9 +5,12 @@ tests:
   examples.nrfx_spim.non_blocking:
     tags: spim
     filter: dt_compat_enabled("nordic,nrf-spim")
-    platform_allow: |
-      nrf52dk/nrf52832 nrf52833dk/nrf52833 nrf52840dk/nrf52840
-      nrf5340dk/nrf5340/cpuapp nrf9160dk/nrf9160
+    platform_allow:
+      - nrf52dk/nrf52832
+      - nrf52833dk/nrf52833
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf9160dk/nrf9160
     integration_platforms:
       - nrf52dk/nrf52832
       - nrf52833dk/nrf52833

--- a/nrfx/samples/src/nrfx_spim_spis/advanced_non_blocking/sample.yaml
+++ b/nrfx/samples/src/nrfx_spim_spis/advanced_non_blocking/sample.yaml
@@ -3,11 +3,16 @@ sample:
   name: nrfx_spim_spis advanced non-blocking example
 tests:
   examples.nrfx_spim_spis.advanced_non_blocking:
-    tags: spim and spis
+    tags:
+      - spim
+      - spis
     filter: dt_compat_enabled("nordic,nrf-spim") and dt_compat_enabled("nordic,nrf-spis")
-    platform_allow: |
-      nrf52dk/nrf52832 nrf52833dk/nrf52833 nrf52840dk/nrf52840
-      nrf5340dk/nrf5340/cpuapp nrf9160dk/nrf9160
+    platform_allow:
+      - nrf52dk/nrf52832
+      - nrf52833dk/nrf52833
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf9160dk/nrf9160
     integration_platforms:
       - nrf52dk/nrf52832
       - nrf52833dk/nrf52833

--- a/nrfx/samples/src/nrfx_spim_spis/non_blocking/sample.yaml
+++ b/nrfx/samples/src/nrfx_spim_spis/non_blocking/sample.yaml
@@ -3,11 +3,16 @@ sample:
   name: nrfx_spim_spis Non-blocking example
 tests:
   examples.nrfx_spim_spis.non_blocking:
-    tags: spim and spis
+    tags:
+      - spim
+      - spis
     filter: dt_compat_enabled("nordic,nrf-spim") and dt_compat_enabled("nordic,nrf-spis")
-    platform_allow: |
-      nrf52dk/nrf52832 nrf52833dk/nrf52833 nrf52840dk/nrf52840
-      nrf5340dk/nrf5340/cpuapp nrf9160dk/nrf9160
+    platform_allow:
+      - nrf52dk/nrf52832
+      - nrf52833dk/nrf52833
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf9160dk/nrf9160
     integration_platforms:
       - nrf52dk/nrf52832
       - nrf52833dk/nrf52833

--- a/nrfx/samples/src/nrfx_temp/blocking/sample.yaml
+++ b/nrfx/samples/src/nrfx_temp/blocking/sample.yaml
@@ -5,9 +5,11 @@ tests:
   examples.nrfx_temp.blocking:
     tags: temp
     filter: dt_compat_enabled("nordic,nrf-temp")
-    platform_allow: |
-      nrf52dk/nrf52832 nrf52833dk/nrf52833 nrf52840dk/nrf52840
-      nrf5340dk/nrf5340/cpunet
+    platform_allow:
+      - nrf52dk/nrf52832
+      - nrf52833dk/nrf52833
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpunet
     integration_platforms:
       - nrf52dk/nrf52832
       - nrf52833dk/nrf52833

--- a/nrfx/samples/src/nrfx_temp/non_blocking/sample.yaml
+++ b/nrfx/samples/src/nrfx_temp/non_blocking/sample.yaml
@@ -5,9 +5,11 @@ tests:
   examples.nrfx_temp.non_blocking:
     tags: temp
     filter: dt_compat_enabled("nordic,nrf-temp")
-    platform_allow: |
-      nrf52dk/nrf52832 nrf52833dk/nrf52833 nrf52840dk/nrf52840
-      nrf5340dk/nrf5340/cpunet
+    platform_allow:
+      - nrf52dk/nrf52832
+      - nrf52833dk/nrf52833
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpunet
     integration_platforms:
       - nrf52dk/nrf52832
       - nrf52833dk/nrf52833

--- a/nrfx/samples/src/nrfx_timer/counter/sample.yaml
+++ b/nrfx/samples/src/nrfx_timer/counter/sample.yaml
@@ -5,9 +5,12 @@ tests:
   examples.nrfx_timer.counter:
     tags: timer
     filter: dt_compat_enabled("nordic,nrf-timer")
-    platform_allow: |
-      nrf52dk/nrf52832 nrf52833dk/nrf52833 nrf52840dk/nrf52840
-      nrf5340dk/nrf5340/cpuapp nrf9160dk/nrf9160
+    platform_allow:
+      - nrf52dk/nrf52832
+      - nrf52833dk/nrf52833
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf9160dk/nrf9160
     integration_platforms:
       - nrf52dk/nrf52832
       - nrf52833dk/nrf52833

--- a/nrfx/samples/src/nrfx_timer/timer/sample.yaml
+++ b/nrfx/samples/src/nrfx_timer/timer/sample.yaml
@@ -5,9 +5,12 @@ tests:
   examples.nrfx_timer.timer:
     tags: timer
     filter: dt_compat_enabled("nordic,nrf-timer")
-    platform_allow: |
-      nrf52dk/nrf52832 nrf52833dk/nrf52833 nrf52840dk/nrf52840
-      nrf5340dk/nrf5340/cpuapp nrf9160dk/nrf9160
+    platform_allow:
+      - nrf52dk/nrf52832
+      - nrf52833dk/nrf52833
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf9160dk/nrf9160
     integration_platforms:
       - nrf52dk/nrf52832
       - nrf52833dk/nrf52833

--- a/nrfx/samples/src/nrfx_twim_twis/tx_rx_blocking/sample.yaml
+++ b/nrfx/samples/src/nrfx_twim_twis/tx_rx_blocking/sample.yaml
@@ -3,11 +3,16 @@ sample:
   name: nrfx_twim_twis tx_rx_blocking example
 tests:
   examples.nrfx_twim_twis.blocking:
-    tags: twim and twis
+    tags:
+      - twim
+      - twis
     filter: dt_compat_enabled("nordic,nrf-twim") and dt_compat_enabled("nordic,nrf-twis")
-    platform_allow: |
-      nrf52dk/nrf52832 nrf52833dk/nrf52833 nrf52840dk/nrf52840
-      nrf5340dk/nrf5340/cpuapp nrf9160dk/nrf9160
+    platform_allow:
+      - nrf52dk/nrf52832
+      - nrf52833dk/nrf52833
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf9160dk/nrf9160
     integration_platforms:
       - nrf52dk/nrf52832
       - nrf52833dk/nrf52833

--- a/nrfx/samples/src/nrfx_twim_twis/tx_rx_non_blocking/sample.yaml
+++ b/nrfx/samples/src/nrfx_twim_twis/tx_rx_non_blocking/sample.yaml
@@ -3,11 +3,16 @@ sample:
   name: nrfx_twim_twis tx_rx_non_blocking example
 tests:
   examples.nrfx_twim_twis.non_blocking:
-    tags: twim and twis
+    tags:
+      - twim
+      - twis
     filter: dt_compat_enabled("nordic,nrf-twim") and dt_compat_enabled("nordic,nrf-twis")
-    platform_allow: |
-      nrf52dk/nrf52832 nrf52833dk/nrf52833 nrf52840dk/nrf52840
-      nrf5340dk/nrf5340/cpuapp nrf9160dk/nrf9160
+    platform_allow:
+      - nrf52dk/nrf52832
+      - nrf52833dk/nrf52833
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf9160dk/nrf9160
     integration_platforms:
       - nrf52dk/nrf52832
       - nrf52833dk/nrf52833

--- a/nrfx/samples/src/nrfx_twim_twis/txrx/sample.yaml
+++ b/nrfx/samples/src/nrfx_twim_twis/txrx/sample.yaml
@@ -3,11 +3,16 @@ sample:
   name: nrfx_twim_twis txrx example
 tests:
   examples.nrfx_twim_twis.txrx:
-    tags: twim and twis
+    tags:
+      - twim
+      - twis
     filter: dt_compat_enabled("nordic,nrf-twim") and dt_compat_enabled("nordic,nrf-twis")
-    platform_allow: |
-      nrf52dk/nrf52832 nrf52833dk/nrf52833 nrf52840dk/nrf52840
-      nrf5340dk/nrf5340/cpuapp nrf9160dk/nrf9160
+    platform_allow:
+      - nrf52dk/nrf52832
+      - nrf52833dk/nrf52833
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf9160dk/nrf9160
     integration_platforms:
       - nrf52dk/nrf52832
       - nrf52833dk/nrf52833

--- a/nrfx/samples/src/nrfx_twim_twis/txtx/sample.yaml
+++ b/nrfx/samples/src/nrfx_twim_twis/txtx/sample.yaml
@@ -3,11 +3,16 @@ sample:
   name: nrfx_twim_twis txtx example
 tests:
   examples.nrfx_twim_twis.txtx:
-    tags: twim and twis
+    tags:
+      - twim
+      - twis
     filter: dt_compat_enabled("nordic,nrf-twim") and dt_compat_enabled("nordic,nrf-twis")
-    platform_allow: |
-      nrf52dk/nrf52832 nrf52833dk/nrf52833 nrf52840dk/nrf52840
-      nrf5340dk/nrf5340/cpuapp nrf9160dk/nrf9160
+    platform_allow:
+      - nrf52dk/nrf52832
+      - nrf52833dk/nrf52833
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf9160dk/nrf9160
     integration_platforms:
       - nrf52dk/nrf52832
       - nrf52833dk/nrf52833

--- a/nrfx/samples/src/nrfx_uarte/rx_double_buffered/sample.yaml
+++ b/nrfx/samples/src/nrfx_uarte/rx_double_buffered/sample.yaml
@@ -5,9 +5,11 @@ tests:
   examples.nrfx_uarte.rx_double_buffered:
     tags: uarte
     filter: dt_compat_enabled("nordic,nrf-uarte")
-    platform_allow: |
-      nrf52833dk/nrf52833 nrf52840dk/nrf52840
-      nrf5340dk/nrf5340/cpuapp nrf9160dk/nrf9160
+    platform_allow:
+      - nrf52833dk/nrf52833
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf9160dk/nrf9160
     integration_platforms:
       - nrf52833dk/nrf52833
       - nrf52840dk/nrf52840

--- a/nrfx/samples/src/nrfx_uarte/tx_rx_non_blocking/sample.yaml
+++ b/nrfx/samples/src/nrfx_uarte/tx_rx_non_blocking/sample.yaml
@@ -5,9 +5,11 @@ tests:
   examples.nrfx_uarte.tx_rx_non_blocking:
     tags: uarte
     filter: dt_compat_enabled("nordic,nrf-uarte")
-    platform_allow: |
-      nrf52833dk/nrf52833 nrf52840dk/nrf52840
-      nrf5340dk/nrf5340/cpuapp nrf9160dk/nrf9160
+    platform_allow:
+      - nrf52833dk/nrf52833
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf9160dk/nrf9160
     integration_platforms:
       - nrf52833dk/nrf52833
       - nrf52840dk/nrf52840


### PR DESCRIPTION
Twister no longer supports space-separated lists.