### PR TITLE
nrfx: helpers: gppi: Add option for external allocator

### DIFF
--- a/nrfx/bsp/stable/soc/interconnect/nrfx_gppi_d2ppi.c
+++ b/nrfx/bsp/stable/soc/interconnect/nrfx_gppi_d2ppi.c
@@ -36,8 +36,10 @@
 #include "nrfx_gppi_d2ppi.h"
 
 /* Available channels for each node. */
+#if !NRFX_CHECK(NRFX_GPPI_CONFIG_EXT_ALLOCATOR)
 static nrfx_atomic_t channels[NRFX_GPPI_NODE_COUNT];
 static nrfx_atomic_t group_channels[NRFX_GPPI_NODE_DPPI_COUNT];
+#endif
 
 /* All nodes in the system. */
 static const nrfx_gppi_node_t nodes[] = {
@@ -142,5 +144,9 @@ void nrfx_gppi_groups_init(nrfx_gppi_node_id_t node_id, uint32_t group_mask)
 {
     NRFX_ASSERT(node_id < NRFX_GPPI_NODE_DPPI_COUNT);
 
+#if NRFX_CHECK(NRFX_GPPI_CONFIG_EXT_ALLOCATOR)
+    (void)group_mask;
+#else
     *nodes[node_id].dppi.p_group_channels = group_mask;
+#endif
 }

--- a/nrfx/bsp/stable/soc/interconnect/nrfx_gppi_d2ppi.h
+++ b/nrfx/bsp/stable/soc/interconnect/nrfx_gppi_d2ppi.h
@@ -46,23 +46,23 @@
 
 /** @brief DPPI domain ID. */
 typedef enum {
-	NRFX_GPPI_DOMAIN_MCU  = 0, ///< MCU domain.
-	NRFX_GPPI_DOMAIN_RAD  = 1, ///< Radio domain.
-	NRFX_GPPI_DOMAIN_PERI = 2, ///< Peripheral domain.
-	NRFX_GPPI_DOMAIN_LP   = 3, ///< Low power domain.
+    NRFX_GPPI_DOMAIN_MCU  = 0, ///< MCU domain.
+    NRFX_GPPI_DOMAIN_RAD  = 1, ///< Radio domain.
+    NRFX_GPPI_DOMAIN_PERI = 2, ///< Peripheral domain.
+    NRFX_GPPI_DOMAIN_LP   = 3, ///< Low power domain.
 } nrfx_gppi_domain_id_t;
 
 /** @brief Identification of a DPPI node in the system. */
 typedef enum {
-	NRFX_GPPI_NODE_DPPIC00,                               ///< DPPIC00 node
-	NRFX_GPPI_NODE_DPPIC10,                               ///< DPPIC10 node
-	NRFX_GPPI_NODE_DPPIC20,                               ///< DPPIC20 node
-	NRFX_GPPI_NODE_DPPIC30,                               ///< DPPIC30 node
+    NRFX_GPPI_NODE_DPPIC00,                               ///< DPPIC00 node
+    NRFX_GPPI_NODE_DPPIC10,                               ///< DPPIC10 node
+    NRFX_GPPI_NODE_DPPIC20,                               ///< DPPIC20 node
+    NRFX_GPPI_NODE_DPPIC30,                               ///< DPPIC30 node
     NRFX_GPPI_NODE_DPPI_COUNT,                            ///< Number of DPPI nodes in the system.
-	NRFX_GPPI_NODE_PPIB00_10 = NRFX_GPPI_NODE_DPPI_COUNT, ///< PPIB00-PPIB10 bridge node
-	NRFX_GPPI_NODE_PPIB11_21,                             ///< PPIB11-PPIB21 bridge node
-	NRFX_GPPI_NODE_PPIB01_20,                             ///< PPIB01-PPIB20 bridge node
-	NRFX_GPPI_NODE_PPIB22_30,                             ///< PPIB22-PPIB30 bridge node
+    NRFX_GPPI_NODE_PPIB00_10 = NRFX_GPPI_NODE_DPPI_COUNT, ///< PPIB00-PPIB10 bridge node
+    NRFX_GPPI_NODE_PPIB11_21,                             ///< PPIB11-PPIB21 bridge node
+    NRFX_GPPI_NODE_PPIB01_20,                             ///< PPIB01-PPIB20 bridge node
+    NRFX_GPPI_NODE_PPIB22_30,                             ///< PPIB22-PPIB30 bridge node
     NRFX_GPPI_NODE_COUNT                                  ///< Number of nodes in the system.
 } nrfx_gppi_node_id_t;
 

--- a/nrfx/helpers/nrfx_gppi.h
+++ b/nrfx/helpers/nrfx_gppi.h
@@ -234,6 +234,9 @@ int nrfx_gppi_conn_alloc(uint32_t eep, uint32_t tep, nrfx_gppi_handle_t * p_hand
  * channels in bridges (PPIB) are cleared and all used resources are freed.. Connection shall be
  * disabled prior to clearing.
  *
+ * @note If NRFX_GPPI_CONFIG_EXT_ALLOCATOR then external implementation need to
+ * be provided.
+ *
  * @param[in] handle Connection handle.
  */
 void nrfx_gppi_domain_conn_free(nrfx_gppi_handle_t handle);
@@ -489,6 +492,9 @@ uint32_t nrfx_gppi_group_task_dis_addr(nrfx_gppi_group_handle_t handle);
  * @ref nrfx_gppi_domain_id_get or target-specific header can be used to get the node ID
  * (see @ref nrfx_gppi_node_id_t).
  *
+ * @note If NRFX_GPPI_CONFIG_EXT_ALLOCATOR then external implementation need to
+ * be provided.
+ *
  * @param[in] node_id Target-specific identifier of the DPPI system node (DPPIC or PPIB).
  *
  * @retval non-negative Allocated channel.
@@ -501,6 +507,9 @@ int nrfx_gppi_channel_alloc(uint32_t node_id);
  *
  * @p channel must be allocated earlier using @ref nrfx_gppi_channel_alloc. @p node_id must be
  * the same as the one used in @ref nrfx_gppi_channel_alloc for allocating that resource.
+ *
+ * @note If NRFX_GPPI_CONFIG_EXT_ALLOCATOR then external implementation need to
+ * be provided.
  *
  * @param[in] node_id Target-specific identifier of the DPPI system node (DPPIC or PPIB).
  * @param[in] channel Channel.
@@ -515,6 +524,9 @@ void nrfx_gppi_channel_free(uint32_t node_id, uint8_t channel);
  * @note @p domain_id parameter is used only in the system with multiple domains.
  * Use @ref nrfx_gppi_domain_id_get to get the ID.
  *
+ * @note If NRFX_GPPI_CONFIG_EXT_ALLOCATOR then external implementation need to
+ * be provided.
+ *
  * @param[in] domain_id Target-specific identifier of the DPPI system node.
  *
  * @retval non-negative Allocated channel.
@@ -527,6 +539,9 @@ int nrfx_gppi_group_channel_alloc(uint32_t domain_id);
  *
  * @p channel must be allocated earlier using @ref nrfx_gppi_group_channel_alloc. @p domain_id must
  * be the same as the one used in @ref nrfx_gppi_group_channel_alloc for allocating that resource.
+ *
+ * @note If NRFX_GPPI_CONFIG_EXT_ALLOCATOR then external implementation need to
+ * be provided.
  *
  * @param[in] domain_id Target-specific identifier of the DPPI system node.
  * @param[in] channel   Channel.
@@ -549,6 +564,9 @@ typedef struct {
  * functions for enabling and disabling the connection are only changing state of channels that
  * were allocated for that connection. If %p is null then function is equivalent of
  * @ref nrfx_gppi_domain_conn_alloc.
+ *
+ * @note If NRFX_GPPI_CONFIG_EXT_ALLOCATOR then external implementation need to
+ * be provided.
  *
  * @param[in]  producer   Domain that will produce (publish) events.
  * @param[in]  consumer   Domain that will consume (subsribe to) events.

--- a/nrfx/helpers/nrfx_gppi_dppi.c
+++ b/nrfx/helpers/nrfx_gppi_dppi.c
@@ -174,6 +174,7 @@ void nrfx_gppi_init(nrfx_gppi_t * p_instance)
     p_gppi = p_instance;
 }
 
+#if !NRFX_CHECK(NRFX_GPPI_CONFIG_EXT_ALLOCATOR)
 static void flag_free(nrfx_atomic_t *p_mask, uint8_t flag)
 {
     int err;
@@ -182,9 +183,16 @@ static void flag_free(nrfx_atomic_t *p_mask, uint8_t flag)
     (void)err;
     NRFX_ASSERT(err == 0);
 }
+#endif
 
 #if defined(NRFX_GPPI_MULTI_DOMAIN)
 
+uint32_t nrfx_gppi_group_domain_id_get(nrfx_gppi_group_handle_t handle)
+{
+    return GHANDLE_GET_DOMAIN(handle);
+}
+
+#if !NRFX_CHECK(NRFX_GPPI_CONFIG_EXT_ALLOCATOR)
 static uint32_t alloc_bit_locked(nrfx_atomic_t *mask)
 {
     uint32_t rv = 31 - NRFX_CLZ(*mask);
@@ -192,11 +200,6 @@ static uint32_t alloc_bit_locked(nrfx_atomic_t *mask)
     *mask &= ~NRFX_BIT(rv);
 
     return rv;
-}
-
-uint32_t nrfx_gppi_group_domain_id_get(nrfx_gppi_group_handle_t handle)
-{
-    return GHANDLE_GET_DOMAIN(handle);
 }
 
 static int alloc_channels(uint8_t * p_channels, const nrfx_gppi_route_t * p_route,
@@ -445,12 +448,15 @@ int nrfx_gppi_ext_conn_alloc(uint32_t producer, uint32_t consumer, nrfx_gppi_han
 #endif
 }
 
+#endif // !NRFX_GPPI_CONFIG_EXT_ALLOCATOR
+
 int nrfx_gppi_domain_conn_alloc(uint32_t producer, uint32_t consumer,
                                 nrfx_gppi_handle_t * p_handle)
 {
     return nrfx_gppi_ext_conn_alloc(producer, consumer, p_handle, NULL);
 }
 
+#if !NRFX_CHECK(NRFX_GPPI_CONFIG_EXT_ALLOCATOR)
 void nrfx_gppi_domain_conn_free(nrfx_gppi_handle_t handle)
 {
     uint32_t route_id = HANDLE_GET_ROUTE_ID(handle);
@@ -493,6 +499,7 @@ void nrfx_gppi_domain_conn_free(nrfx_gppi_handle_t handle)
     NRFX_ASSERT(rv == 0);
 #endif
 }
+#endif // !NRFX_GPPI_CONFIG_EXT_ALLOCATOR
 #else
 int nrfx_gppi_domain_conn_alloc(uint32_t producer, uint32_t consumer, nrfx_gppi_handle_t *p_handle)
 {
@@ -579,16 +586,6 @@ static NRF_DPPIC_Type *dppi_reg_get(uint32_t domain_id)
 #else
     (void)domain_id;
     return NRF_DPPIC;
-#endif
-}
-
-static nrfx_atomic_t *get_group_chan_mask(uint32_t domain_id)
-{
-#if defined(NRFX_GPPI_MULTI_DOMAIN)
-    return p_gppi->routes[domain_id].p_nodes[0]->dppi.p_group_channels;
-#else
-    (void)domain_id;
-    return &p_gppi->group_mask;
 #endif
 }
 
@@ -721,6 +718,18 @@ int nrfx_gppi_ep_attach(uint32_t ep, nrfx_gppi_handle_t handle)
     return nrfx_gppi_ep_to_ch_attach(ep, (uint8_t)ch);
 }
 
+#if !NRFX_CHECK(NRFX_GPPI_CONFIG_EXT_ALLOCATOR)
+
+static nrfx_atomic_t *get_group_chan_mask(uint32_t domain_id)
+{
+#if defined(NRFX_GPPI_MULTI_DOMAIN)
+    return p_gppi->routes[domain_id].p_nodes[0]->dppi.p_group_channels;
+#else
+    (void)domain_id;
+    return &p_gppi->group_mask;
+#endif
+}
+
 int nrfx_gppi_group_alloc(uint32_t domain_id, nrfx_gppi_group_handle_t *handle)
 {
     nrfx_atomic_t *group_mask = get_group_chan_mask(domain_id);
@@ -747,6 +756,7 @@ void nrfx_gppi_group_free(nrfx_gppi_group_handle_t handle)
     nrf_dppi_group_clear(p_reg, (nrf_dppi_channel_group_t)ch);
     flag_free(group_mask, ch);
 }
+#endif // !NRFX_GPPI_CONFIG_EXT_ALLOCATOR
 
 void nrfx_gppi_group_ch_add(nrfx_gppi_group_handle_t handle, uint32_t ch)
 {

--- a/nrfx/helpers/nrfx_gppi_routes.h
+++ b/nrfx/helpers/nrfx_gppi_routes.h
@@ -51,58 +51,62 @@ extern "C" {
 
 /** @brief PPIB node. */
 typedef struct {
+#if !NRFX_CHECK(NRFX_GPPI_CONFIG_EXT_ALLOCATOR)
     /** Pointer to channel mask. */
-	nrfx_atomic_t * p_channels;
+    nrfx_atomic_t * p_channels;
     /** Two PPIB register sets that form a bridge. */
-	NRF_PPIB_Type * p_reg[2];
+    NRF_PPIB_Type * p_reg[2];
+#endif
 } nrfx_gppi_node_ppib_t;
 
 /** @brief DPPI node. */
 typedef struct {
+#if !NRFX_CHECK(NRFX_GPPI_CONFIG_EXT_ALLOCATOR)
     /** Pointer to channel mask. */
-	nrfx_atomic_t * p_channels;
+    nrfx_atomic_t * p_channels;
     /** Pointer to group mask. */
-	nrfx_atomic_t * p_group_channels;
+    nrfx_atomic_t * p_group_channels;
     /** DPPIC register set. */
-	NRF_DPPIC_Type * p_reg;
+#endif
+    NRF_DPPIC_Type * p_reg;
 } nrfx_gppi_node_dppi_t;
 
 /** @brief Generic node. */
 typedef struct {
     /** Pointer to channel mask. */
-	nrfx_atomic_t *p_channels;
+    nrfx_atomic_t *p_channels;
 } nrfx_gppi_node_generic_t;
 
 /** @brief Node types. */
 typedef enum {
-	NRFX_GPPI_NODE_DPPI,
-	NRFX_GPPI_NODE_PPIB,
+    NRFX_GPPI_NODE_DPPI,
+    NRFX_GPPI_NODE_PPIB,
 } nrfx_gppi_node_type_t;
 
 /** @brief Node structure. */
 typedef struct {
     /** Node type. */
-	nrfx_gppi_node_type_t type;
+    uint8_t type; /* Use uint8_t as riscv has 32 bit enum. */
     /** Domain ID. */
-	uint8_t domain_id;
-#if NRFX_CHECK(NRFX_GPPI_FIXED_CONNECTIONS)
+    uint8_t domain_id;
+#if !NRFX_CHECK(NRFX_GPPI_CONFIG_EXT_ALLOCATOR) && NRFX_CHECK(NRFX_GPPI_FIXED_CONNECTIONS)
     /** Channel offset. */
-	uint8_t ch_off[2];
+    uint8_t ch_off[2];
 #endif
     /** Node specific data. */
-	union {
-		nrfx_gppi_node_dppi_t dppi;
-		nrfx_gppi_node_ppib_t ppib;
-		nrfx_gppi_node_generic_t generic;
-	};
+    union {
+        nrfx_gppi_node_dppi_t dppi;
+        nrfx_gppi_node_ppib_t ppib;
+        nrfx_gppi_node_generic_t generic;
+    };
 } nrfx_gppi_node_t;
 
 /** @brief Route in a DPPI system. */
 typedef struct {
     /** Array of nodes that form a route. */
-	const nrfx_gppi_node_t * const * p_nodes;
+    const nrfx_gppi_node_t * const * p_nodes;
     /** Number of nodes in a route. */
-	uint8_t len;
+    uint8_t len;
 } nrfx_gppi_route_t;
 
 /** @brief Macro for defining a DPPI node.
@@ -110,41 +114,45 @@ typedef struct {
  * @param _id Node ID.
  * @param _domain_id Domain ID.
  */
-#define NRFX_GPPI_DPPI_NODE_DEFINE(_id, _domain_id)                         \
-[NRFX_GPPI_NODE_DPPIC##_id] = {                                             \
-		.type = NRFX_GPPI_NODE_DPPI,                                        \
-		.domain_id = _domain_id,                                            \
-		.dppi = {                                                           \
-			.p_channels = &channels[NRFX_GPPI_NODE_DPPIC##_id],             \
-			.p_group_channels = &group_channels[NRFX_GPPI_NODE_DPPIC##_id], \
-			.p_reg = NRF_DPPIC##_id                                         \
-		}                                                                   \
-	}
+#define NRFX_GPPI_DPPI_NODE_DEFINE(_id, _domain_id)                             \
+[NRFX_GPPI_NODE_DPPIC##_id] = {                                                 \
+        .type = NRFX_GPPI_NODE_DPPI,                                            \
+        .domain_id = _domain_id,                                                \
+        .dppi = {                                                               \
+            NRFX_COND_CODE_1(NRFX_GPPI_CONFIG_EXT_ALLOCATOR, (), (              \
+                .p_channels = &channels[NRFX_GPPI_NODE_DPPIC##_id],             \
+                .p_group_channels = &group_channels[NRFX_GPPI_NODE_DPPIC##_id], \
+            ))                                                                  \
+            .p_reg = NRF_DPPIC##_id                                             \
+        }                                                                       \
+    }
 
 /** @brief Macro for defining a PPIB node.
  *
  * @param _id1 PPIB ID of the first PPIB.
  * @param _id2 PPIB ID of the second PPIB.
  */
-#define NRFX_GPPI_PPIB_NODE_DEFINE(_id1, _id2)                              \
-[NRFX_GPPI_NODE_PPIB##_id1##_##_id2] = {                                    \
-		.type = NRFX_GPPI_NODE_PPIB,                                        \
-		.domain_id = NRFX_GPPI_NODE_PPIB##_id1##_##_id2,                    \
-		.ppib = {                                                           \
-			.p_channels = &channels[NRFX_GPPI_NODE_PPIB##_id1##_##_id2],    \
-			.p_reg = {NRF_PPIB##_id1, NRF_PPIB##_id2}                       \
-		}                                                                   \
-	}
+#define NRFX_GPPI_PPIB_NODE_DEFINE(_id1, _id2)                                  \
+[NRFX_GPPI_NODE_PPIB##_id1##_##_id2] = {                                        \
+        .type = NRFX_GPPI_NODE_PPIB,                                            \
+        .domain_id = NRFX_GPPI_NODE_PPIB##_id1##_##_id2,                        \
+        NRFX_COND_CODE_1(NRFX_GPPI_CONFIG_EXT_ALLOCATOR, (), (                  \
+            .ppib = {                                                           \
+                .p_channels = &channels[NRFX_GPPI_NODE_PPIB##_id1##_##_id2],    \
+                .p_reg = {NRF_PPIB##_id1, NRF_PPIB##_id2}                       \
+            }                                                                   \
+        ))                                                                      \
+    }
 
 /** @brief Macro for creating a route.
  *
  * @param _name Route name.
  * @param _nodes List of nodes in parenthesis.
  */
-#define NRFX_GPPI_ROUTE_DEFINE(_name, _nodes)                               \
-{                                                                           \
-	.p_nodes = (const nrfx_gppi_node_t * const[]){ NRFX_DEBRACKET _nodes},  \
-	.len = 1 + NRFX_NUM_VA_ARGS_LESS_1 _nodes,                              \
+#define NRFX_GPPI_ROUTE_DEFINE(_name, _nodes)                                   \
+{                                                                               \
+    .p_nodes = (const nrfx_gppi_node_t * const[]){ NRFX_DEBRACKET _nodes},      \
+    .len = 1 + NRFX_NUM_VA_ARGS_LESS_1 _nodes,                                  \
 }
 
 /** @} */


### PR DESCRIPTION
Add support for case where local GPPI helper is not managing DPPI resources and PPI connection setup. In that case some functionality can be removed from the GPPI helper. External allocator is used on targets like VPR core (PPR, FLPR) where APP is managing actual PPI resources and VPR core is getting a PPI connection handle via IPC communication.