### PR TITLE
nrfx: mdk: Fix errata 55 presence on nRF54LV10A Eng A

### DIFF
--- a/nrfx/mdk/nrf54l_erratas.h
+++ b/nrfx/mdk/nrf54l_erratas.h
@@ -2874,7 +2874,8 @@ static bool nrf54l_errata_50(void)
 }
 
 /* ========= Errata 55 ========= */
-#if    defined (NRF54LM20A_ENGA_XXAA) || defined (DEVELOP_IN_NRF54LM20A_ENGA)
+#if    defined (NRF54LM20A_ENGA_XXAA) || defined (DEVELOP_IN_NRF54LM20A_ENGA) \
+    || defined (NRF54LV10A_ENGA_XXAA) || defined (DEVELOP_IN_NRF54LV10A_ENGA)
     #define NRF54L_ERRATA_55_PRESENT 1
 #else
     #define NRF54L_ERRATA_55_PRESENT 0
@@ -2889,9 +2890,22 @@ static bool nrf54l_errata_55(void)
     #ifndef NRF54L_SERIES
         return false;
     #else
-        #if defined (NRF54LM20A_ENGA_XXAA) || defined (DEVELOP_IN_NRF54LM20A_ENGA)
+        #if defined (NRF54LM20A_ENGA_XXAA) || defined (DEVELOP_IN_NRF54LM20A_ENGA)\
+         || defined (NRF54LV10A_ENGA_XXAA) || defined (DEVELOP_IN_NRF54LV10A_ENGA)
             uint32_t var1 = *(uint32_t *)0x00FFC340ul;
             uint32_t var2 = *(uint32_t *)0x00FFC344ul;
+        #endif
+        #if defined (NRF54LV10A_ENGA_XXAA) || defined (DEVELOP_IN_NRF54LV10A_ENGA)
+            if (var1 == 0x27)
+            {
+                switch(var2)
+                {
+                    case 0x00ul:
+                        return true;
+                    default:
+                        return true;
+                }
+            }
         #endif
         #if defined (NRF54LM20A_ENGA_XXAA) || defined (DEVELOP_IN_NRF54LM20A_ENGA)
             if (var1 == 0x29)


### PR DESCRIPTION
Errata 55 applies to nRF54LV10A Eng A as well.