### PR TITLE
nrfs: timeout set and disable without response as default

### DIFF
--- a/nrfs/include/services/nrfs_gswdt.h
+++ b/nrfs/include/services/nrfs_gswdt.h
@@ -46,6 +46,19 @@ nrfs_err_t nrfs_gswdt_init(nrfs_gswdt_evt_handler_t handler);
 void nrfs_gswdt_uninit(void);
 
 /**
+ * @brief Function for requesting a watchdog timeout change, with an optional response.
+ *
+ * @param[in] timeout_ms  Watchdog timeout in milliseconds.
+ * @param[in] p_context   Opaque user data that will be passed to registered callback.
+ * @param[in] rsp         If true, a response is expected from the backend.
+ *
+ * @retval NRFS_SUCCESS           Request sent successfully.
+ * @retval NRFS_ERR_INVALID_STATE Service is uninitialized.
+ * @retval NRFS_ERR_IPC           Backend returned error during request sending.
+ */
+nrfs_err_t nrfs_gswdt_timeout_rsp_set(uint32_t timeout_ms, void *p_context, bool rsp);
+
+/**
  * @brief Function for requesting a watchdog timeout change.
  *
  * @param[in] timeout_ms  Watchdog timeout in milliseconds.
@@ -58,7 +71,19 @@ void nrfs_gswdt_uninit(void);
 nrfs_err_t nrfs_gswdt_timeout_set(uint32_t timeout_ms, void *p_context);
 
 /**
- * @brief Function for requesting the watchdog to stop.
+ * @brief Function for requesting the watchdog to stop, with an optional response.
+ *
+ * @param[in] p_context   Opaque user data that will be passed to registered callback.
+ * @param[in] rsp         If true, a response is expected from the backend.
+ *
+ * @retval NRFS_SUCCESS           Request sent successfully.
+ * @retval NRFS_ERR_INVALID_STATE Service is uninitialized.
+ * @retval NRFS_ERR_IPC           Backend returned error during request sending.
+ */
+nrfs_err_t nrfs_gswdt_stop_rsp(void *p_context, bool rsp);
+
+/**
+ * @brief Function for requesting the watchdog to stop, without expecting a response.
  *
  * @param[in] p_context   Opaque user data that will be passed to registered callback.
  *

--- a/nrfs/src/services/nrfs_gswdt.c
+++ b/nrfs/src/services/nrfs_gswdt.c
@@ -61,7 +61,7 @@ void nrfs_gswdt_uninit(void)
 	m_cb.is_initialized = false;
 }
 
-nrfs_err_t nrfs_gswdt_timeout_set(uint32_t timeout_ms, void *p_context)
+nrfs_err_t nrfs_gswdt_timeout_rsp_set(uint32_t timeout_ms, void *p_context, bool rsp)
 {
 	if (!m_cb.is_initialized) {
 		return NRFS_ERR_INVALID_STATE;
@@ -70,13 +70,21 @@ nrfs_err_t nrfs_gswdt_timeout_set(uint32_t timeout_ms, void *p_context)
 	nrfs_gswdt_timeout_set_req_t req;
 
 	NRFS_SERVICE_HDR_FILL(&req, NRFS_GSWDT_TIMEOUT_SET_REQ);
+	if (!rsp) {
+		NRFS_HDR_NO_RSP_SET(&req.hdr);
+	}
 	req.ctx.ctx = (uint32_t)p_context;
 	req.timeout_ms = timeout_ms;
 
 	return nrfs_backend_send(&req, sizeof(req));
 }
 
-nrfs_err_t nrfs_gswdt_stop(void *p_context)
+nrfs_err_t nrfs_gswdt_timeout_set(uint32_t timeout_ms, void *p_context)
+{
+	return nrfs_gswdt_timeout_rsp_set(timeout_ms, p_context, false);
+}
+
+nrfs_err_t nrfs_gswdt_stop_rsp(void *p_context, bool rsp)
 {
 	if (!m_cb.is_initialized) {
 		return NRFS_ERR_INVALID_STATE;
@@ -85,7 +93,15 @@ nrfs_err_t nrfs_gswdt_stop(void *p_context)
 	nrfs_gswdt_stop_req_t req;
 
 	NRFS_SERVICE_HDR_FILL(&req, NRFS_GSWDT_STOP_REQ);
+	if (!rsp) {
+		NRFS_HDR_NO_RSP_SET(&req.hdr);
+	}
 	req.ctx.ctx = (uint32_t)p_context;
 
 	return nrfs_backend_send(&req, sizeof(req));
+}
+
+nrfs_err_t nrfs_gswdt_stop(void *p_context)
+{
+	return nrfs_gswdt_stop_rsp(p_context, false);
 }


### PR DESCRIPTION
If software global watchdog is used from power
management function it will wakeup domain when
receiving response from system controller. To avoid this by default requests to stop and set timeout
will set NO_RSP. There is still option to use
responses with _rsp functions.