### PR TITLE
nrfs: Disabling subscription in the temp service

### DIFF
--- a/nrfs/include/services/nrfs_temp.h
+++ b/nrfs/include/services/nrfs_temp.h
@@ -8,6 +8,7 @@
 #define NRFS_TEMP_H
 
 #include <internal/services/nrfs_temp.h>
+#include <nrfs_config.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -16,7 +17,9 @@ extern "C" {
 /** @brief Temperature service event types. */
 typedef enum __NRFS_PACKED {
 	NRFS_TEMP_EVT_MEASURE_DONE, /** Temperature measurement done. */
+#ifdef NRFS_TEMP_SERVICE_SUBSCRIPTION_ENABLED
 	NRFS_TEMP_EVT_CHANGE,	    /** Temperature threshold crossed. */
+#endif
 	NRFS_TEMP_EVT_REJECT,	    /** Request rejected. */
 } nrfs_temp_evt_type_t;
 
@@ -58,6 +61,7 @@ void nrfs_temp_uninit(void);
  */
 nrfs_err_t nrfs_temp_measure_request(void * p_context);
 
+#ifdef NRFS_TEMP_SERVICE_SUBSCRIPTION_ENABLED
 /**
  * @brief Function for subscribing to the temperature monitoring in Temperature service.
  *
@@ -86,6 +90,7 @@ nrfs_err_t nrfs_temp_subscribe(uint16_t measure_rate_ms,
  * @retval NRFS_ERR_IPC           Backend returned error during request sending.
  */
 nrfs_err_t nrfs_temp_unsubscribe(void);
+#endif /* NRFS_TEMP_SERVICE_SUBSCRIPTION_ENABLED */
 
 /**
  * @brief Function for converting the temperature value from raw data to Celsius scale.

--- a/nrfs/src/services/nrfs_temp.c
+++ b/nrfs/src/services/nrfs_temp.c
@@ -35,12 +35,12 @@ void nrfs_temp_service_notify(void *p_notification, size_t size)
 		evt.type = NRFS_TEMP_EVT_MEASURE_DONE;
 		m_cb.handler(&evt, (void *)p_rsp->ctx.ctx);
 		break;
-
+#ifdef NRFS_TEMP_SERVICE_SUBSCRIPTION_ENABLED
 	case NRFS_TEMP_REQ_SUBSCRIBE:
 		evt.type = NRFS_TEMP_EVT_CHANGE;
 		m_cb.handler(&evt, (void *)p_rsp->ctx.ctx);
 		break;
-
+#endif
 	default:
 		break;
 	}
@@ -75,7 +75,7 @@ nrfs_err_t nrfs_temp_measure_request(void *p_context)
 
 	return nrfs_backend_send(&req, sizeof(req));
 }
-
+#ifdef NRFS_TEMP_SERVICE_SUBSCRIPTION_ENABLED
 nrfs_err_t nrfs_temp_subscribe(uint16_t measure_rate_ms,
 			       int32_t lower_threshold,
 			       int32_t upper_threshold,
@@ -108,3 +108,4 @@ nrfs_err_t nrfs_temp_unsubscribe(void)
 
 	return nrfs_backend_send(&req, sizeof(req));
 }
+#endif  /* NRFS_TEMP_SERVICE_SUBSCRIPTION_ENABLED */


### PR DESCRIPTION
Code optimization for platforms which don't use subscription feature in the temperature service