### PR TITLE
nrfx: spim: fix nRF54L Series Anomaly 8 and nRF54H20 Anomaly 115

### DIFF
--- a/nrfx/drivers/src/nrfx_spim.c
+++ b/nrfx/drivers/src/nrfx_spim.c
@@ -448,24 +448,6 @@ static void spim_configure(nrfx_spim_t *              p_instance,
     }
 #endif
 
-#if NRF_ERRATA_STATIC_CHECK(54L, 8) || NRF_ERRATA_STATIC_CHECK(54H, 115)
-    if (NRF_ERRATA_DYNAMIC_CHECK(54L, 8) || NRF_ERRATA_DYNAMIC_CHECK(54H, 115))
-    {
-        /* Workaround must be applied only if PRESCALER is larger than 2 and CPHA=0 */
-        if ((prescaler > 2) &&
-            ((p_config->mode == NRF_SPIM_MODE_0) || (p_config->mode == NRF_SPIM_MODE_2)))
-        {
-            uint8_t min_dur = (uint8_t)((prescaler / 2) + 1);
-            csn_duration = NRFX_MAX(csn_duration, min_dur);
-            p_cb->apply_errata_8_115 = 1;
-        }
-        else
-        {
-            p_cb->apply_errata_8_115 = 0;
-        }
-    }
-#endif
-
     p_cb->skip_gpio_cfg = p_config->skip_gpio_cfg;
     configure_pins(p_instance, p_config);
 
@@ -524,6 +506,25 @@ static void spim_configure(nrfx_spim_t *              p_instance,
     };
 
     nrfy_spim_periph_configure(p_instance->p_reg, &nrfy_config);
+
+#if NRF_ERRATA_STATIC_CHECK(54L, 8) || NRF_ERRATA_STATIC_CHECK(54H, 115)
+    if (NRF_ERRATA_DYNAMIC_CHECK(54L, 8) || NRF_ERRATA_DYNAMIC_CHECK(54H, 115))
+    {
+        /* Workaround must be applied only if PRESCALER is larger than 2 and CPHA=0 */
+        if ((prescaler > 2) &&
+            ((p_config->mode == NRF_SPIM_MODE_0) || (p_config->mode == NRF_SPIM_MODE_2)))
+        {
+            uint8_t min_dur = (uint8_t)((prescaler / 2) + 1);
+            nrfy_spim_csn_duration_set(p_instance->p_reg, NRFX_MAX(csn_duration, min_dur));
+            p_cb->apply_errata_8_115 = 1;
+        }
+        else
+        {
+            p_cb->apply_errata_8_115 = 0;
+        }
+    }
+#endif
+
     if (p_cb->handler)
     {
         nrfy_spim_int_init(p_instance->p_reg, 0, p_config->irq_priority, false);

--- a/nrfx/hal/nrf_spim.h
+++ b/nrfx/hal/nrf_spim.h
@@ -830,14 +830,33 @@ NRF_STATIC_INLINE uint32_t nrf_spim_miso_pin_get(NRF_SPIM_Type const * p_reg);
  * @param[in] p_reg    Pointer to the structure of registers of the peripheral.
  * @param[in] pin      CSN pin number.
  * @param[in] polarity CSN pin polarity.
- * @param[in] duration Minimum duration between the edge of CSN and the edge of SCK
- *                     and minimum duration of CSN must stay unselected between transactions.
- *                     The value is specified in number of 64 MHz clock cycles (15.625 ns).
+ * @param[in] duration Minimum duration between the edge of CSN and the edge of SCK.
+ *                     Also, minimum duration of CSN to remain unasserted between transactions.
+ *                     The value is specified in number of SPIM core clock cycles.
  */
 NRF_STATIC_INLINE void nrf_spim_csn_configure(NRF_SPIM_Type *    p_reg,
                                               uint32_t           pin,
                                               nrf_spim_csn_pol_t polarity,
                                               uint32_t           duration);
+
+/**
+ * @brief Function for setting the SPIM hardware CSN pin duration.
+ *
+ * @param[in] p_reg    Pointer to the structure of registers of the peripheral.
+ * @param[in] duration Minimum duration between the edge of CSN and the edge of SCK
+ *                     Also, minimum duration of CSN to remain unasserted between transactions.
+ *                     The value is specified in number of SPIM core clock cycles.
+ */
+NRF_STATIC_INLINE void nrf_spim_csn_duration_set(NRF_SPIM_Type * p_reg, uint32_t duration);
+
+/**
+ * @brief Function for getting the SPIM hardware CSN pin duration.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ *
+ * @return CSN pin duration in number of SPIM core clock cycles.
+ */
+NRF_STATIC_INLINE uint32_t nrf_spim_csn_duration_get(NRF_SPIM_Type const * p_reg);
 
 /**
  * @brief Function for getting the CSN pin selection.
@@ -1431,6 +1450,16 @@ NRF_STATIC_INLINE void nrf_spim_csn_configure(NRF_SPIM_Type *    p_reg,
 #endif
     p_reg->CSNPOL = polarity;
     p_reg->IFTIMING.CSNDUR = duration;
+}
+
+NRF_STATIC_INLINE void nrf_spim_csn_duration_set(NRF_SPIM_Type * p_reg, uint32_t duration)
+{
+    p_reg->IFTIMING.CSNDUR = duration;
+}
+
+NRF_STATIC_INLINE uint32_t nrf_spim_csn_duration_get(NRF_SPIM_Type const * p_reg)
+{
+    return p_reg->IFTIMING.CSNDUR;
 }
 
 NRF_STATIC_INLINE uint32_t nrf_spim_csn_pin_get(NRF_SPIM_Type const * p_reg)

--- a/nrfx/haly/nrfy_spim.h
+++ b/nrfx/haly/nrfy_spim.h
@@ -623,6 +623,22 @@ NRFY_STATIC_INLINE void nrfy_spim_csn_configure(NRF_SPIM_Type *    p_reg,
     nrf_barrier_w();
 }
 
+/** @refhal{nrf_spim_csn_duration_set} */
+NRFY_STATIC_INLINE void nrfy_spim_csn_duration_set(NRF_SPIM_Type * p_reg, uint32_t duration)
+{
+    nrf_spim_csn_duration_set(p_reg, duration);
+    nrf_barrier_w();
+}
+
+/** @refhal{nrf_spim_csn_duration_get} */
+NRF_STATIC_INLINE uint32_t nrfy_spim_csn_duration_get(NRF_SPIM_Type const * p_reg)
+{
+    nrf_barrier_rw();
+    uint32_t csndur = nrf_spim_csn_duration_get(p_reg);
+    nrf_barrier_r();
+    return csndur;
+}
+
 /** @refhal{nrf_spim_csn_pin_get} */
 NRFY_STATIC_INLINE uint32_t nrfy_spim_csn_pin_get(NRF_SPIM_Type const * p_reg)
 {


### PR DESCRIPTION
Workaround for these anomalies requires CSN duration configuration, which is conditionally applied by the driver.
Apply the workaround irrespective of these conditions.