### PR TITLE
NRFX-8012: drivers: Separate hfclk driver from clock driver.

### DIFF
--- a/nrfx/drivers/include/nrfx_clock.h
+++ b/nrfx/drivers/include/nrfx_clock.h
@@ -40,6 +40,9 @@
 #if defined(LFRC_PRESENT)
 #include <hal/nrf_lfrc.h>
 #endif
+#if NRF_CLOCK_HAS_HFCLK
+#include <nrfx_clock_hfclk.h>
+#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -204,20 +207,6 @@ NRFX_STATIC_INLINE void nrfx_clock_lfclk_stop(void);
  * @retval false The LFCLK is not running.
  */
 NRFX_STATIC_INLINE bool nrfx_clock_lfclk_is_running(void);
-
-/**
- * @brief Function for starting the high-accuracy source HFCLK.
- *
- * @note This function is deprecated. Use @ref nrfx_clock_start instead.
- */
-NRFX_STATIC_INLINE void nrfx_clock_hfclk_start(void);
-
-/**
- * @brief Function for stopping the external high-accuracy source HFCLK.
- *
- * @note This function is deprecated. Use @ref nrfx_clock_stop instead.
- */
-NRFX_STATIC_INLINE void nrfx_clock_hfclk_stop(void);
 
 /**
  * @brief Function for checking the HFCLK state.
@@ -389,16 +378,6 @@ NRFX_STATIC_INLINE void nrfx_clock_lfclk_stop(void)
     nrfx_clock_stop(NRF_CLOCK_DOMAIN_LFCLK);
 }
 
-NRFX_STATIC_INLINE void nrfx_clock_hfclk_start(void)
-{
-    nrfx_clock_start(NRF_CLOCK_DOMAIN_HFCLK);
-}
-
-NRFX_STATIC_INLINE void nrfx_clock_hfclk_stop(void)
-{
-    nrfx_clock_stop(NRF_CLOCK_DOMAIN_HFCLK);
-}
-
 NRFX_STATIC_INLINE uint32_t nrfx_clock_task_address_get(nrf_clock_task_t task)
 {
     return nrf_clock_task_address_get(NRF_CLOCK, task);
@@ -411,7 +390,17 @@ NRFX_STATIC_INLINE uint32_t nrfx_clock_event_address_get(nrf_clock_event_t event
 
 NRFX_STATIC_INLINE bool nrfx_clock_is_running(nrf_clock_domain_t domain, void * p_clk_src)
 {
-    return nrf_clock_is_running(NRF_CLOCK, domain, p_clk_src);
+    switch(domain)
+    {
+    case NRF_CLOCK_DOMAIN_HFCLK:
+#if NRF_CLOCK_HAS_HFCLKSRC
+        return nrfx_clock_hfclk_running_check(p_clk_src);
+#else
+        return nrf_clock_is_running(NRF_CLOCK, domain, p_clk_src);
+#endif
+    default:
+        return nrf_clock_is_running(NRF_CLOCK, domain, p_clk_src);
+    }
 }
 
 NRFX_STATIC_INLINE bool nrfx_clock_hfclk_is_running(void)

--- a/nrfx/drivers/include/nrfx_clock_hfclk.h
+++ b/nrfx/drivers/include/nrfx_clock_hfclk.h
@@ -1,0 +1,67 @@
+/*$$$LICENCE_NORDIC_STANDARD<2025>$$$*/
+
+#ifndef NRFX_CLOCK_HFCLK_H__
+#define NRFX_CLOCK_HFCLK_H__
+
+#include <hal/nrf_clock.h>
+
+/**
+ * @brief Clock event handler.
+ *
+ * @param[in] event Event.
+ */
+typedef void (*nrfx_clock_hfclk_event_handler_t)(void);
+
+/**
+ * @brief Function for initializing internal structures in the nrfx_clock_hfclk module.
+ *
+ * After initialization, the module is in power off state (clock is not started).
+ *
+ * @param[in] event_handler Event handler provided by the user.
+ *                          If not provided, driver works in blocking mode.
+ *
+ * @retval NRFX_SUCCESS       The procedure is successful.
+ * @retval NRFX_ERROR_ALREADY The driver is already initialized.
+ */
+nrfx_err_t nrfx_clock_hfclk_init(nrfx_clock_hfclk_event_handler_t event_handler);
+
+/** @brief Function for uninitializing the clock module. */
+void nrfx_clock_hfclk_uninit(void);
+
+/** @brief Function for starting the hfclk clock domain. */
+void nrfx_clock_hfclk_start(void);
+
+/** @brief Function for stopping the hfclk clock domain. */
+void nrfx_clock_hfclk_stop(void);
+
+#if defined(CLOCK_FEATURE_HFCLK_DIVIDE_PRESENT)
+/**
+ * @brief Function for setting the hfclk divider.
+ *
+ * @param[in] div    New divider for the hfclk.
+ *
+ * @retval NRFX_SUCCESS             Divider successfully set.
+ * @retval NRFX_ERROR_INVALID_PARAM Divider not supported by the specified domain.
+ */
+nrfx_err_t nrfx_clock_hfclk_divider_set(nrf_clock_hfclk_div_t div);
+#endif
+
+/**
+ * @brief Function for checking the hfclk state.
+ *
+ * @param[out] p_clk_src Pointer to a clock source that is running.
+ *
+ * @retval true  The hfclk is running.
+ * @retval false The hfclk is not running.
+ */
+NRFX_STATIC_INLINE bool nrfx_clock_hfclk_running_check(nrf_clock_hfclk_t * p_clk_src);
+
+void nrfx_clock_hfclk_irq_handler(void);
+
+NRFX_STATIC_INLINE bool nrfx_clock_hfclk_running_check(nrf_clock_hfclk_t * p_clk_src)
+{
+    bool ret = nrf_clock_is_running(NRF_CLOCK, NRF_CLOCK_DOMAIN_HFCLK, p_clk_src);
+    return (ret && (*p_clk_src == NRF_CLOCK_HFCLK_HIGH_ACCURACY));
+}
+
+#endif // NRFX_CLOCK_HFCLK_H__

