### PR TITLE
NRFX-7066: Add default CLKSEL for GRTC

### DIFF
--- a/nrfx/haly/nrfy_grtc.h
+++ b/nrfx/haly/nrfy_grtc.h
@@ -210,7 +210,7 @@ NRFY_STATIC_INLINE uint32_t nrfy_grtc_events_process(NRF_GRTC_Type * p_reg,
  */
 NRFY_STATIC_INLINE void nrfy_grtc_prepare(NRF_GRTC_Type * p_reg, bool busy_wait)
 {
-#if NRFY_GRTC_HAS_CLKSEL
+#if NRFY_GRTC_HAS_CLKSEL && NRFX_IS_ENABLED(NRFX_GRTC_CONFIG_DEFAULT_CLKSEL_LFCLK)
     nrf_grtc_clksel_set(p_reg, NRF_GRTC_CLKSEL_LFCLK);
 #endif
     nrf_grtc_sys_counter_set(p_reg, false);


### PR DESCRIPTION
By default, the driver sets the clock source to LFCLK during initialization. If the application needs to change the clock source, the `NRFX_GRTC_CONFIG_DEFAULT_CLKSEL_LFCLK` parameter should be disabled. The application should then call `nrfx_grtc_clock_source_set()` with the desired clock source passed as an argument before executing `nrfx_grtc_init()`.