### PR TITLE
nrfx: Update to version 3.12.1

### DIFF
--- a/nrfx/CHANGELOG.md
+++ b/nrfx/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 All notable changes to this project are documented in this file.
 
+## [3.12.1] - 2025-06-09
+### Fixed
+- Fixed missing event clearing in case of NULL user handler in the GRTC driver.
+- Fixed the workaround condition for nRF54L Series anomaly 55 in the SPIM driver.
+
 ## [3.12.0] - 2025-06-02
 ### Added
 - Added a driver, HALY and HAL for MRAMC.

--- a/nrfx/README
+++ b/nrfx/README
@@ -2,10 +2,10 @@ nrfx
 ####
 
 Origin:
-   https://github.com/NordicSemiconductor/nrfx/tree/v3.12.0
+   https://github.com/NordicSemiconductor/nrfx/tree/v3.12.1
 
 Status:
-   v3.12.0
+   v3.12.1
 
 Purpose:
    With added proper shims adapting it to Zephyr's APIs, nrfx will provide
@@ -32,7 +32,7 @@ URL:
    https://github.com/NordicSemiconductor/nrfx
 
 commit:
-   db85149b1871aa09e8ff8ed240a177e8406ead58
+   472e5c92addb926b0f53f3072e8fae3dbf1a97cf
 
 Maintained-by:
    External
@@ -41,4 +41,4 @@ License:
    BSD-3-Clause
 
 License Link:
-   https://github.com/NordicSemiconductor/nrfx/blob/v3.12.0/LICENSE
+   https://github.com/NordicSemiconductor/nrfx/blob/v3.12.1/LICENSE

--- a/nrfx/doc/nrfx.doxyfile
+++ b/nrfx/doc/nrfx.doxyfile
@@ -50,7 +50,7 @@ PROJECT_NAME           = "nrfx"
 
 ### EDIT THIS ###
 
-PROJECT_NUMBER         = "3.12"
+PROJECT_NUMBER         = "3.12.1"
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/nrfx/drivers/include/nrfx_grtc.h
+++ b/nrfx/drivers/include/nrfx_grtc.h
@@ -356,6 +356,7 @@ nrfx_err_t nrfx_grtc_syscounter_cc_disable(uint8_t channel);
 /**
  * @brief Function for setting the absolute compare value for the SYSCOUNTER.
  *
+ * @note This function is deprecated. Use @ref nrfx_grtc_syscounter_cc_abs_set instead.
  * @note This function marks the specified @p channel as used.
  *
  * @param[in] p_chan_data Pointer to the channel data instance structure.
@@ -390,6 +391,8 @@ void nrfx_grtc_syscounter_cc_abs_set(uint8_t channel, uint64_t val, bool safe_se
 
 /**
  * @brief Function for setting the relative compare value for the SYSCOUNTER.
+ *
+ * @note This function is deprecated. Use @ref nrfx_grtc_syscounter_cc_rel_set instead.
  *
  * Function has no assumptions on the current channel state so channel event is cleared and
  * interrupt can optionally be enabled for that channel.

--- a/nrfx/drivers/nrfx_common.h
+++ b/nrfx/drivers/nrfx_common.h
@@ -94,7 +94,7 @@ extern "C" {
 #define NRFX_RELEASE_VER_MINOR 12
 
 /** @brief Symbol specifying micro number of the current nrfx version. */
-#define NRFX_RELEASE_VER_MICRO 0
+#define NRFX_RELEASE_VER_MICRO 1
 
 /**
  * @brief Macro for checking if the specified identifier is defined and it has

--- a/nrfx/drivers/src/nrfx_grtc.c
+++ b/nrfx/drivers/src/nrfx_grtc.c
@@ -976,19 +976,16 @@ static void grtc_irq_handler(void)
                  */
                 if (!nrf_grtc_event_check(NRF_GRTC, NRFY_INT_BITPOS_TO_EVENT(idx)))
                 {
-                    break;
+                    continue;
                 }
 
                 nrf_grtc_event_clear(NRF_GRTC, NRFY_INT_BITPOS_TO_EVENT(idx));
 
                 m_cb.channel_data[i].handler(idx, cc_value, m_cb.channel_data[i].p_context);
-                break;
             }
-
-            /* Return early as this is the most likely scenario (single CC expiring). */
-            if (NRFX_IS_ENABLED(GRTC_EXT) && (intpend == 0))
+            else if (nrf_grtc_event_check(NRF_GRTC, NRFY_INT_BITPOS_TO_EVENT(idx)))
             {
-                break;
+                nrf_grtc_event_clear(NRF_GRTC, NRFY_INT_BITPOS_TO_EVENT(idx));
             }
         }
 #if NRF_GRTC_HAS_RTCOUNTER

--- a/nrfx/hal/nrf_saadc.h
+++ b/nrfx/hal/nrf_saadc.h
@@ -164,14 +164,14 @@ extern "C" {
 /** @brief @deprecated Symbol specifying width of the 8-bit sample in bits. */
 #define NRF_SAADC_8BIT_SAMPLE_WIDTH 16
 
-#if defined SAADC_SAMPLERATE_CC_Min || defined(__NRFX_DOXYGEN__)
+#if defined(SAADC_SAMPLERATE_CC_Min) || defined(__NRFX_DOXYGEN__)
 /** @brief Symbol specifying minimum capture and compare value for sample rate. */
 #define NRF_SAADC_SAMPLERATE_CC_MIN SAADC_SAMPLERATE_CC_Min
 #else
 #define NRF_SAADC_SAMPLERATE_CC_MIN (80UL)
 #endif
 
-#if defined SAADC_SAMPLERATE_CC_Max || defined(__NRFX_DOXYGEN__)
+#if defined(SAADC_SAMPLERATE_CC_Max) || defined(__NRFX_DOXYGEN__)
 /** @brief Symbol specifying maximum capture and compare value for sample rate. */
 #define NRF_SAADC_SAMPLERATE_CC_MAX SAADC_SAMPLERATE_CC_Max
 #else


### PR DESCRIPTION
Update nrfx to the recently released version. See
https://github.com/NordicSemiconductor/nrfx/blob/v3.12.1/CHANGELOG.md for a list of changes that this version introduces.

Origin: nrfx
License: BSD 3-Clause
URL: https://github.com/NordicSemiconductor/nrfx/tree/v3.12.1
commit: 472e5c92addb926b0f53f3072e8fae3dbf1a97cf
Purpose: Provide peripheral drivers for Nordic SoCs
Maintained-by: External