--- a/nrfx/drivers/src/nrfx_clock_hfclk.c
+++ b/nrfx/drivers/src/nrfx_clock_hfclk.c
@@ -1,0 +1,214 @@
+/*$$$LICENCE_NORDIC_STANDARD<2025>$$$*/
+
+#include <nrfx.h>
+#include <nrfx_clock_hfclk.h>
+
+#if NRFX_CHECK(NRFX_CLOCK_ENABLED)
+
+#define NRFX_LOG_MODULE CLOCK_HFCLK
+#include <nrfx_log.h>
+
+#if !defined(USE_WORKAROUND_FOR_ANOMALY_201) && \
+    (defined(NRF52810_XXAA) || \
+     defined(NRF52832_XXAA) || defined(NRF52832_XXAB) || \
+     defined(NRF52840_XXAA))
+    // Enable workaround for nRF52 anomaly 201 (EVENTS_HFCLKSTARTED might be generated twice).
+    #define USE_WORKAROUND_FOR_ANOMALY_201 1
+#endif
+
+/** @brief CLOCK control block. */
+typedef struct
+{
+    nrfx_clock_hfclk_event_handler_t event_handler;
+    bool                             module_initialized; /*< Indicate the state of module */
+#if NRFX_CHECK(USE_WORKAROUND_FOR_ANOMALY_201)
+    bool                             hfclk_started;      /*< Anomaly 201 workaround. */
+#endif
+} nrfx_clock_hfclk_cb_t;
+
+static nrfx_clock_hfclk_cb_t m_clock_cb;
+
+static void clock_stop()
+{
+    nrf_clock_int_disable(NRF_CLOCK, NRF_CLOCK_INT_HF_STARTED_MASK);
+    nrf_clock_task_trigger(NRF_CLOCK, NRF_CLOCK_TASK_HFCLKSTOP);
+    nrf_clock_event_clear(NRF_CLOCK, NRF_CLOCK_EVENT_HFCLKSTARTED);
+#if NRFX_CHECK(NRF54L_ERRATA_39_ENABLE_WORKAROUND)
+    if (nrf54l_errata_39())
+    {
+        nrf_clock_task_trigger(NRF_CLOCK, NRF_CLOCK_TASK_PLLSTOP);
+    }
+#endif
+
+    bool stopped;
+    nrf_clock_hfclk_t clk_src = NRF_CLOCK_HFCLK_HIGH_ACCURACY;
+    NRFX_WAIT_FOR(!nrfx_clock_hfclk_running_check(&clk_src), 10000, 1, stopped);
+    if (!stopped)
+    {
+        NRFX_LOG_ERROR("Failed to stop clock domain: NRF_CLOCK_DOMAIN_HFCLK.");
+    }
+    else
+    {
+#if NRFX_CHECK(USE_WORKAROUND_FOR_ANOMALY_201)
+        m_clock_cb.hfclk_started = false;
+#endif
+    }
+}
+
+nrfx_err_t nrfx_clock_hfclk_init(nrfx_clock_hfclk_event_handler_t event_handler)
+{
+    nrfx_err_t err_code = NRFX_SUCCESS;
+    if (m_clock_cb.module_initialized)
+    {
+        err_code = NRFX_ERROR_ALREADY;
+    }
+    else
+    {
+        m_clock_cb.event_handler = event_handler;
+        m_clock_cb.module_initialized = true;
+#if NRFX_CHECK(USE_WORKAROUND_FOR_ANOMALY_201)
+        m_clock_cb.hfclk_started = false;
+#endif
+    }
+#if NRF_CLOCK_HAS_HFCLKSRC
+    nrf_clock_hf_src_set(NRF_CLOCK, NRF_CLOCK_HFCLK_HIGH_ACCURACY);
+#endif // NRF_CLOCK_HAS_HFCLKSRC
+    NRFX_LOG_INFO("Function: %s, error code: %s.", __func__, NRFX_LOG_ERROR_STRING_GET(err_code));
+    return err_code;
+}
+
+void nrfx_clock_hfclk_uninit(void)
+{
+    NRFX_ASSERT(m_clock_cb.module_initialized);
+    clock_stop();
+
+    m_clock_cb.module_initialized = false;
+    NRFX_LOG_INFO("Uninitialized.");
+}
+
+void nrfx_clock_hfclk_start(void)
+{
+    NRFX_ASSERT(m_clock_cb.module_initialized);
+
+    nrf_clock_event_clear(NRF_CLOCK, NRF_CLOCK_EVENT_HFCLKSTARTED);
+    nrf_clock_task_trigger(NRF_CLOCK, NRF_CLOCK_TASK_HFCLKSTART);
+    if (m_clock_cb.event_handler)
+    {
+        nrf_clock_int_enable(NRF_CLOCK, NRF_CLOCK_INT_HF_STARTED_MASK);
+    }
+    else
+    {
+        while (!nrf_clock_event_check(NRF_CLOCK, NRF_CLOCK_EVENT_HFCLKSTARTED))
+        {}
+        nrf_clock_event_clear(NRF_CLOCK, NRF_CLOCK_EVENT_HFCLKSTARTED);
+    }
+}
+
+void nrfx_clock_hfclk_stop(void)
+{
+    NRFX_ASSERT(m_clock_cb.module_initialized);
+    clock_stop();
+}
+
+#if defined(CLOCK_FEATURE_HFCLK_DIVIDE_PRESENT)
+nrfx_err_t nrfx_clock_hfclk_divider_set(nrf_clock_hfclk_div_t div)
+{
+    switch (div)
+    {
+        case NRF_CLOCK_HFCLK_DIV_2:
+#if !defined(NRF_TRUSTZONE_NONSECURE) && NRFX_CHECK(NRF53_ERRATA_4_ENABLE_WORKAROUND)
+            if (nrf53_errata_4())
+            {
+                NRFX_CRITICAL_SECTION_ENTER();
+                __DSB();
+
+                nrf_clock_hfclk_div_set(NRF_CLOCK, div);
+
+                *(volatile uint32_t *)0x5084450C = 0x0;
+                *(volatile uint32_t *)0x50026548 = 0x0;
+                *(volatile uint32_t *)0x50081EE4 = 0x0D;
+
+                NRFX_CRITICAL_SECTION_EXIT();
+            }
+            else
+#endif
+            {
+                nrf_clock_hfclk_div_set(NRF_CLOCK, div);
+            }
+            break;
+        case NRF_CLOCK_HFCLK_DIV_1:
+#if !defined(NRF_TRUSTZONE_NONSECURE) && NRFX_CHECK(NRF53_ERRATA_4_ENABLE_WORKAROUND)
+            if (nrf53_errata_4())
+            {
+                NRFX_CRITICAL_SECTION_ENTER();
+                __DSB();
+
+                *(volatile uint32_t *)0x5084450C = 0x4040;
+                *(volatile uint32_t *)0x50026548 = 0x40;
+                *(volatile uint32_t *)0x50081EE4 = 0x4D;
+
+                nrf_clock_hfclk_div_set(NRF_CLOCK, div);
+
+                NRFX_CRITICAL_SECTION_EXIT();
+            }
+            else
+#endif
+            {
+                nrf_clock_hfclk_div_set(NRF_CLOCK, div);
+            }
+            break;
+        default:
+            return NRFX_ERROR_INVALID_PARAM;
+    }
+    SystemCoreClockUpdate();
+    return NRFX_SUCCESS;
+}
+#endif
+
+void nrfx_clock_hfclk_irq_handler(void)
+{
+#if NRF_CLOCK_HAS_INTPEND
+    uint32_t intpend = nrf_clock_int_pending_get(NRF_CLOCK);
+#else
+    uint32_t intpend = nrf_clock_int_enable_check(NRF_CLOCK, UINT32_MAX);
+#endif
+
+    if(!(intpend & NRF_CLOCK_INT_HF_STARTED_MASK))
+    {
+        return;
+    }
+
+    uint32_t int_bit = 31 - NRF_CLZ(NRF_CLOCK_INT_HF_STARTED_MASK);
+    nrf_clock_event_t evt = (nrf_clock_event_t)NRFY_INT_BITPOS_TO_EVENT(int_bit);
+    bool call_handler = true;
+
+#if !NRF_CLOCK_HAS_INTPEND
+    // Check if event is set for that interrupt and if not continue.
+    if (!nrf_clock_event_check(NRF_CLOCK, evt)) {
+        return;
+    }
+#endif
+
+    nrf_clock_event_clear(NRF_CLOCK, evt);
+    nrf_clock_int_disable(NRF_CLOCK, NRF_CLOCK_INT_HF_STARTED_MASK);
+
+    NRFX_LOG_DEBUG("Event: HFCLK_STARTED");
+
+#if NRFX_CHECK(USE_WORKAROUND_FOR_ANOMALY_201)
+    if (!m_clock_cb.hfclk_started)
+    {
+        m_clock_cb.hfclk_started = true;
+    }
+    else
+    {
+        call_handler = false;
+    }
+#endif
+
+    if (call_handler)
+    {
+        m_clock_cb.event_handler();
+    }
+}
+
+#endif // NRFX_CHECK(NRFX_CLOCK_ENABLED)

