### PR TITLE
.gitignore: ignore binary blobs pulled by `west blobs`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /drivers/nrf_wifi/doc_build
+/zephyr/blobs


### PR DESCRIPTION
Add binary blobs to `.gitignore`, since they should not be committed and clutter up git status output.