### PR TITLE
nrfx: drivers: saadc: Fix 8-bit samples handling in nrfx_saadc

### DIFF
--- a/nrfx/drivers/include/nrfx_saadc.h
+++ b/nrfx/drivers/include/nrfx_saadc.h
@@ -135,36 +135,28 @@ extern "C" {
     .channel_index  = _index,                                           \
 }
 
-#if (NRF_SAADC_8BIT_SAMPLE_WIDTH == 8) || defined(__NRFX_DOXYGEN__)
+#if NRFX_API_VER_AT_LEAST(3, 12, 0) || defined(__NRFX_DOXYGEN__)
 /**
- * @brief Macro for getting number of bytes needed to store specified number of SAADC samples
- *        for given resolution of the SAADC.
+ * @brief Macro for getting number of bytes needed to store specified number of SAADC samples.
  *
- * @param[in] _resolution Resolution expressed as @ref nrf_saadc_resolution_t.
  * @param[in] _samples    Number of samples.
  *
  * @return Number of bytes needed to store specified number of samples.
  */
-#define NRFX_SAADC_SAMPLES_TO_BYTES(_resolution, _samples) \
-    ((_resolution) == NRF_SAADC_RESOLUTION_8BIT ? _samples : (_samples * 2))
-#else
-#define NRFX_SAADC_SAMPLES_TO_BYTES(_resolution, _samples) (_samples)
-#endif
+#define NRFX_SAADC_SAMPLES_TO_BYTES(_samples) (_samples * 2)
 
-#if (NRF_SAADC_8BIT_SAMPLE_WIDTH == 8) || defined(__NRFX_DOXYGEN__)
 /**
  * @brief Macro for getting specified SAADC sample from the filled buffer.
  *
- * @param[in] _resolution Resolution expressed as @ref nrf_saadc_resolution_t.
  * @param[in] _samples    Pointer to the buffer filled with SAADC samples.
  * @param[in] _index      Sample index.
  *
  * @return Specified sample.
  */
-#define NRFX_SAADC_SAMPLE_GET(_resolution, _samples, _index) \
-    ((_resolution) == NRF_SAADC_RESOLUTION_8BIT ? (((int8_t *) (_samples))[(_index)]) : \
-                                                  (((int16_t *)(_samples))[(_index)]))
+#define NRFX_SAADC_SAMPLE_GET(_samples, _index) (((int16_t *)(_samples))[(_index)])
+
 #else
+#define NRFX_SAADC_SAMPLES_TO_BYTES(_resolution, _samples) (_samples * 2)
 #define NRFX_SAADC_SAMPLE_GET(_resolution, _samples, _index) (((int16_t *)(_samples))[(_index)])
 #endif
 

--- a/nrfx/drivers/src/nrfx_saadc.c
+++ b/nrfx/drivers/src/nrfx_saadc.c
@@ -571,18 +571,9 @@ nrfx_err_t nrfx_saadc_mode_trigger(void)
             // END event will arrive when single chunk is filled with samples.
             nrfy_saadc_buffer_t chunk = { .length = m_cb.channels_activated_count};
 
-#if (NRF_SAADC_8BIT_SAMPLE_WIDTH == 8)
-            if (nrfy_saadc_resolution_get(NRF_SAADC) == NRF_SAADC_RESOLUTION_8BIT)
-            {
-                chunk.p_buffer = (nrf_saadc_value_t *)
-                    &((uint8_t *)m_cb.buffer_primary.p_buffer)[m_cb.samples_converted];
-            }
-            else
-#endif
-            {
-                chunk.p_buffer = (nrf_saadc_value_t *)
-                    &((uint16_t *)m_cb.buffer_primary.p_buffer)[m_cb.samples_converted];
-            }
+            chunk.p_buffer = (nrf_saadc_value_t *)
+                &((uint16_t *)m_cb.buffer_primary.p_buffer)[m_cb.samples_converted];
+
             nrfy_saadc_buffer_set(NRF_SAADC, &chunk, true, true);
             if (m_cb.oversampling_without_burst)
             {


### PR DESCRIPTION
Fix 8-bit samples handling on nRF54 Series