--- a/nrfx/drivers/src/nrfx_power.c
+++ b/nrfx/drivers/src/nrfx_power.c
@@ -429,6 +429,9 @@ void nrfx_power_clock_irq_handler(void)
 {
     nrfx_power_irq_handler();
     nrfx_clock_irq_handler();
+#if NRF_CLOCK_HAS_HFCLK
+    nrfx_clock_hfclk_irq_handler();
+#endif
 }
 #endif
 

--- a/nrfx/hal/nrf_clock.h
+++ b/nrfx/hal/nrf_clock.h
@@ -116,6 +116,13 @@ extern "C" {
 #define NRF_CLOCK_HAS_HFCLK_ALWAYSRUN 0
 #endif
 
+#if defined(CLOCK_HFCLKRUN_STATUS_Msk) || defined(__NRFX_DOXYGEN__)
+/** @brief Symbol indicating whether the HFCLK clock is present. */
+#define NRF_CLOCK_HAS_HFCLK 1
+#else
+#define NRF_CLOCK_HAS_HFCLK 0
+#endif
+
 #if defined(CLOCK_HFCLKSRC_SRC_Msk) || defined(__NRFX_DOXYGEN__)
 /** @brief Symbol indicating whether the HFCLKSRC register is present. */
 #define NRF_CLOCK_HAS_HFCLKSRC 1


### PR DESCRIPTION
In this PR only hfclk is separated from clock_control_nrf shim, other clocks will be separated in the following PRs.