### PR TITLE
Fix -Wshift-count-overflow warning for clang.

### DIFF
--- a/nrfx/drivers/nrfx_common.h
+++ b/nrfx/drivers/nrfx_common.h
@@ -168,7 +168,7 @@ extern "C" {
  *
  * @return Bit mask.
  */
-#define NRFX_BIT_MASK(x) (((x) == 32) ? UINT32_MAX : ((1UL << (x)) - 1))
+#define NRFX_BIT_MASK(x) (((x) == 32) ? UINT32_MAX : ((uint32_t)((1ULL << (x)) - 1)))
 
 /**
  * @brief Macro for returning size in bits for given size in bytes.


### PR DESCRIPTION
llvm clang generates warning:  warning: shift count >= width of type [-Wshift-count-overflow] when x==32, so a temporary upcast is required.