### PR TITLE
nrfx: drivers: nrfx_grtc: Improvements to speed up nrf_grtc_timer

### DIFF
--- a/nrfx/drivers/include/nrfx_grtc.h
+++ b/nrfx/drivers/include/nrfx_grtc.h
@@ -170,6 +170,19 @@ nrfx_err_t nrfx_grtc_sleep_configuration_get(nrfx_grtc_sleep_config_t * p_sleep_
 nrfx_err_t nrfx_grtc_channel_alloc(uint8_t * p_channel);
 
 /**
+ * @brief Function for setting a callback to a channel.
+ *
+ * Function enabled the interrupt for that channel.
+ *
+ * @param[in] channel   Pointer to the capture/compare channel.
+ * @param[in] handler   User handler called when channel expires.
+ * @param[in] p_context Context passed to the callback.
+ */
+void nrfx_grtc_channel_callback_set(uint8_t                channel,
+                                    nrfx_grtc_cc_handler_t handler,
+                                    void *                 p_context);
+
+/**
  * @brief Function for freeing the GRTC capture/compare channel.
  *
  * @note Function is thread safe as it uses @ref nrfx_flag32_free.
@@ -296,7 +309,6 @@ void nrfx_grtc_syscountervalid_int_disable(void);
  */
 
 nrfx_err_t nrfx_grtc_syscounter_start(bool busy_wait, uint8_t * p_main_cc_channel);
-
 /**
  * @brief Function for performing an action for the GRTC.
  *
@@ -360,6 +372,22 @@ nrfx_err_t nrfx_grtc_syscounter_cc_absolute_set(nrfx_grtc_channel_t * p_chan_dat
                                                 bool                  enable_irq);
 
 /**
+ * @brief Function for setting the absolute compare value for the SYSCOUNTER.
+ *
+ * Function must be called with interrupts locked. If %p safe_setting is true then
+ * it means that previous CC for that channel did not yet expired and it
+ * was set to a value earlier than %p val so there is a chance that it will
+ * expire during setting the new value. In that case compare event may be misinterpreted.
+ * Slower but safe procedure is used in that case. If %p safe_setting is false then
+ * function just sets new CC value.
+ *
+ * @param[in] channel     Channel.
+ * @param[in] val         Absolute value to be set in the compare register.
+ * @param[in] safe_setting Use safe procedure if true or just set CC to a new value if false.
+ */
+void nrfx_grtc_syscounter_cc_abs_set(uint8_t channel, uint64_t val, bool safe_setting);
+
+/**
  * @brief Function for setting the relative compare value for the SYSCOUNTER.
  *
  * @note This function marks the specified @p channel as used.
@@ -378,6 +406,22 @@ nrfx_err_t nrfx_grtc_syscounter_cc_relative_set(nrfx_grtc_channel_t *           
                                                 uint32_t                          val,
                                                 bool                              enable_irq,
                                                 nrfx_grtc_cc_relative_reference_t reference);
+
+/**
+ * @brief Function for setting the relative compare value for the SYSCOUNTER.
+ *
+ * Function just sets CCADD value and does not attempt to enable or disable the interrupt.
+ * It assumes that expected channel configuration is done prior to that call.
+ * Function assumes that previously used CC value has already expired so new value
+ * can be safely set without a risk of spurious CC expiration.
+ *
+ * @param[in] channel     Channel.
+ * @param[in] val         Relative value to be set in the CCADD register.
+ * @param[in] reference   Reference. Current counter value or current CC value.
+ */
+void nrfx_grtc_syscounter_cc_rel_set(uint8_t channel,
+                                     uint32_t val,
+                                     nrfx_grtc_cc_relative_reference_t reference);
 
 /**
  * @brief Function for disabling the SYSCOUNTER compare interrupt.
@@ -539,6 +583,15 @@ NRFX_STATIC_INLINE bool nrfx_grtc_sys_counter_cc_enable_check(uint8_t channel);
  */
 NRFX_STATIC_INLINE bool nrfx_grtc_syscounter_compare_event_check(uint8_t channel);
 
+/**
+ * @brief Function for retrieving CC value.
+ *
+ * @param[in] channel Compare channel.
+ *
+ * @return Value read from CC register.
+ */
+NRFX_STATIC_INLINE uint64_t nrfx_grtc_sys_counter_cc_get(uint8_t channel);
+
 #if NRF_GRTC_HAS_RTCOUNTER || defined(__NRFX_DOXYGEN__)
 /**
  * @brief Function for reading the GRTC RTCOUNTER value.
@@ -588,6 +641,11 @@ NRFX_STATIC_INLINE bool nrfx_grtc_sys_counter_cc_enable_check(uint8_t channel)
 NRFX_STATIC_INLINE bool nrfx_grtc_syscounter_compare_event_check(uint8_t channel)
 {
     return nrfy_grtc_sys_counter_compare_event_check(NRF_GRTC, channel);
+}
+
+NRFX_STATIC_INLINE uint64_t nrfx_grtc_sys_counter_cc_get(uint8_t channel)
+{
+    return nrfy_grtc_sys_counter_cc_get(NRF_GRTC, channel);
 }
 
 #if NRF_GRTC_HAS_RTCOUNTER

--- a/nrfx/hal/nrf_grtc.h
+++ b/nrfx/hal/nrf_grtc.h
@@ -1559,7 +1559,6 @@ NRF_STATIC_INLINE void nrf_grtc_event_clear(NRF_GRTC_Type * p_reg, nrf_grtc_even
 #endif
 
     *((volatile uint32_t *)((uint8_t *)p_reg + (uint32_t)event)) = 0x0UL;
-    nrf_event_readback((uint8_t *)p_reg + (uint32_t)event);
 }
 
 #if NRF_GRTC_HAS_RTCOUNTER


### PR DESCRIPTION
Set of proposed improvements to reduce time spent in the GRTC functions. The main factor impacting performance is the number of register accesses. For example on nrf54h20 each register access to GRTC takes ~0.5 us which is 160 cycles at 320 MHz.

Following improvements are proposed:
- Using INTPEND register in the interrupt handler - it reduces the need of reading INTEN and EVENTS registers. After INTPEND is read then only EVENTS clearing for events that actually triggered the interrupt are cleared
- Removing event readback after clearing the register. Event readback was introduced in nrf52 series and it was recommended to avoid a risk of getting another interrupt triggered. It could happen in a case where event clearing happens just before exiting an interrupt since register writes are queued and write may not happen before interrupt routine finishes. That will never be the case for GRTC since there is always user handler and next CC value being set (which will ensure that write to EVENT register is done)
- Adding functions dedicated for `nrf_grtc_timer` that will speed up CC configuration.

Newly added functons: 
`nrfx_grtc_channel_cb_alloc` Allocated a channel, enables interrupt source and stores callback + p_context. Previously only channel was allocated and enabling interrupt and storing callback+p_context was done on every new CC value setting. Those operations were redundant.
`nrfx_grtc_syscounter_cc_abs_set` - Function for setting absolute CC value. One of the parameters is `safe_setting` bool. If true then it indicates that previous CC is earlier than new CC and it is not far in the future so longer and safer procedure must be applied. If false then CC can be just written with the new value.
`nrfx_grtc_syscounter_cc_rel_set` - Function for setting CCADD. It just writes CCADD. It is caller responsibility to use it only when it makes sense. For `nrf_grtc_timer` it is used when setting a new CC value from callback of previous Compare event. It is using relative to CC.

Modified function:
`nrfx_grtc_syscounter_start` - Added `handler` and `p_context` to function parameters. It not only allocates main channel but stores callback and enables interrupt handler.