### PR TITLE
drivers: nrfx_usbreg: clear USBPWRRDY event on initialization

### DIFF
--- a/nrfx/drivers/src/nrfx_usbreg.c
+++ b/nrfx/drivers/src/nrfx_usbreg.c
@@ -51,6 +51,7 @@ void nrfx_usbreg_init(nrfx_usbreg_config_t const * p_config)
 
     nrfx_usbreg_uninit();
     m_usbevt_handler = p_config->handler;
+    nrf_usbreg_event_clear(NRF_USBREGULATOR, NRF_USBREG_EVENT_USBPWRRDY);
 
     NRFX_IRQ_PRIORITY_SET(nrfx_get_irq_number(NRF_USBREGULATOR), p_config->irq_priority);
     NRFX_IRQ_ENABLE(nrfx_get_irq_number(NRF_USBREGULATOR));


### PR DESCRIPTION
Clear USBPWRRDY event on driver initialization and prevent spurious event right after initialization.

This was already fixed in commit cad21db72a61
("drivers: nrfx_usbreg: clear events on initialization") and the fix was removed in commit 2591a2b6006a
("nrfx: Update to version 3.9.0")
.
Partially reinstate the fix. Do not clear all events, as this prevents the USBDETECTED event from being fired if the cable was already connected during initialization.