### PR TITLE
nrfx: mdk: fix cmsis include for BSIM/POSIX

### DIFF
--- a/nrfx/mdk/nrf51.h
+++ b/nrfx/mdk/nrf51.h
@@ -123,7 +123,11 @@ typedef enum {
 
 /** @} */ /* End of group Configuration_of_CMSIS */
 
+#ifdef CONFIG_ARCH_POSIX
+#include "cmsis.h"
+#else
 #include "core_cm0.h"                           /*!< ARM Cortex-M0 processor and core peripherals                              */
+#endif
 #include "system_nrf51.h"                       /*!< nrf51 System                                                              */
 
 #ifndef __IM                                    /*!< Fallback for older CMSIS versions                                         */

--- a/nrfx/mdk/nrf52.h
+++ b/nrfx/mdk/nrf52.h
@@ -141,7 +141,11 @@ typedef enum {
 
 /** @} */ /* End of group Configuration_of_CMSIS */
 
+#ifdef CONFIG_ARCH_POSIX
+#include "cmsis.h"
+#else
 #include "core_cm4.h"                           /*!< ARM Cortex-M4 processor and core peripherals                              */
+#endif
 #include "system_nrf52.h"                       /*!< nrf52 System                                                              */
 
 #ifndef __IM                                    /*!< Fallback for older CMSIS versions                                         */

--- a/nrfx/mdk/nrf52805.h
+++ b/nrfx/mdk/nrf52805.h
@@ -128,7 +128,11 @@ typedef enum {
 
 /** @} */ /* End of group Configuration_of_CMSIS */
 
+#ifdef CONFIG_ARCH_POSIX
+#include "cmsis.h"
+#else
 #include "core_cm4.h"                           /*!< ARM Cortex-M4 processor and core peripherals                              */
+#endif
 #include "system_nrf52805.h"                    /*!< nrf52805 System                                                           */
 
 #ifndef __IM                                    /*!< Fallback for older CMSIS versions                                         */

--- a/nrfx/mdk/nrf52810.h
+++ b/nrfx/mdk/nrf52810.h
@@ -131,7 +131,11 @@ typedef enum {
 
 /** @} */ /* End of group Configuration_of_CMSIS */
 
+#ifdef CONFIG_ARCH_POSIX
+#include "cmsis.h"
+#else
 #include "core_cm4.h"                           /*!< ARM Cortex-M4 processor and core peripherals                              */
+#endif
 #include "system_nrf52810.h"                    /*!< nrf52810 System                                                           */
 
 #ifndef __IM                                    /*!< Fallback for older CMSIS versions                                         */

--- a/nrfx/mdk/nrf52811.h
+++ b/nrfx/mdk/nrf52811.h
@@ -131,7 +131,11 @@ typedef enum {
 
 /** @} */ /* End of group Configuration_of_CMSIS */
 
+#ifdef CONFIG_ARCH_POSIX
+#include "cmsis.h"
+#else
 #include "core_cm4.h"                           /*!< ARM Cortex-M4 processor and core peripherals                              */
+#endif
 #include "system_nrf52811.h"                    /*!< nrf52811 System                                                           */
 
 #ifndef __IM                                    /*!< Fallback for older CMSIS versions                                         */

--- a/nrfx/mdk/nrf52820.h
+++ b/nrfx/mdk/nrf52820.h
@@ -130,7 +130,11 @@ typedef enum {
 
 /** @} */ /* End of group Configuration_of_CMSIS */
 
+#ifdef CONFIG_ARCH_POSIX
+#include "cmsis.h"
+#else
 #include "core_cm4.h"                           /*!< ARM Cortex-M4 processor and core peripherals                              */
+#endif
 #include "system_nrf52820.h"                    /*!< nrf52820 System                                                           */
 
 #ifndef __IM                                    /*!< Fallback for older CMSIS versions                                         */

--- a/nrfx/mdk/nrf52833.h
+++ b/nrfx/mdk/nrf52833.h
@@ -145,7 +145,11 @@ typedef enum {
 
 /** @} */ /* End of group Configuration_of_CMSIS */
 
+#ifdef CONFIG_ARCH_POSIX
+#include "cmsis.h"
+#else
 #include "core_cm4.h"                           /*!< ARM Cortex-M4 processor and core peripherals                              */
+#endif
 #include "system_nrf52833.h"                    /*!< nrf52833 System                                                           */
 
 #ifndef __IM                                    /*!< Fallback for older CMSIS versions                                         */

--- a/nrfx/mdk/nrf52840.h
+++ b/nrfx/mdk/nrf52840.h
@@ -148,7 +148,11 @@ typedef enum {
 
 /** @} */ /* End of group Configuration_of_CMSIS */
 
+#ifdef CONFIG_ARCH_POSIX
+#include "cmsis.h"
+#else
 #include "core_cm4.h"                           /*!< ARM Cortex-M4 processor and core peripherals                              */
+#endif
 #include "system_nrf52840.h"                    /*!< nrf52840 System                                                           */
 
 #ifndef __IM                                    /*!< Fallback for older CMSIS versions                                         */

--- a/nrfx/mdk/nrf5340_application.h
+++ b/nrfx/mdk/nrf5340_application.h
@@ -148,7 +148,11 @@ typedef enum {
 
 /** @} */ /* End of group Configuration_of_CMSIS */
 
+#ifdef CONFIG_ARCH_POSIX
+#include "cmsis.h"
+#else
 #include "core_cm33.h"                          /*!< ARM Cortex-M33 processor and core peripherals                             */
+#endif
 #include "system_nrf5340_application.h"         /*!< nrf5340_application System                                                */
 
 #ifndef __IM                                    /*!< Fallback for older CMSIS versions                                         */

--- a/nrfx/mdk/nrf5340_network.h
+++ b/nrfx/mdk/nrf5340_network.h
@@ -127,7 +127,11 @@ typedef enum {
 
 /** @} */ /* End of group Configuration_of_CMSIS */
 
+#ifdef CONFIG_ARCH_POSIX
+#include "cmsis.h"
+#else
 #include "core_cm33.h"                          /*!< ARM Cortex-M33 processor and core peripherals                             */
+#endif
 #include "system_nrf5340_network.h"             /*!< nrf5340_network System                                                    */
 
 #ifndef __IM                                    /*!< Fallback for older CMSIS versions                                         */

--- a/nrfx/mdk/nrf54h20_application.h
+++ b/nrfx/mdk/nrf54h20_application.h
@@ -251,7 +251,11 @@ typedef enum {
 #define __SAUREGION_PRESENT            1             /*!< SAU present                                                          */
 #define __NUM_SAUREGIONS               8             /*!< Number of regions                                                    */
 
+#ifdef CONFIG_ARCH_POSIX
+#include "cmsis.h"
+#else
 #include "core_cm33.h"                               /*!< ARM Cortex-M33 processor and core peripherals                        */
+#endif
 #include "system_nrf.h"                              /*!< nrf54h20_application System Library                                  */
 
 #endif                                               /*!< NRF_APPLICATION                                                      */

--- a/nrfx/mdk/nrf54h20_radiocore.h
+++ b/nrfx/mdk/nrf54h20_radiocore.h
@@ -273,7 +273,11 @@ typedef enum {
 #define __SAUREGION_PRESENT            1             /*!< SAU present                                                          */
 #define __NUM_SAUREGIONS               8             /*!< Number of regions                                                    */
 
+#ifdef CONFIG_ARCH_POSIX
+#include "cmsis.h"
+#else
 #include "core_cm33.h"                               /*!< ARM Cortex-M33 processor and core peripherals                        */
+#endif
 #include "system_nrf.h"                              /*!< nrf54h20_radiocore System Library                                    */
 
 #endif                                               /*!< NRF_RADIOCORE                                                        */

--- a/nrfx/mdk/nrf54l05_application.h
+++ b/nrfx/mdk/nrf54l05_application.h
@@ -200,7 +200,11 @@ typedef enum {
 #define __SAUREGION_PRESENT            1             /*!< SAU present                                                          */
 #define __NUM_SAUREGIONS               4             /*!< Number of regions                                                    */
 
+#ifdef CONFIG_ARCH_POSIX
+#include "cmsis.h"
+#else
 #include "core_cm33.h"                               /*!< ARM Cortex-M33 processor and core peripherals                        */
+#endif
 #include "system_nrf.h"                              /*!< nrf54l05_application System Library                                  */
 
 #endif                                               /*!< NRF_APPLICATION                                                      */

--- a/nrfx/mdk/nrf54l10_application.h
+++ b/nrfx/mdk/nrf54l10_application.h
@@ -200,7 +200,11 @@ typedef enum {
 #define __SAUREGION_PRESENT            1             /*!< SAU present                                                          */
 #define __NUM_SAUREGIONS               4             /*!< Number of regions                                                    */
 
+#ifdef CONFIG_ARCH_POSIX
+#include "cmsis.h"
+#else
 #include "core_cm33.h"                               /*!< ARM Cortex-M33 processor and core peripherals                        */
+#endif
 #include "system_nrf.h"                              /*!< nrf54l10_application System Library                                  */
 
 #endif                                               /*!< NRF_APPLICATION                                                      */

--- a/nrfx/mdk/nrf54l15_application.h
+++ b/nrfx/mdk/nrf54l15_application.h
@@ -200,7 +200,11 @@ typedef enum {
 #define __SAUREGION_PRESENT            1             /*!< SAU present                                                          */
 #define __NUM_SAUREGIONS               4             /*!< Number of regions                                                    */
 
+#ifdef CONFIG_ARCH_POSIX
+#include "cmsis.h"
+#else
 #include "core_cm33.h"                               /*!< ARM Cortex-M33 processor and core peripherals                        */
+#endif
 #include "system_nrf.h"                              /*!< nrf54l15_application System Library                                  */
 
 #endif                                               /*!< NRF_APPLICATION                                                      */

--- a/nrfx/mdk/nrf54lm20a_enga_application.h
+++ b/nrfx/mdk/nrf54lm20a_enga_application.h
@@ -225,7 +225,11 @@ typedef enum {
 #define __SAUREGION_PRESENT            1             /*!< SAU present                                                          */
 #define __NUM_SAUREGIONS               4             /*!< Number of regions                                                    */
 
+#ifdef CONFIG_ARCH_POSIX
+#include "cmsis.h"
+#else
 #include "core_cm33.h"                               /*!< ARM Cortex-M33 processor and core peripherals                        */
+#endif
 #include "system_nrf.h"                              /*!< nrf54lm20a_enga_application System Library                           */
 
 #endif                                               /*!< NRF_APPLICATION                                                      */

--- a/nrfx/mdk/nrf54lv10a_enga_application.h
+++ b/nrfx/mdk/nrf54lv10a_enga_application.h
@@ -174,7 +174,11 @@ typedef enum {
 #define __SAUREGION_PRESENT            1             /*!< SAU present                                                          */
 #define __NUM_SAUREGIONS               4             /*!< Number of regions                                                    */
 
+#ifdef CONFIG_ARCH_POSIX
+#include "cmsis.h"
+#else
 #include "core_cm33.h"                               /*!< ARM Cortex-M33 processor and core peripherals                        */
+#endif
 #include "system_nrf.h"                              /*!< nrf54lv10a_enga_application System Library                           */
 
 #endif                                               /*!< NRF_APPLICATION                                                      */

--- a/nrfx/mdk/nrf7120_enga_application.h
+++ b/nrfx/mdk/nrf7120_enga_application.h
@@ -243,7 +243,11 @@ typedef enum {
 #define __SAUREGION_PRESENT            1             /*!< SAU present                                                          */
 #define __NUM_SAUREGIONS               4             /*!< Number of regions                                                    */
 
+#ifdef CONFIG_ARCH_POSIX
+#include "cmsis.h"
+#else
 #include "core_cm33.h"                               /*!< ARM Cortex-M33 processor and core peripherals                        */
+#endif
 #include "system_nrf.h"                              /*!< nrf7120_enga_application System Library                              */
 
 #endif                                               /*!< NRF_APPLICATION                                                      */

--- a/nrfx/mdk/nrf9120.h
+++ b/nrfx/mdk/nrf9120.h
@@ -138,7 +138,11 @@ typedef enum {
 
 /** @} */ /* End of group Configuration_of_CMSIS */
 
+#ifdef CONFIG_ARCH_POSIX
+#include "cmsis.h"
+#else
 #include "core_cm33.h"                          /*!< ARM Cortex-M33 processor and core peripherals                             */
+#endif
 #include "system_nrf9120.h"                     /*!< nrf9120 System                                                            */
 
 #ifndef __IM                                    /*!< Fallback for older CMSIS versions                                         */

--- a/nrfx/mdk/nrf9160.h
+++ b/nrfx/mdk/nrf9160.h
@@ -138,7 +138,11 @@ typedef enum {
 
 /** @} */ /* End of group Configuration_of_CMSIS */
 
+#ifdef CONFIG_ARCH_POSIX
+#include "cmsis.h"
+#else
 #include "core_cm33.h"                          /*!< ARM Cortex-M33 processor and core peripherals                             */
+#endif
 #include "system_nrf9160.h"                     /*!< nrf9160 System                                                            */
 
 #ifndef __IM                                    /*!< Fallback for older CMSIS versions                                         */

--- a/nrfx/mdk/nrf9230_engb_application.h
+++ b/nrfx/mdk/nrf9230_engb_application.h
@@ -251,7 +251,11 @@ typedef enum {
 #define __SAUREGION_PRESENT            1             /*!< SAU present                                                          */
 #define __NUM_SAUREGIONS               4             /*!< Number of regions                                                    */
 
+#ifdef CONFIG_ARCH_POSIX
+#include "cmsis.h"
+#else
 #include "core_cm33.h"                               /*!< ARM Cortex-M33 processor and core peripherals                        */
+#endif
 #include "system_nrf.h"                              /*!< nrf9230_engb_application System Library                              */
 
 #endif                                               /*!< NRF_APPLICATION                                                      */

--- a/nrfx/mdk/nrf9230_engb_radiocore.h
+++ b/nrfx/mdk/nrf9230_engb_radiocore.h
@@ -273,7 +273,11 @@ typedef enum {
 #define __SAUREGION_PRESENT            1             /*!< SAU present                                                          */
 #define __NUM_SAUREGIONS               4             /*!< Number of regions                                                    */
 
+#ifdef CONFIG_ARCH_POSIX
+#include "cmsis.h"
+#else
 #include "core_cm33.h"                               /*!< ARM Cortex-M33 processor and core peripherals                        */
+#endif
 #include "system_nrf.h"                              /*!< nrf9230_engb_radiocore System Library                                */
 
 #endif                                               /*!< NRF_RADIOCORE                                                        */


### PR DESCRIPTION
### What is the change?
Do not use header files from cmsis module when compiling for BSIM,
instead use zephyr/boards/native/nrf_bsim/common/cmsis/cmsis.h
which has the required alternatives apis.

### Why do we need this change?
BSIM ci reported compiler errors when CMSIS_6 module was used for
Cortex-M instead of the older cmsis module.
The error was because CMSIS_6 couldn't find "arm_acl.h" and that
__ARM_ARCH_PROFILE was not defined to an expected value however,
this error highlighted that hal_nordic was including cmsis header
files even CONFIG_ARCH was "posix" and not "arm".

Updating to CMSIS_6 is important for future maintenance and to add new
features so we can't include those header files in hal_nordic but,
hal_nordic still needs some cmsis alternative header file to compile.
Upon inspection it was found that there is a cmsis.h created as an
alternative when compiling for POSIX/BSIM in Zephyr so,
we use that file and fix the issue