### PR TITLE
nrfx: helpers: gppi: Fix potential memory violation

### DIFF
--- a/nrfx/helpers/nrfx_gppi_dppi.c
+++ b/nrfx/helpers/nrfx_gppi_dppi.c
@@ -599,16 +599,18 @@ static nrfx_atomic_t *get_group_chan_mask(uint32_t domain_id)
     _ch = HANDLE_GET_CHAN(_handle, 0);                                                      \
     for (i = 0, _d_id = HANDLE_GET_DPPI_ID(_handle, 0), _reg = dppi_reg_get(d_id);          \
          i < cnt;                                                                           \
-         i++, _d_id = HANDLE_GET_DPPI_ID(_handle, i), _reg = dppi_reg_get(_d_id))
+         i++, _d_id = HANDLE_GET_DPPI_ID(_handle, i), _reg = i < cnt ? dppi_reg_get(_d_id) : NULL)
 #elif defined(NRFX_GPPI_MULTI_DOMAIN)
 #define FOR_EACH_DPPI(_gppi, _handle, _ch, _reg, _d_id)                                     \
     const nrfx_gppi_route_t *_route = &_gppi->routes[HANDLE_GET_ROUTE_ID(_handle)];         \
     size_t i;                                                                               \
-	for (i = 0, _ch = HANDLE_GET_CHAN(_handle, i), _d_id = _route->p_nodes[i]->domain_id,	\
-			_reg = _route->p_nodes[i]->dppi.p_reg;					                        \
-	     i < _route->len;									                                \
-	     i += 2, _ch = HANDLE_GET_CHAN(_handle, i), _d_id = _route->p_nodes[i]->domain_id,	\
-	     _reg = _route->p_nodes[i]->dppi.p_reg) if (_ch != DPPI_CH_RESERVED)
+    size_t _len = _route->len;                                                              \
+    for (i = 0, _ch = HANDLE_GET_CHAN(_handle, i), _d_id = _route->p_nodes[i]->domain_id,   \
+         _reg = _route->p_nodes[i]->dppi.p_reg;                                             \
+         i < _len;                                                                          \
+         i += 2, _ch = HANDLE_GET_CHAN(_handle, i),                                         \
+         _d_id = i < _len ? _route->p_nodes[i]->domain_id : 0,                              \
+         _reg = i < _len ? _route->p_nodes[i]->dppi.p_reg : NULL) if (_ch != DPPI_CH_RESERVED)
 #else
 #define FOR_EACH_DPPI(_gppi, _handle, _ch, _reg, _d_id)                                     \
     _reg = NRF_DPPIC;                                                                       \


### PR DESCRIPTION
If for loop has multiple operations in the update phase then all are executed even if the ending condition is already met. In GPPI macro index 'i' was used in update actions which lead to reading out of the expected memory.